### PR TITLE
CORS withCredentials move to xhr open state

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -762,9 +762,6 @@ Request.prototype.end = function(fn){
   // store callback
   this._callback = fn || noop;
 
-  // CORS
-  if (this._withCredentials) xhr.withCredentials = true;
-
   // state change
   xhr.onreadystatechange = function(){
     if (4 != xhr.readyState) return;
@@ -800,6 +797,9 @@ Request.prototype.end = function(fn){
 
   // initiate request
   xhr.open(this.method, this.url, true);
+
+  // CORS
+  if (this._withCredentials) xhr.withCredentials = true;
 
   // body
   if ('GET' != this.method && 'HEAD' != this.method && 'string' != typeof data && !isHost(data)) {

--- a/superagent.js
+++ b/superagent.js
@@ -384,7 +384,7 @@ require.register("RedVentures-reduce/index.js", function(exports, require, modul
  * TODO: combatible error handling?
  */
 
-module.exports = function(arr, fn, initial){  
+module.exports = function(arr, fn, initial){
   var idx = 0;
   var len = arr.length;
   var curr = arguments.length == 3
@@ -394,7 +394,7 @@ module.exports = function(arr, fn, initial){
   while (idx < len) {
     curr = fn.call(null, curr, arr[idx], ++idx, arr);
   }
-  
+
   return curr;
 };
 });
@@ -1163,9 +1163,6 @@ Request.prototype.end = function(fn){
   // store callback
   this._callback = fn || noop;
 
-  // CORS
-  if (this._withCredentials) xhr.withCredentials = true;
-
   // state change
   xhr.onreadystatechange = function(){
     if (4 != xhr.readyState) return;
@@ -1201,6 +1198,9 @@ Request.prototype.end = function(fn){
 
   // initiate request
   xhr.open(this.method, this.url, true);
+
+  // CORS
+  if (this._withCredentials) xhr.withCredentials = true;
 
   // body
   if ('GET' != this.method && 'HEAD' != this.method && 'string' != typeof data && !isHost(data)) {


### PR DESCRIPTION
According to [w3 spec](http://www.w3.org/TR/XMLHttpRequest2/#the-withcredentials-attribute) the XHR state should be open or unsent when setting the withCredentials flag.
So I have moved the flag to after `xhr.open`.

Running superagent without this change in PhantomJS 1.9.2-5 causes
`INVALID_STATE_ERR: DOM Exception 11`

[Related SO post](http://stackoverflow.com/questions/3488698/invalid-state-err-dom-exception-11-webkit)
