### PR TITLE
make `Response#toError()` have a more meaningful `message`

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -288,16 +288,17 @@ function params(str){
  * @api private
  */
 
-function Response(xhr, options) {
+function Response(req, options) {
   options = options || {};
-  this.xhr = xhr;
-  this.text = xhr.responseText;
-  this.setStatusProperties(xhr.status);
-  this.header = this.headers = parseHeader(xhr.getAllResponseHeaders());
+  this.req = req;
+  this.xhr = this.req.xhr;
+  this.text = this.xhr.responseText;
+  this.setStatusProperties(this.xhr.status);
+  this.header = this.headers = parseHeader(this.xhr.getAllResponseHeaders());
   // getAllResponseHeaders sometimes falsely returns "" for CORS requests, but
   // getResponseHeader still works. so we get content-type even if getting
   // other headers fails.
-  this.header['content-type'] = xhr.getResponseHeader('content-type');
+  this.header['content-type'] = this.xhr.getResponseHeader('content-type');
   this.setHeaderProperties(this.header);
   this.body = this.parseBody(this.text);
 }
@@ -409,9 +410,16 @@ Response.prototype.setStatusProperties = function(status){
  */
 
 Response.prototype.toError = function(){
-  var msg = 'got ' + this.status + ' response';
+  var req = this.req;
+  var method = req.method;
+  var path = req.path;
+
+  var msg = 'can not ' + method + ' ' + path + ' (' + this.status + ')';
   var err = new Error(msg);
   err.status = this.status;
+  err.method = method;
+  err.path = path;
+
   return err;
 };
 
@@ -438,7 +446,7 @@ function Request(method, url) {
   this.header = {};
   this._header = {};
   this.on('end', function(){
-    var res = new Response(self.xhr);
+    var res = new Response(self);
     if ('HEAD' == method) res.text = null;
     self.callback(null, res);
   });

--- a/lib/node/response.js
+++ b/lib/node/response.js
@@ -96,9 +96,16 @@ Response.prototype.resume = function(){
  */
 
 Response.prototype.toError = function(){
-  var msg = 'got ' + this.status + ' response';
+  var req = this.req;
+  var method = req.method;
+  var path = req.path;
+
+  var msg = 'can not ' + method + ' ' + path + ' (' + this.status + ')';
   var err = new Error(msg);
   err.status = this.status;
+  err.method = method;
+  err.path = path;
+
   return err;
 };
 

--- a/test/node/basic.js
+++ b/test/node/basic.js
@@ -105,7 +105,7 @@ describe('request', function(){
       request
       .get(':5000/error')
       .end(function(res){
-        res.error.message.should.equal('got 500 response');
+        res.error.message.should.equal('can not GET /error (500)');
         res.error.status.should.equal(500);
         done();
       });

--- a/test/node/toError.js
+++ b/test/node/toError.js
@@ -18,7 +18,9 @@ describe('res.toError()', function(){
     .end(function(res){
       var err = res.toError();
       assert(err.status == 400);
-      assert(err.message == 'got 400 response');
+      assert(err.method == 'GET');
+      assert(err.path == '/');
+      assert(err.message == 'can not GET / (400)');
       done();
     });
   })


### PR DESCRIPTION
Now it includes the .method and .path of the Request object, which
should aid in debugging when these kinds of HTTP requests fail.

Also the Error object now includes additional `method` and `path` fields.
