### PR TITLE
Adds support and tests for parsing json variants

### DIFF
--- a/lib/node/index.js
+++ b/lib/node/index.js
@@ -611,9 +611,9 @@ Request.prototype.end = function(fn){
   // response
   req.on('response', function(res){
     var max = self._maxRedirects
-      , type = (res.headers['content-type'] || '').split(';')[0].split('/')
-      , subtype = type[1]
-      , type = type[0]
+      , types = (res.headers['content-type'] || '').split(';')[0].split('/')
+      , subtype = types[1]
+      , type = types[0]
       , multipart = 'multipart' == type
       , redirect = isRedirect(res.statusCode);
 
@@ -650,14 +650,19 @@ Request.prototype.end = function(fn){
 
     // by default only buffer text/*, json
     // and messed up thing from hell
-    var text = 'text' == type || 'json' == subtype || 'x-www-form-urlencoded' == subtype;
+    var isJSON = !!type.match('json') || subtype && !!subtype.match('json')
+      , isUrlEncodedForm = 'x-www-form-urlencoded' == subtype
+      , isText = 'text' == type
+      , text = isText || isJSON || isUrlEncodedForm;
+
     if (null == buffer && text) buffer = true;
 
     // buffered response
     if (buffer) {
-      var parse = 'text' == type
-        ? exports.parse.text
-        : exports.parse[utils.type(res.headers['content-type'] || '')];
+      var parse = exports.parse[utils.type(res.headers['content-type'] || '')];
+
+      if (isJSON) parse = exports.parse['application/json'];
+      if (isText) parse = exports.parse.text;
 
       if (parse) {
         parse(res, function(err, obj){

--- a/test/node/json.js
+++ b/test/node/json.js
@@ -14,6 +14,16 @@ app.get('/json', function(req, res){
   res.send({ name: 'manny' });
 });
 
+app.get('/json-hal', function(req, res){
+  res.set('content-type', 'application/json+hal')
+  res.send({ name: 'hal 5000' });
+});
+
+app.get('/collection-json', function(req, res){
+  res.set('content-type', 'application/vnd.collection+json')
+  res.send({ name: 'chewbacca' });
+});
+
 app.listen(3001);
 
 describe('req.send(Object) as "json"', function(){
@@ -62,6 +72,30 @@ describe('res.body', function(){
       .end(function(res){
         res.text.should.equal('{"name":"manny"}');
         res.body.should.eql({ name: 'manny' });
+        done();
+      });
+    })
+  })
+
+  describe('application/json+hal', function(){
+    it('should parse the body', function(done){
+      request
+      .get('http://localhost:3001/json-hal')
+      .end(function(res){
+        res.text.should.equal('{"name":"hal 5000"}');
+        res.body.should.eql({ name: 'hal 5000' });
+        done();
+      });
+    })
+  })
+
+  describe('vnd.collection+json', function(){
+    it('should parse the body', function(done){
+      request
+      .get('http://localhost:3001/collection-json')
+      .end(function(res){
+        res.text.should.equal('{"name":"chewbacca"}');
+        res.body.should.eql({ name: 'chewbacca' });
         done();
       });
     })


### PR DESCRIPTION
From the discussion in pull request #122, this will allow the following json variants to use the default json parser:
- `application/json+hal`
- `vnd.collection+json`
