### PR TITLE
ADD: Support IE8,9 for CORS

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -47,17 +47,42 @@ function isHost(obj) {
  * Determine XHR.
  */
 
-function getXHR() {
-  if (root.XMLHttpRequest
-    && ('file:' != root.location.protocol || !root.ActiveXObject)) {
+function getXHR(isCORS) {
+  // Detect the version of IE and which version it is, for cross domain request and IE = 8 and 9
+  // XDomainRequest should be created, IE7 or below does not support CORS
+  this.isCORS = isCORS || false
+  if (root.XMLHttpRequest 
+    && ('file:' != root.location.protocol || !root.ActiveXObject) && (!ie() || ie() > 9)) {
     return new XMLHttpRequest;
   } else {
+    if (isCORS) {
+      try {return new XDomainRequest()} catch(e) {}
+    }
     try { return new ActiveXObject('Microsoft.XMLHTTP'); } catch(e) {}
     try { return new ActiveXObject('Msxml2.XMLHTTP.6.0'); } catch(e) {}
     try { return new ActiveXObject('Msxml2.XMLHTTP.3.0'); } catch(e) {}
     try { return new ActiveXObject('Msxml2.XMLHTTP'); } catch(e) {}
   }
   return false;
+}
+
+/**
+ * Determine the version of IE and which version it is
+ * will not work for IE 11 or above as they have changed the user agent
+ * However, XMLHTTPRequest works as it should be since IE 11
+ * Example 
+ *   ie()
+ *   => 9
+ *
+ *
+ * @return {integer / boolean}, false for non IE and version number for IE (e.g. 7 or 8 or 9)
+ */
+function ie() {
+  if (window) {
+    var myNav = navigator.userAgent.toLowerCase()
+    return (myNav.indexOf('msie') !== -1) ? parseInt(myNav.split('msie')[1]) : false
+  }
+  return false // No window means not on browser, return false
 }
 
 /**
@@ -96,10 +121,8 @@ function serialize(obj) {
   if (!isObject(obj)) return obj;
   var pairs = [];
   for (var key in obj) {
-    if (null != obj[key]) {
-      pairs.push(encodeURIComponent(key)
-        + '=' + encodeURIComponent(obj[key]));
-    }
+    pairs.push(encodeURIComponent(key)
+      + '=' + encodeURIComponent(obj[key]));
   }
   return pairs.join('&');
 }
@@ -296,11 +319,16 @@ function Response(req, options) {
   this.xhr = this.req.xhr;
   this.text = this.xhr.responseText;
   this.setStatusProperties(this.xhr.status);
-  this.header = this.headers = parseHeader(this.xhr.getAllResponseHeaders());
+  // Prevent error from IE, XDomainRequest in IE8 and 9 doesnt support headers
+  if (this.xhr.getAllResponseHeaders) {
+    this.header = this.headers = parseHeader(this.xhr.getAllResponseHeaders());
+  }
   // getAllResponseHeaders sometimes falsely returns "" for CORS requests, but
   // getResponseHeader still works. so we get content-type even if getting
-  // other headers fails.
-  this.header['content-type'] = this.xhr.getResponseHeader('content-type');
+  // other headers fails. (Except IE8 and 9)
+  if (this.xhr.getResponseHeader) {
+    this.header['content-type'] = this.xhr.getResponseHeader('content-type');
+  }
   this.setHeaderProperties(this.header);
   this.body = this.req.method != 'HEAD'
     ? this.parseBody(this.text)
@@ -333,7 +361,7 @@ Response.prototype.get = function(field){
 
 Response.prototype.setHeaderProperties = function(header){
   // content-type
-  var ct = this.header['content-type'] || '';
+  var ct = (this.header && this.header['content-type']) || ''; 
   this.type = type(ct);
 
   // params
@@ -450,6 +478,7 @@ function Request(method, url) {
   this.header = {};
   this._header = {};
   this.on('end', function(){
+    Request.busy = false
     var res = new Response(self);
     if ('HEAD' == method) res.text = null;
     self.callback(null, res);
@@ -636,6 +665,20 @@ Request.prototype.query = function(val){
 };
 
 /**
+ * Set the request as cross domain or not
+ *   For Chrome, Firefox, Safari and IE 10 or above the XMLHTTPRequest generally
+ *   would do the job for CORS
+ *   However, for IE8 and 9 (IE 7 or below doesn't support CORS), XDomainRequest object should be use and its functionality is very limiting
+ *   http://blogs.msdn.com/b/ieinternals/archive/2010/05/13/xdomainrequest-restrictions-limitations-and-workarounds.aspx
+ * @param {Boolean} isCORS
+ * @return {Request} for chaining
+ */
+Request.prototype.crossDomain = function(isCORS) {
+  this.isCORS = (isCORS === true)
+  return this
+}
+
+/**
  * Send `data`, defaulting the `.type()` to "json" when
  * an object is given.
  *
@@ -779,16 +822,27 @@ Request.prototype.withCredentials = function(){
  * @return {Request} for chaining
  * @api public
  */
-
+Request.busy = false          // CORS in IE8 and 9 can cancel each other if too many request fire at once to the same domain
 Request.prototype.end = function(fn){
   var self = this;
-  var xhr = this.xhr = getXHR();
+  if (Request.busy === true && ie() && ie() < 10 && this.isCORS === true) {
+    setTimeout(function(){
+      self.end(fn)
+    },50);
+    return
+  }
+  Request.busy = true
+  
+  var xhr = this.xhr = getXHR(this.isCORS || false);
   var query = this._query.join('&');
   var timeout = this._timeout;
   var data = this._data;
 
   // store callback
   this._callback = fn || noop;
+
+  // CORS
+  if (this._withCredentials) xhr.withCredentials = true;
 
   // state change
   xhr.onreadystatechange = function(){
@@ -799,13 +853,36 @@ Request.prototype.end = function(fn){
     }
     self.emit('end');
   };
-
+  
+  // Hook up to onreadyStatechange if under ie and crossDomain condition or IE8 and IE9
+  // Missing any of the callback below will causes CORS to fail without any error
+  if (ie() && ie() < 10 && this.isCORS === true) {
+    var req = xhr
+    xhr.onload = function(){
+      req.readyState = 4
+      req.onreadystatechange()
+    }
+    xhr.onerror = function(err) {
+      self.callback(err)
+    }
+    xhr.ontimeout = function() {
+      req.readyState = 0
+      req.onreadystatechange()
+    }
+    xhr.onprogress = function() {}
+  }
+   
   // progress
   if (xhr.upload) {
     xhr.upload.onprogress = function(e){
       e.percent = e.loaded / e.total * 100;
       self.emit('progress', e);
     };
+  }
+  if (ie() && ie() < 10 && this.isCORS === true) {
+    if (xhr.upload) {
+      xhr.onprogress = xhr.upload.onprogress
+    }
   }
 
   // timeout
@@ -825,9 +902,6 @@ Request.prototype.end = function(fn){
 
   // initiate request
   xhr.open(this.method, this.url, true);
-
-  // CORS
-  if (this._withCredentials) xhr.withCredentials = true;
 
   // body
   if ('GET' != this.method && 'HEAD' != this.method && 'string' != typeof data && !isHost(data)) {


### PR DESCRIPTION
This commit should work for IE(8 -11)

Example

```
var sagent = require('superagent')
sagent.post('/example')
  .crossDomain(true)        // Add this line to support cors in IE8 and 9
  .end(function(err, res){

  })
```

The following is done to fix the issue
- IE 8-9 support XDomainRequest instead of XMLHTTPRequest
- IE 8-9 has an issue of making too many request to same domain would cancel out each other. Therefore, a mechanism is introduce to prevent firing too many request at the same time
  By default, any header is strip off when the request is fired in IE8 and 9. So no authentication and other thing related to header is supported
