### PR TITLE
Add Bower manifest

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,22 @@
+{
+  "name": "superagent",
+  "main": "superagent.js",
+  "version": "0.16.0",
+  "homepage": "https://github.com/visionmedia/superagent",
+  "authors": [
+    "TJ Holowaychuk <tj@vision-media.ca>"
+  ],
+  "description": "elegant & feature rich browser / node HTTP with a fluent API",
+  "keywords": [
+    "http",
+    "ajax",
+    "request",
+    "agent"
+  ],
+  "license": "MIT",
+  "ignore": [
+    "**/.*",
+    "node_modules",
+    "test"
+  ]
+}


### PR DESCRIPTION
It’s already in the registry. A manifest would be helpful for things that use
the Bower API to find the main file.
