### PR TITLE
Add HTTP PATCH Support

### DIFF
--- a/lib/superagent.js
+++ b/lib/superagent.js
@@ -685,6 +685,23 @@ var superagent = function(exports){
   };
 
   /**
+   * PATCH `url` with optional `data` and callback `fn(res)`.
+   *
+   * @param {String} url
+   * @param {Mixed} data
+   * @param {Function} fn
+   * @return {Request}
+   * @api public
+   */
+
+  request.patch = function(url, data, fn){
+    var req = request('PATCH', url);
+    if (data) req.send(data);
+    if (fn) req.end(fn);
+    return req;
+  };
+
+  /**
    * POST `url` with optional `data` and callback `fn(res)`.
    *
    * @param {String} url

--- a/test/server.js
+++ b/test/server.js
@@ -37,6 +37,10 @@ app.put('/user/:id', function(req, res){
   res.send('updated');
 });
 
+app.patch('/user/:id', function(req, res){
+  res.send('updated');
+});
+
 app.get('/querystring', function(req, res){
   res.send(req.query);
 });

--- a/test/test.request.js
+++ b/test/test.request.js
@@ -112,6 +112,13 @@ test('get()', function(next){
   });
 });
 
+test('patch()', function(next){
+  request.patch('/user/12').end(function(res){
+    assert('updated' == res.text, 'response text');
+    next();
+  });
+});
+
 test('put()', function(next){
   request.put('/user/12').end(function(res){
     assert('updated' == res.text, 'response text');


### PR DESCRIPTION
Add HTTP PATCH Support in the browser.

Tested on Chrome 17 and FF 9 (Which has issues with the HEAD test in the test suite, but works otherwise).

Let me know if there's anything else I need to do. Cheers!
