### PR TITLE
Encoding fixes

### DIFF
--- a/lib/node/index.js
+++ b/lib/node/index.js
@@ -582,12 +582,11 @@ Request.prototype.end = function(fn){
     self.emit('response', res);
 
     // zlib support
-    var dataStream;
-    if (/^(deflate|gzip)$/.test(res.headers['content-encoding'])) {
+    var dataStream = res;
+
+    if (zlib && /^(deflate|gzip)$/.test(res.headers['content-encoding'])) {
       dataStream = zlib.createUnzip();
       res.pipe(dataStream);
-    } else {
-      dataStream = res;
     }
 
     // buffered response


### PR DESCRIPTION
Avoids using `setEncoding`, and fixes urlencoded encoding (it should be `ascii`)
We want to avoid using `setEncoding` so that we can pass around streams returned by the `zlib` module. Right now, even though `setEncoding` is documented for "Streams" in the node docs, it really is just defined for the net/http/fs streams impl.
