### PR TITLE
Fix GET example with query argument

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -76,17 +76,10 @@
    
      request
        .get('/search')
-       .data({ query: 'tobi the ferret' })
+       .query({ query-arg-1: 'tobi the ferret' })
+       .query({ query-arg-2: 'tobi the ferret is amazing' })
        .end(function(res){
          
-       });
-
-   Or one may pass the query-string object to `.get()`:
-   
-     request
-       .get('/search', { query: 'tobi the ferret' })
-       .end(function(res){
-       
        });
   
   Taking this even further the callback may be passed as well:


### PR DESCRIPTION
.data method does not exist AFAICT and so should use the .query method. Also added second .query to show you can keep adding arguments.
