### PR TITLE
Make Content-Length detection work for strings containing multibyte characters

### DIFF
--- a/lib/node/index.js
+++ b/lib/node/index.js
@@ -502,7 +502,7 @@ Request.prototype.end = function(fn){
 
       // content-length
       if (data && !req.getHeader('Content-Length')) {
-        this.set('Content-Length', data.length);
+        this.set('Content-Length', Buffer.byteLength(data));
       }
   }
 


### PR DESCRIPTION
Hi!

With the current code, the Content-Length header field gets set to a wrong (too small) value if `this_.data` contains multibyte characters because `String.length` is the length of the string in characters, whereas Content-Length should be set to the size of the content in bytes. `Buffer.byteLength()` should be used instead. For example:

``` js
"aou".length; // => 3
Buffer.byteLength("aou"); // => 3

"äöü".length; // => 3
Buffer.byteLength("äöü"); // => 6
```
