### PR TITLE
node: add a Request#agent() function to set the http Agent to use

### DIFF
--- a/lib/node/index.js
+++ b/lib/node/index.js
@@ -116,6 +116,7 @@ exports.parse = require('./parsers');
 function Request(method, url) {
   var self = this;
   if ('string' != typeof url) url = format(url);
+  this._agent = false;
   this.method = method;
   this.url = url;
   this.header = {};
@@ -182,6 +183,20 @@ Request.prototype.redirects = function(n){
 
 Request.prototype.part = function(){
   return new Part(this);
+};
+
+/**
+ * Gets/sets the `Agent` to use for this HTTP request. The default (if this
+ * function is not called) is to opt out of connection pooling (`agent: false`).
+ *
+ * @param {http.Agent} agent
+ * @return {http.Agent}
+ * @api public
+ */
+
+Request.prototype.agent = function(agent){
+  if (agent) this._agent = agent;
+  return this._agent;
 };
 
 /**
@@ -559,7 +574,7 @@ Request.prototype.request = function(){
   options.port = url.port;
   options.path = url.pathname;
   options.host = url.hostname;
-  options.agent = false;
+  options.agent = this._agent;
 
   // initiate request
   var mod = exports.protocols[url.protocol];


### PR DESCRIPTION
Still defaults to `agent: false` like before...

Could use some tests still...
