### PR TITLE
Set xhr.withCredentials after xhr.open to avoid INVALID_STATE_ERR

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -760,9 +760,6 @@ Request.prototype.end = function(fn){
   // store callback
   this._callback = fn || noop;
 
-  // CORS
-  if (this._withCredentials) xhr.withCredentials = true;
-
   // state change
   xhr.onreadystatechange = function(){
     if (4 != xhr.readyState) return;
@@ -798,6 +795,9 @@ Request.prototype.end = function(fn){
 
   // initiate request
   xhr.open(this.method, this.url, true);
+
+  // CORS
+  if (this._withCredentials) xhr.withCredentials = true;
 
   // body
   if ('GET' != this.method && 'HEAD' != this.method && 'string' != typeof data && !isHost(data)) {


### PR DESCRIPTION
Apparently they changed that in the spec so it fails now on v8...

See https://groups.google.com/forum/#!msg/v8-dev/yYMQ1peZtLw/nbD7rV7ZMmgJ for some context.
