### PR TITLE
Add X-Requested-With header

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -841,6 +841,10 @@ Request.prototype.end = function(fn){
     if (null == this.header[field]) continue;
     xhr.setRequestHeader(field, this.header[field]);
   }
+  // Chrome xhr request has no X-Requested-With header now
+  if (!this.getHeader('X-Requested-With')) {
+    xhr.setRequestHeader('X-Requested-With', 'XMLHttpRequest');
+  }
 
   // send stuff
   xhr.send(data);


### PR DESCRIPTION
Chrome xhr request will not send `X-Requested-With` header. Many services rely this header to determine whether it is an Ajax request or not.
