### PR TITLE
Allow raw query strings to be added to requests

### DIFF
--- a/lib/node/index.js
+++ b/lib/node/index.js
@@ -126,6 +126,7 @@ function Request(method, url) {
   this.attachments = [];
   this.cookies = '';
   this.qs = {};
+  this.qsRaw = [];
   this._redirectList = [];
   this.on('end', this.clearTimeout.bind(this));
   this.on('response', function(res){
@@ -329,6 +330,27 @@ Request.prototype.query = function(val){
   }
 
   extend(this.qs, val);
+  return this;
+};
+
+/**
+ * Add raw query-string `val` without additional encoding.
+ *
+ * Examples:
+ *
+ *   request.get('/print')
+ *     .queryRaw('data=%F6')
+ *
+ * @param {Object|String} val
+ * @return {Request} for chaining
+ * @api public
+ */
+
+Request.prototype.queryRaw = function(val){
+  if ('string' == typeof val) {
+    this.qsRaw.push(val);
+  }
+
   return this;
 };
 
@@ -703,6 +725,7 @@ Request.prototype.end = function(fn){
   // querystring
   try {
     var querystring = qs.stringify(this.qs);
+    querystring += ((querystring.length && this.qsRaw.length) ? '&' : '') + this.qsRaw.join('&');
     req.path += querystring.length
       ? (~req.path.indexOf('?') ? '&' : '?') + querystring
       : '';

--- a/test/node/query.js
+++ b/test/node/query.js
@@ -149,3 +149,57 @@ describe('req.query(Object)', function(){
     });
   });
 })
+
+describe('req.queryRaw(String)', function(){
+  it('should work when called once', function(done){
+    request
+    .del('http://localhost:3006/')
+    .queryRaw('name=t%F6bi')
+    .end(function(res){
+      res.body.should.eql({ name: 't%F6bi' });
+      done();
+    });
+  })
+
+  it('should work with url query-string', function(done){
+    request
+    .del('http://localhost:3006/?name=tobi')
+    .queryRaw('age=2%20')
+    .end(function(res){
+      res.body.should.eql({ name: 'tobi', age: '2 ' });
+      done();
+    });
+  })
+
+  it('should work with compound elements', function(done){
+    request
+      .del('http://localhost:3006/')
+      .queryRaw('name=t%F6bi&age=2')
+      .end(function(res){
+        res.body.should.eql({ name: 't%F6bi', age: '2' });
+        done();
+      });
+  })
+
+  it('should work when called multiple times', function(done){
+    request
+    .del('http://localhost:3006/')
+    .queryRaw('name=t%F6bi')
+    .queryRaw('age=2%F6')
+    .end(function(res){
+      res.body.should.eql({ name: 't%F6bi', age: '2%F6' });
+      done();
+    });
+  })
+
+  it('should work with normal `query`', function(done){
+    request
+    .del('http://localhost:3006/')
+    .queryRaw('name=t%F6bi')
+    .query('age=2%20')
+    .end(function(res){
+      res.body.should.eql({ name: 't%F6bi', age: '2%20' });
+      done();
+    });
+  })
+})


### PR DESCRIPTION
In some scenarios[1], it may be valuable to be able to pass
raw/pre-encoded query string parameters with a request. A recent change
to superagent forced all qs params to be utf8 encoded, which changed the
previous behavior of superagent. This commit adds another function,
`queryRaw`, to allow adding query string parameters that are NOT
re-encoded in any way prior to being passed as part of the request.

I thought it best to have an explicit approach to doing this to make
sure the developer intended this behavior, rather than trying to deduce
which querystring values should be encoded via other means.

[1] One example: when testing a server that uses a non-UTF8 URL encoding

See discussion on this commit for more context: https://github.com/visionmedia/superagent/commit/629bf9b10d26e2e6b44aea11b197ef8fea99a9c5