### PR TITLE
combo path should skip qs parser

### DIFF
--- a/lib/node/index.js
+++ b/lib/node/index.js
@@ -702,10 +702,15 @@ Request.prototype.end = function(fn){
 
   // querystring
   try {
-    var querystring = qs.stringify(this.qs);
-    req.path += querystring.length
-      ? (~req.path.indexOf('?') ? '&' : '?') + querystring
-      : '';
+    var url = parse(this.url, true);
+    if (url.search.substring(0, 2) === '??') {
+      req.path += url.search;
+    } else {    
+      var querystring = qs.stringify(this.qs);
+      req.path += querystring.length
+        ? (~req.path.indexOf('?') ? '&' : '?') + querystring
+        : '';
+    }
   } catch (e) {
     return this.callback(e);
   }

--- a/test/node/combo-path.js
+++ b/test/node/combo-path.js
@@ -1,0 +1,21 @@
+
+var request = require('../..')
+  , express = require('express')
+  , app = express();
+
+app.get('/', function(req, res){
+  res.send(req.url);
+});
+
+app.listen(3100);
+
+describe('combo path', function(){
+  it('should work skip qs parse', function(done){
+    request
+    .get('http://localhost:3100/??a.js,b.js')
+    .end(function(res){
+      res.text.should.eql('/??a.js,b.js');
+      done();
+    });
+  });
+});


### PR DESCRIPTION
A combo path using `??` as querystring, online example: https://a.alipayobjects.com/??seajs/seajs/2.1.1/sea.js,jquery/jquery/1.7.2/jquery.js

If I request `/??a.js, b.js` using speragent, it will return `/?%3Fa.js%2Cb.js=`, but it's not expected.
