### PR TITLE
Update emitter and rename to component-emitter

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "qs": "0.6.5",
     "formidable": "1.0.14",
     "mime": "1.2.5",
-    "emitter-component": "1.0.0",
+    "component-emitter": "1.1.2",
     "methods": "0.0.1",
     "cookiejar": "1.3.0",
     "debug": "~0.7.2",
@@ -39,7 +39,7 @@
   },
   "browser": {
     "./lib/node/index.js": "./lib/client.js",
-    "emitter": "emitter-component",
+    "emitter": "component-emitter",
     "reduce": "reduce-component"
   },
   "component": {


### PR DESCRIPTION
The emitter-component has been renamed to component-emitter.

All tests pass with latest version of component-emitter.
