### PR TITLE
Make javascript pass as being text

### DIFF
--- a/lib/node/index.js
+++ b/lib/node/index.js
@@ -1,4 +1,3 @@
-
 /**
  * Module dependencies.
  */
@@ -919,6 +918,7 @@ function isText(mime) {
 
   return 'text' == type
     || 'json' == subtype
+    || 'javascript' == subtype
     || 'x-www-form-urlencoded' == subtype;
 }
 


### PR DESCRIPTION
Hi this is a bit of a quick fix to make requests for javascript return its content.

It allows to just do:

``` javascript
 superagent.get('/script.js').end(...
```

and end up with the contents of the javascript.

Regarding that isText() function I think maybe the response being send being text is not the exception,
a response which is not text is. It would become a very big list if for example xml feeds also had to be tested as being text.

Also, on the node.js side I'm not sure about how the parsers are implemented, they are actually buffer readers and
execute a function inside it. If on the client side the parser is e.g. JSON.parse, there is no reason why on the server side this parser wouldn't also be JSON.parse. Reading out the buffer is not really a job of the parser I think.

It could be that I'm abusing the library and there is already another way to do this, but I couldn't get it to work by adding a custom parser.
