### PR TITLE
Added client-side basic auth

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -542,6 +542,21 @@ Request.prototype.type = function(type){
 };
 
 /**
+ * Set Authorization field value with `user` and `pass`.
+ *
+ * @param {String} user
+ * @param {String} pass
+ * @return {Request} for chaining
+ * @api public
+ */
+
+Request.prototype.auth = function(user, pass){
+  var str = btoa(user + ':' + pass);
+  this.set('Authorization', 'Basic ' + str);
+  return this;
+};
+
+/**
 * Add query-string `val`.
 *
 * Examples:

--- a/test/server.js
+++ b/test/server.js
@@ -103,6 +103,16 @@ app.get('/foo', function(req, res){
     .send('foo=bar');
 });
 
+app.post('/auth', function(req, res) {
+  var auth = req.headers.authorization,
+      parts = auth.split(' '),
+      credentials = new Buffer(parts[1], 'base64').toString().split(':'),
+      user = credentials[0],
+      pass = credentials[1];
+
+  res.send({ user : user, pass : pass });
+});
+
 app.use(express.static(__dirname + '/../'));
 
 app.listen(4000);

--- a/test/test.request.js
+++ b/test/test.request.js
@@ -491,3 +491,14 @@ test('x-domain failure', function(next){
     next();
   });
 });
+
+test('basic auth', function(next){
+  request
+  .post('/auth')
+  .auth('foo', 'bar')
+  .end(function(res){
+    assert('foo' == res.body.user);
+    assert('bar' == res.body.pass);
+    next();
+  });
+});


### PR DESCRIPTION
Same signature as node's version: `.auth(user, pass)`

One caveat is that base64 encoding (`btoa`) is not well supported in IE. It'd be easy to support with something like: https://github.com/ForbesLindesay/base64-encode, but I'm not sure what you think of the additional dependency.
