### PR TITLE
callback must be called in case of error event

### DIFF
--- a/lib/node/index.js
+++ b/lib/node/index.js
@@ -1,4 +1,3 @@
-
 /*!
  * superagent
  * Copyright (c) 2011 TJ Holowaychuk <tj@vision-media.ca>
@@ -523,7 +522,7 @@ Request.prototype.request = function(){
     // because node will emit a faux-error "socket hang up"
     // when request is aborted before a connection is made
     if (self._aborted) return;
-    self.emit('error', err);
+    self.callback(err);
   });
 
   // auth


### PR DESCRIPTION
It is up to Request.callback to decide if error event is re-emitted or juste sent to fn(err, res).
