### PR TITLE
Bump dependency version for cookiejar.

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "mime": "1.2.5",
     "component-emitter": "1.1.2",
     "methods": "0.0.1",
-    "cookiejar": "1.3.0",
+    "cookiejar": "1.3.2",
     "debug": "~0.7.2",
     "reduce-component": "1.0.1",
     "extend": "~1.2.1"


### PR DESCRIPTION
The `cookiejar` dependency is out by 2 minor versions; which solve a few bugs in that package such as https://github.com/bmeck/node-cookiejar/pull/6

The author has recently `published` a new version to `npm`: https://github.com/bmeck/node-cookiejar/issues/12

fixes: https://github.com/visionmedia/superagent/issues/174
