### PR TITLE
add browser testing via zuul

### DIFF
--- a/.zuul.yml
+++ b/.zuul.yml
@@ -1,0 +1,13 @@
+ui: mocha-tdd
+server: ./test/server.js
+browsers:
+  - name: chrome
+    version: latest
+    platform: 'Mac 10.9'
+  - name: chrome
+    version: latest
+    platform: 'Windows 2008'
+  - name: firefox
+    version: latest
+  - name: ie
+    version: latest

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "reduce-component": "1.0.1"
   },
   "devDependencies": {
+    "zuul": "~1.3.0",
     "express": "3.3.1",
     "better-assert": "~0.1.0",
     "should": "1.3.0",

--- a/test/index.js
+++ b/test/index.js
@@ -1,0 +1,3 @@
+require('./test.utils.js');
+require('./test.request.js');
+require('./test.xdomain.js');

--- a/test/server.js
+++ b/test/server.js
@@ -16,9 +16,20 @@ app.use(function(req, res, next){
 });
 
 app.use(express.bodyParser());
+app.use(express.cookieParser());
 
 app.use(function(req, res, next){
   res.cookie('name', 'tobi');
+  next();
+});
+
+app.use('/xdomain', function(req, res, next){
+  if (!req.get('Origin')) return next();
+  res.set('Access-Control-Allow-Origin', req.get('Origin'));
+  res.set('Access-Control-Allow-Credentials', 'true');
+  res.set('Access-Control-Allow-Methods', 'POST');
+  res.set('Access-Control-Allow-Headers', 'X-Requested-With, Content-Type');
+  if ('OPTIONS' == req.method) return res.send(200);
   next();
 });
 
@@ -117,28 +128,12 @@ app.post('/auth', function(req, res) {
   res.send({ user : user, pass : pass });
 });
 
-app.use(express.static(__dirname + '/../'));
-
-app.listen(4000);
-console.log('Test server listening on port 4000');
-
-var two = express();
-
-two.use(express.cookieParser());
-
-two.all('*', function(req, res, next){
-  if (!req.get('Origin')) return next();
-  res.set('Access-Control-Allow-Origin', 'http://localhost:4000');
-  res.set('Access-Control-Allow-Credentials', 'true');
-  res.set('Access-Control-Allow-Methods', 'POST');
-  res.set('Access-Control-Allow-Headers', 'X-Requested-With, Content-Type');
-  if ('OPTIONS' == req.method) return res.send(200);
-  next();
-});
-
-two.get('/', function(req, res){
+app.get('/xdomain', function(req, res){
   res.send(req.cookies.name);
 });
 
-two.listen(4001);
-console.log('Test server #2 listening on port 4001');
+app.use(express.static(__dirname + '/../'));
+
+var server = app.listen(process.env.ZUUL_PORT, function() {
+  //console.log('Test server listening on port %d', server.address().port);
+});

--- a/test/test.request.js
+++ b/test/test.request.js
@@ -1,17 +1,18 @@
 
-request = superagent;
+var assert = require('assert');
+var request = require('../');
 
 test('Request inheritance', function(){
   assert(request.get('/') instanceof request.Request);
 });
 
 test('request() simple GET without callback', function(next){
-  request('GET', 'test.request.js').end();
+  request('GET', 'test/test.request.js').end();
   next();
 });
 
 test('request() simple GET', function(next){
-  request('GET', 'test.request.js').end(function(res){
+  request('GET', 'test/test.request.js').end(function(res){
     assert(res instanceof request.Response, 'respond with Response');
     assert(res.ok, 'response should be ok');
     assert(res.text, 'res.text');
@@ -20,7 +21,7 @@ test('request() simple GET', function(next){
 });
 
 test('request() simple HEAD', function(next){
-  request.head('test.request.js').end(function(res){
+  request.head('test/test.request.js').end(function(res){
     assert(res instanceof request.Response, 'respond with Response');
     assert(res.ok, 'response should be ok');
     assert(!res.text, 'res.text');
@@ -361,7 +362,7 @@ test('GET json', function(next){
   request
   .get('/pets')
   .end(function(res){
-    assert.eql(res.body, ['tobi', 'loki', 'jane']);
+    assert.deepEqual(res.body, ['tobi', 'loki', 'jane']);
     next();
   });
 });
@@ -370,7 +371,7 @@ test('GET x-www-form-urlencoded', function(next){
   request
   .get('/foo')
   .end(function(res){
-    assert.eql(res.body, { foo: 'bar' });
+    assert.deepEqual(res.body, { foo: 'bar' });
     next();
   });
 });
@@ -401,7 +402,7 @@ test('GET querystring object', function(next){
   .get('/querystring')
   .query({ search: 'Manny' })
   .end(function(res){
-    assert.eql(res.body, { search: 'Manny' });
+    assert.deepEqual(res.body, { search: 'Manny' });
     next();
   });
 });
@@ -411,7 +412,7 @@ test('GET querystring append original', function(next){
   .get('/querystring?search=Manny')
   .query({ range: '1..5' })
   .end(function(res){
-    assert.eql(res.body, { search: 'Manny', range: '1..5' });
+    assert.deepEqual(res.body, { search: 'Manny', range: '1..5' });
     next();
   });
 });
@@ -423,7 +424,7 @@ test('GET querystring multiple objects', function(next){
   .query({ range: '1..5' })
   .query({ order: 'desc' })
   .end(function(res){
-    assert.eql(res.body, { search: 'Manny', range: '1..5', order: 'desc' });
+    assert.deepEqual(res.body, { search: 'Manny', range: '1..5', order: 'desc' });
     next();
   });
 });
@@ -433,8 +434,8 @@ test('GET querystring empty objects', function(next){
   .get('/querystring')
   .query({})
   .end(function(res){
-    assert.eql(req._query, []);
-    assert.eql(res.body, {});
+    assert.deepEqual(req._query, []);
+    assert.deepEqual(res.body, {});
     next();
   });
 });
@@ -446,7 +447,7 @@ test('GET querystring with strings', function(next){
   .query('range=1..5')
   .query('order=desc')
   .end(function(res){
-    assert.eql(res.body, { search: 'Manny', range: '1..5', order: 'desc' });
+    assert.deepEqual(res.body, { search: 'Manny', range: '1..5', order: 'desc' });
     next();
   });
 });
@@ -457,7 +458,7 @@ test('GET querystring with strings and objects', function(next){
   .query('search=Manny')
   .query({ order: 'desc', range: '1..5' })
   .end(function(res){
-    assert.eql(res.body, { search: 'Manny', range: '1..5', order: 'desc' });
+    assert.deepEqual(res.body, { search: 'Manny', range: '1..5', order: 'desc' });
     next();
   });
 });
@@ -466,7 +467,7 @@ test('GET querystring object .get(uri, obj)', function(next){
   request
   .get('/querystring', { search: 'Manny' })
   .end(function(res){
-    assert.eql(res.body, { search: 'Manny' });
+    assert.deepEqual(res.body, { search: 'Manny' });
     next();
   });
 });
@@ -474,7 +475,7 @@ test('GET querystring object .get(uri, obj)', function(next){
 test('GET querystring object .get(uri, obj, fn)', function(next){
   request
   .get('/querystring', { search: 'Manny'}, function(res){
-    assert.eql(res.body, { search: 'Manny' });
+    assert.deepEqual(res.body, { search: 'Manny' });
     next();
   });
 });
@@ -512,27 +513,6 @@ test('req.timeout(ms)', function(next){
     next();
   })
 })
-
-test('req.withCredentials()', function(next){
-  request
-  .get('http://localhost:4001/')
-  .withCredentials()
-  .end(function(res){
-    assert(200 == res.status);
-    assert('tobi' == res.text);
-    next();
-  })
-})
-
-test('x-domain failure', function(next){
-  request
-  .get('http://google.com')
-  .end(function(err, res){
-    assert(err, 'error missing');
-    assert(err.crossDomain, 'not .crossDomain');
-    next();
-  });
-});
 
 test('basic auth', function(next){
   request

--- a/test/test.utils.js
+++ b/test/test.utils.js
@@ -1,5 +1,6 @@
 
-request = superagent;
+var assert = require('assert');
+var request = require('../');
 
 function serialize(obj, res) {
   var val = request.serializeObject(obj);
@@ -10,7 +11,7 @@ function serialize(obj, res) {
 
 function parse(str, obj) {
   var val = request.parseString(str);
-  assert.eql(val
+  assert.deepEqual(val
     , obj
     , '"' + str + '" to '
     + JSON.stringify(obj) + ' parse failed. got: '

--- a/test/test.xdomain.js
+++ b/test/test.xdomain.js
@@ -1,0 +1,34 @@
+
+var assert = require('assert');
+var request = require('../');
+
+test('req.withCredentials()', function(next){
+
+  // we force port 80 here when we don't know
+  // this works on localhost testing cause we have a port
+  // but on regular localtunnel.me we don't
+  // and since localtunnel.me loads over https, port 80
+  // becomes cross domain
+  var port = window.location.port || 80;
+  var hostname = window.location.hostname;
+
+  request
+  .get('http://' + hostname + ':' + port + '/xdomain')
+  .withCredentials()
+  .end(function(res){
+    assert(200 == res.status);
+    assert('tobi' == res.text);
+    next();
+  })
+})
+
+test('x-domain failure', function(next){
+  request
+  .get('http://google.com')
+  .end(function(err, res){
+    assert(err, 'error missing');
+    assert(err.crossDomain, 'not .crossDomain');
+    next();
+  });
+});
+


### PR DESCRIPTION
You can run the tests locally in a browser with:

```
zuul --local -- test/index.js
```

Or you can run the suite in sauce browsers with

```
zuul -- test/index.js
```

I have not hooked up any of the travis stuff, but everything you need is documented here:
https://github.com/defunctzombie/zuul/wiki/Quickstart

Note that some tests are failing in Chrome 31 on windows with xdomain stuff. We ran into this on the engine.io module and believe it to be a bug in chrome on windows.
