### PR TITLE
add request event

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -843,6 +843,7 @@ Request.prototype.end = function(fn){
   }
 
   // send stuff
+  this.emit('request', this);
   xhr.send(data);
   return this;
 };

--- a/lib/node/index.js
+++ b/lib/node/index.js
@@ -809,6 +809,7 @@ Request.prototype.end = function(fn){
   // multi-part boundary
   if (this._boundary) this.writeFinalBoundary();
 
+  this.emit('request', this);
   req.end(data);
   return this;
 };

--- a/superagent.js
+++ b/superagent.js
@@ -27,14 +27,10 @@ function require(path, parent, orig) {
   // perform real require()
   // by invoking the module's
   // registered function
-  if (!module._resolving && !module.exports) {
-    var mod = {};
-    mod.exports = {};
-    mod.client = mod.component = true;
-    module._resolving = true;
-    module.call(this, mod.exports, require.relative(resolved), mod);
-    delete module._resolving;
-    module.exports = mod.exports;
+  if (!module.exports) {
+    module.exports = {};
+    module.client = module.component = true;
+    module.call(this, module.exports, require.relative(resolved), module);
   }
 
   return module.exports;
@@ -367,7 +363,7 @@ Emitter.prototype.hasListeners = function(event){
 };
 
 });
-require.register("RedVentures-reduce/index.js", function(exports, require, module){
+require.register("component-reduce/index.js", function(exports, require, module){
 
 /**
  * Reduce `arr` with `fn`.
@@ -1392,13 +1388,11 @@ module.exports = request;
 });
 
 
-
-
 require.alias("component-emitter/index.js", "superagent/deps/emitter/index.js");
 require.alias("component-emitter/index.js", "emitter/index.js");
 
-require.alias("RedVentures-reduce/index.js", "superagent/deps/reduce/index.js");
-require.alias("RedVentures-reduce/index.js", "reduce/index.js");
+require.alias("component-reduce/index.js", "superagent/deps/reduce/index.js");
+require.alias("component-reduce/index.js", "reduce/index.js");
 
 require.alias("superagent/lib/client.js", "superagent/index.js");if (typeof exports == "object") {
   module.exports = require("superagent");

--- a/test/node/basic.js
+++ b/test/node/basic.js
@@ -367,6 +367,15 @@ describe('request', function(){
         done();
       });
     })
+
+    it('should emit request', function(done){
+      var req = request.post('http://localhost:5000/echo');
+      req.on('request', function(request){
+        assert(req == request);
+        done();
+      });
+      req.end();
+    })
   })
 
   describe('.buffer()', function(){


### PR DESCRIPTION
sorry about the build in the diff, didn't notice what i'm `git adding`.
this is very useful if you want to log `request -> response`, when you are not in control of the request instance.

i currently have an ugly hack to achieve this:

``` js
var end = req.end;
req.end = function(){
  emitter.emit('request', this);
  end.apply(this, arguments);
};
```
