### PR TITLE
Calculate Content Length of request

### DIFF
--- a/lib/node/index.js
+++ b/lib/node/index.js
@@ -754,12 +754,31 @@ Request.prototype.contentLength = function(fn) {
     , req = this.request()
     , contentLength = 0
     , files = this.attachments
-    , fields = this.fields;
+    , fields = this.fields
+    , hasFirstBoundary = false;
+
+  var addedData = "";
 
   addToContentLength = function(data) {
     if(!data) return;
 
+    addedData += data;
+
     contentLength += Buffer.byteLength(data);
+  };
+
+  boundary = function() {
+    var boundaryString = '--' + self._boundary + '\r\n';
+
+    if(hasFirstBoundary) {
+      boundaryString = '\r\n' + boundaryString;
+    }
+    else
+    {
+      hasFirstBoundary = true;
+    }
+
+    return boundaryString;
   };
 
   // if(data) {
@@ -770,11 +789,15 @@ Request.prototype.contentLength = function(fn) {
     return field + ': ' + val + '\r\n';
   };
 
+  done = function() {
+    addToContentLength('\r\n--' + self._boundary + '--');
+    fn(contentLength);
+  };
 
   // Field parts
   fields.forEach(function(field) {
     var parts = [
-      '\r\n--' + self._boundary + '\r\n',
+      boundary(),
       buildPartHeader('Content-Disposition', 'form-data; name="' + field.name + '"'),
       '\r\n',
       field.value
@@ -783,26 +806,27 @@ Request.prototype.contentLength = function(fn) {
     addToContentLength(parts.join(""));
   });
 
+  if (!self.attachments.length) done();
+
   // Attachments
   self.attachmentSize(function(attachmentSize) {
     contentLength += attachmentSize;
 
     files.forEach(function(file) {
       var parts = [
-        '\r\n--' + self._boundary + '\r\n',
+        boundary(),
         buildPartHeader('Content-Type', mime.lookup(file.filename)),
         buildPartHeader(
           'Content-Disposition',
           'attachment; name="' + file.field + '"; filename="' + basename(file.filename) + '"'
-        )
+        ),
+        '\r\n'
       ];
 
       addToContentLength(parts.join(""));
     });
 
-    addToContentLength('\r\n--' + self._boundary + '--');
-
-    fn(contentLength);
+    done();
   });
 
   return this;

--- a/test/node/multipart.js
+++ b/test/node/multipart.js
@@ -281,11 +281,43 @@ describe('Part', function(){
       });
     })
 
+    it('calculates correctly with multiple attachments', function(done){
+      var req = request.post('http://localhost:3005/contentLength');
+
+      req.attach('document', 'test/node/fixtures/user.html');
+      req.attach('document2', 'test/node/fixtures/user.html');
+
+      req.contentLength(function(calculatedSize) {
+
+        req.end(function(res){
+          var expectedSize = parseInt(res.text, 0);
+          calculatedSize.should.equal(expectedSize);
+          done();
+        });
+      });
+    })
+
     it('calculates correctly when fields are added', function(done){
       var req = request.post('http://localhost:3005/contentLength');
 
       req.field('name', 'Tobi');
       req.attach('document', 'test/node/fixtures/user.html');
+      req.field('species', 'ferret');
+
+      req.contentLength(function(calculatedSize) {
+
+        req.end(function(res){
+          var expectedSize = parseInt(res.text, 0);
+          calculatedSize.should.equal(expectedSize);
+          done();
+        });
+      });
+    })
+
+    it('calculates correctly without attachments', function(done){
+      var req = request.post('http://localhost:3005/contentLength');
+
+      req.field('name', 'Tobi');
       req.field('species', 'ferret');
 
       req.contentLength(function(calculatedSize) {


### PR DESCRIPTION
I added a method to calculate the content length of a request.

You can use it by calling

``` javascript
request.contentLength(function(contentLength) {
  request.set("Content-Length", contentLength);
});
```

It automatically considers attachments and field values.
I did not get it to work properly with raw data that was added via send.

See issue #196
