### PR TITLE
request.accept('json')

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -130,6 +130,19 @@ request.types = {
 };
 
 /**
+ * Default Accept MIME type map.
+ *
+ *     superagent.acceptTypes.html = 'text/html';
+ *
+ */
+
+request.acceptTypes = {
+  html: 'text/html',
+  json: 'application/json',
+  text: 'text/plain'
+};
+
+/**
  * Default serialization map.
  *
  *     superagent.serialize['application/xml'] = function(obj){
@@ -524,6 +537,35 @@ Request.prototype.set = function(field, val){
 
 Request.prototype.type = function(type){
   this.set('Content-Type', request.types[type] || type);
+  return this;
+};
+
+/**
+ * Set Accept to `type`, mapping values from `request.acceptTypes`.
+ * In the future, it should/could allow multiple types
+ * with weights.
+ *
+ * Examples:
+ *
+ *      superagent.acceptTypes.html = 'text/html';
+ *
+ *      request.post('/')
+ *        .accept('html')
+ *        .send(data)
+ *        .end(callback);
+ *
+ *      request.post('/')
+ *        .accept('json')
+ *        .send(data)
+ *        .end(callback);
+ *
+ * @param {String} type
+ * @return {Request} for chaining
+ * @api public
+ */
+
+Request.prototype.accept = function (type) {
+  this.set('Accept', request.acceptTypes[type] || type);
   return this;
 };
 

--- a/test/server.js
+++ b/test/server.js
@@ -103,6 +103,20 @@ app.get('/foo', function(req, res){
     .send('foo=bar');
 });
 
+app.get('/accept', function(req, res){
+  res.format({
+    text: function(){
+      res.send('text')
+    },
+    html: function(){
+      res.send('html')
+    },
+    json: function(){
+      res.send({message: 'json'})
+    }
+  })
+})
+
 app.use(express.static(__dirname + '/../'));
 
 app.listen(4000);

--- a/test/test.request.js
+++ b/test/test.request.js
@@ -167,6 +167,26 @@ test('request .type() with alias', function(next){
   });
 });
 
+test('request .accept()', function(next){
+  request
+  .get('/accept')
+  .accept('json')
+  .end(function(res){
+    assert(res.body.message === 'json', 'response text');
+    next();
+  });
+});
+
+test('request .accept() with alias', function(next){
+  request
+  .get('/accept')
+  .accept('application/json')
+  .end(function(res){
+    assert(res.body.message === 'json', 'response text');
+    next();
+  });
+});
+
 test('request .get() with no data or callback', function(next){
   request.get('/echo-header/content-type');
   next();


### PR DESCRIPTION
#150

Doesn't accept lists or weights. Basically the same as `request.type()`.
