### PR TITLE
fix part content-disposition

### DIFF
--- a/lib/node/part.js
+++ b/lib/node/part.js
@@ -1,4 +1,3 @@
-
 /**
  * Module dependencies.
  */
@@ -116,7 +115,7 @@ Part.prototype.name = function(name){
 
 Part.prototype.attachment = function(name, filename){
   this.type(filename);
-  this.set('Content-Disposition', 'attachment; name="' + name + '"; filename="' + basename(filename) + '"');
+  this.set('Content-Disposition', 'form-data; name="' + name + '"; filename="' + basename(filename) + '"');
   return this;
 };
 


### PR DESCRIPTION
For a content-type of 'multipart/form-data', the content-disposition of each child part must be 'form-data' (and not 'attachment' for files).
