### PR TITLE
Handle unzip error event

### DIFF
--- a/lib/node/utils.js
+++ b/lib/node/utils.js
@@ -129,7 +129,10 @@ exports.unzip = function(req, res){
   res.on = function(type, fn){
     if ('data' == type || 'end' == type) {
       stream.on(type, fn);
-    } else {
+    }else if(type == 'error'){
+      stream.on(type, fn);
+      _on.call(res, type, fn);
+    }else{
       _on.call(res, type, fn);
     }
   };


### PR DESCRIPTION
Hello @visionmedia,

This pull request takes care of the error event emitted by the unzip stream. @Yizen raised this issue [here](https://github.com/lbdremy/scrapinode/issues/30). Also I wonder what should we do to cleanup the streams in this situation or maybe node already takes care of the cleanup, I really don't know.

Thank you
