### PR TITLE
add browser field to support browserify

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "emitter-component": "1.0.0",
     "methods": "0.0.1",
     "cookiejar": "1.3.0",
-    "debug": "~0.7.2"
+    "debug": "~0.7.2",
+    "reduce": "RedVentures/reduce#346d59"
   },
   "devDependencies": {
     "express": "3.3.1",
@@ -31,12 +32,16 @@
     "should": "*",
     "mocha": "*"
   },
+  "browser": {
+    "./lib/node/index.js": "./lib/client.js",
+    "emitter": "emitter-component"
+  },
   "component": {
     "scripts": {
       "superagent": "lib/client.js"
     }
   },
-  "main": "lib/node",
+  "main": "./lib/node/index.js",
   "engines": {
     "node": "*"
   }


### PR DESCRIPTION
Allows for superagent to be used with browserify (or other browser
field compatible packaging tools).
