### PR TITLE
Using ActiveX XHR object for IE when doing PATCH request

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -47,16 +47,30 @@ function isHost(obj) {
  * Determine XHR.
  */
 
-function getXHR() {
-  if (root.XMLHttpRequest
-    && ('file:' != root.location.protocol || !root.ActiveXObject)) {
-    return new XMLHttpRequest;
-  } else {
-    try { return new ActiveXObject('Microsoft.XMLHTTP'); } catch(e) {}
-    try { return new ActiveXObject('Msxml2.XMLHTTP.6.0'); } catch(e) {}
-    try { return new ActiveXObject('Msxml2.XMLHTTP.3.0'); } catch(e) {}
-    try { return new ActiveXObject('Msxml2.XMLHTTP'); } catch(e) {}
+function getXHR(method) {
+  if (method) {
+    method = method.toLowerCase();
   }
+
+  if (root.ActiveXObject) {
+    if ('file:' === root.location.protocol || 'patch' === method) {
+      return getIEXHR();
+    } else if (root.XMLHttpRequest) {
+      return new XMLHttpRequest;
+    } else {
+      return getIEXHR();
+    }
+  } else {
+    return new XMLHttpRequest;
+  }
+  return false;
+}
+
+function getIEXHR() {
+  try { return new ActiveXObject('Microsoft.XMLHTTP'); } catch(e) {}
+  try { return new ActiveXObject('Msxml2.XMLHTTP.6.0'); } catch(e) {}
+  try { return new ActiveXObject('Msxml2.XMLHTTP.3.0'); } catch(e) {}
+  try { return new ActiveXObject('Msxml2.XMLHTTP'); } catch(e) {}
   return false;
 }
 
@@ -752,7 +766,7 @@ Request.prototype.withCredentials = function(){
 
 Request.prototype.end = function(fn){
   var self = this;
-  var xhr = this.xhr = getXHR();
+  var xhr = this.xhr = getXHR(this.method);
   var query = this._query.join('&');
   var timeout = this._timeout;
   var data = this._data;


### PR DESCRIPTION
In IE8, HTTP PATCH requests are not allowed with the native XHR object.
(see http://msdn.microsoft.com/en-us/library/ms537505(v=vs.85).aspx#xdomain)

I have modified the logic of getXHR() to include the HTTP verb/method as a parameter.
I have also made the conditional logic of the function a bit easier to reason about,
with the addition of adding this check for method. (other common methods like `DELETE`
and `PUT` are still allowed, only `PATCH` needs special treatment at this point)
