### PR TITLE
Quick Browser Test Fix

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -82,7 +82,7 @@ request.post('/api/pet', cat, function(error, res){
 
     $ make test-server
 
- Visit `localhost:3000/` in the browser.
+ Visit `localhost:4000/` in the browser.
 
 ## Browser build
 

--- a/test/index.html
+++ b/test/index.html
@@ -3,7 +3,7 @@
   <head>
     <title>superagent test suite</title>
     <script src="json2.js"></script>
-    <script src="../build/build.js"></script>
+    <script src="../superagent.js"></script>
     <script src="jquery.js"></script>
     <script src="test.js"></script>
     <script src="test.request.js"></script>

--- a/test/server.js
+++ b/test/server.js
@@ -97,6 +97,10 @@ app.get('/pets', function(req, res){
   res.send(['tobi', 'loki', 'jane']);
 });
 
+app.get('/text', function(req, res){
+  res.send("just some text");
+});
+
 app.get('/foo', function(req, res){
   res
     .header('Content-Type', 'application/x-www-form-urlencoded')

--- a/test/test.request.js
+++ b/test/test.request.js
@@ -310,7 +310,7 @@ test('GET .type', function(next){
 
 test('GET Content-Type params', function(next){
   request
-  .get('/pets')
+  .get('/text')
   .end(function(res){
     assert('utf-8' == res.charset);
     next();


### PR DESCRIPTION
The browser-based tests were not working right away for me, here are some changes I made to correct that:
- Fixed the test-runner to use `superagent.js` instead of `build/build.js`
- The "Content-Type params" test was broken (looks like an update to express change the behavior of charset in content-type headers recently)
- Updated URL on README for `make test-server`
