### PR TITLE
Small enhancement to .query()

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -603,7 +603,7 @@ Request.prototype.auth = function(user, pass){
 
 Request.prototype.query = function(val){
   if ('string' != typeof val) val = serialize(val);
-  this._query.push(val);
+  if (val) this._query.push(val);
   return this;
 };
 

--- a/superagent.js
+++ b/superagent.js
@@ -1002,7 +1002,7 @@ Request.prototype.auth = function(user, pass){
 
 Request.prototype.query = function(val){
   if ('string' != typeof val) val = serialize(val);
-  this._query.push(val);
+  if (val) this._query.push(val);
   return this;
 };
 

--- a/test/test.request.js
+++ b/test/test.request.js
@@ -388,6 +388,17 @@ test('GET querystring multiple objects', function(next){
   });
 });
 
+test('GET querystring empty objects', function(next){
+  var req = request
+  .get('/querystring')
+  .query({})
+  .end(function(res){
+    assert.eql(req._query, []);
+    assert.eql(res.body, {});
+    next();
+  });
+});
+
 test('GET querystring with strings', function(next){
   request
   .get('/querystring')


### PR DESCRIPTION
Currently, passing an empty object to `.query()` causes an empty string to be appended to `_query`. This just adds a check to ensure `val` is truthy before appending it. (test included)
