### PR TITLE
Remove dependency on 'extend' module

### DIFF
--- a/lib/node/index.js
+++ b/lib/node/index.js
@@ -11,7 +11,6 @@ var format = require('url').format;
 var methods = require('methods');
 var Stream = require('stream');
 var utils = require('./utils');
-var extend = require('extend');
 var Part = require('./part');
 var mime = require('mime');
 var https = require('https');
@@ -315,6 +314,13 @@ Request.prototype.accept = function(type){
  * @return {Request} for chaining
  * @api public
  */
+
+function extend(i, j){
+  for ( var key in j )
+    if ( j.hasOwnProperty(key) )
+      i[key] = j[key];
+  return i;
+}
 
 Request.prototype.query = function(val){
   var obj = {};

--- a/package.json
+++ b/package.json
@@ -27,8 +27,7 @@
     "methods": "0.0.1",
     "cookiejar": "1.3.0",
     "debug": "~0.7.2",
-    "reduce-component": "1.0.1",
-    "extend": "~1.2.1"
+    "reduce-component": "1.0.1"
   },
   "devDependencies": {
     "zuul": "~1.3.0",


### PR DESCRIPTION
I thought it might be simpler just to use a simple routine to achieve the same effect, rather than depend on a separate module. What do you think?
