### PR TITLE
add support for pre-defined data to .attach

### DIFF
--- a/lib/node/index.js
+++ b/lib/node/index.js
@@ -149,13 +149,14 @@ Request.prototype.__proto__ = Stream.prototype;
  * @api public
  */
 
-Request.prototype.attach = function(field, file, filename){
+Request.prototype.attach = function(field, file, filename, data){
   debug('attach %s %s', field, file);
   this.attachments.push({
     field: field,
     path: file,
     part: new Part(this),
-    filename: filename || file
+    filename: filename || file,
+    data: data
   });
   return this;
 };
@@ -865,6 +866,11 @@ Request.prototype.writeAttachments = function(){
       }
 
       file.part.attachment(file.field, file.filename);
+      if ('string' == typeof file.data) {
+        file.part.write(file.data);
+        return process.nextTick(next);
+      }
+
       var stream = fs.createReadStream(file.path);
 
       // TODO: pipe


### PR DESCRIPTION
Usually it's easier to not refer to file system and still be able to
attach files to requests and instead of writing

```
request(...).post(...).part().attachment(...).write(...)
```

I want to re-use current .attach API and use it as

```
request(...).post(...).attach('upload', 'my_file.txt', 'Some content')
```

It makes your code to have less lines and be more readable :)
