### PR TITLE
Fix JSON.parse error for client HEAD requests

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -299,6 +299,7 @@ function Response(req, options) {
   // other headers fails.
   this.header['content-type'] = this.xhr.getResponseHeader('content-type');
   this.setHeaderProperties(this.header);
+  if (this.req.method === 'HEAD') { this.text = null; }
   this.body = this.parseBody(this.text);
 }
 


### PR DESCRIPTION
On the client version, when performing a HEAD request to a JSON resource, superagent tries to parse the res.text with JSON.parse. However, res.text is an empty string and this causes JSON.parse to error with "SyntaxError: JSON Parse error: Unexpected EOF". This patch will set the text to null for HEAD requests, because JSON.parse(null) will not error and simply return null.
