### PR TITLE
allow query() to be called after the `req` has been created

### DIFF
--- a/lib/node/index.js
+++ b/lib/node/index.js
@@ -258,9 +258,15 @@ Request.prototype.type = function(type){
  */
 
 Request.prototype.query = function(obj){
+  var req = this.request();
+  var query = qs.stringify(obj);
   this._query = this._query || {};
   for (var key in obj) {
     this._query[key] = obj[key];
+  }
+  var count = Object.keys(this._query).length;
+  if (count > 0) {
+    req.path += (~req.path.indexOf('?') ? '&' : '?') + query;
   }
   return this;
 };
@@ -446,28 +452,17 @@ Request.prototype.request = function(){
   var self = this
     , options = {}
     , data = this._data
-    , query = this._query
     , url = this.url;
 
   // default to http://
   if (0 != url.indexOf('http')) url = 'http://' + url;
-  url = parse(url);
+  url = parse(url, true);
 
   // options
   options.method = this.method;
   options.port = url.port;
   options.path = url.pathname;
   options.host = url.hostname;
-
-  if (null == url.query) url.query = '';
-
-  // querystring
-  if (query) {
-    query = qs.stringify(query);
-    url.query += (url.query.length ? '&' : '') + query;
-  }
-
-  if (url.query.length) options.path += '?' + url.query;
 
   // initiate request
   var mod = exports.protocols[url.protocol];
@@ -484,6 +479,9 @@ Request.prototype.request = function(){
     var auth = url.auth.split(':');
     this.auth(auth[0], auth[1]);
   }
+
+  // query
+  this.query(url.query);
 
   return req;
 };


### PR DESCRIPTION
This makes code like this work as expected:

``` js
request.get('http://google.com')
  .set('some', 'header')
  .query({ foo: 'bar' });
```

It relies on the "path" property of the node request object, which is mutable
up until the HTTP headers get flushed.
