### PR TITLE
add browser field to support browserify

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,9 +20,10 @@
     "qs": "0.5.6",
     "formidable": "1.0.9",
     "mime": "1.2.5",
-    "emitter-component": "0.0.6",
+    "emitter": "component/emitter#1.0.0",
     "methods": "0.0.1",
-    "cookiejar": "1.3.0"
+    "cookiejar": "1.3.0",
+    "reduce": "RedVentures/reduce#346d59"
   },
   "devDependencies": {
     "express": "3.0.3",
@@ -35,6 +36,7 @@
       "superagent": "lib/client.js"
     }
   },
+  "browser": "./lib/client.js",
   "main": "lib/node",
   "engines": {
     "node": "*"


### PR DESCRIPTION
Allows for superagent to be used with browserify (or other browser field
compatible packaging tools).
