### PR TITLE
Support for content-type for the attachments.

### DIFF
--- a/lib/node/index.js
+++ b/lib/node/index.js
@@ -149,11 +149,12 @@ Request.prototype.__proto__ = Stream.prototype;
  * @api public
  */
 
-Request.prototype.attach = function(field, file, filename){
+Request.prototype.attach = function(field, file, filename, contenttype){
   debug('attach %s %s', field, file);
   this.attachments.push({
     field: field,
     path: file,
+    contenttype: contenttype,
     part: new Part(this),
     filename: filename || file
   });
@@ -864,7 +865,7 @@ Request.prototype.writeAttachments = function(){
         return req.end();
       }
 
-      file.part.attachment(file.field, file.filename);
+      file.part.attachment(file.field, file.filename, file.contenttype);
       var stream = fs.createReadStream(file.path);
 
       // TODO: pipe

--- a/lib/node/part.js
+++ b/lib/node/part.js
@@ -113,8 +113,13 @@ Part.prototype.name = function(name){
  * @api public
  */
 
-Part.prototype.attachment = function(name, filename){
-  this.type(filename);
+Part.prototype.attachment = function(name, filename, contenttype){
+  if (typeof contenttype !== "undefined" && contenttype !== null) {
+      this.set('Content-Type', contenttype);
+  }else{
+      this.type(filename);
+  }
+
   this.set('Content-Disposition', 'form-data; name="' + name + '"; filename="' + basename(filename) + '"');
   return this;
 };


### PR DESCRIPTION
The proposed changes add possibility to specify content types to the attached files. 
Something like this:

request.post(url)
        .query(reqPar)
        .attach(field, file, filename, contenttype)
        .end (res) ->

where contenttype is just a content type text like "image/jpeg" or something else. 
Sometimes you cannot trust on filename extensions.
