### PR TITLE
node: part: update comment to not say "Content-Disposition: attachment;" in .attach()

### DIFF
--- a/lib/node/part.js
+++ b/lib/node/part.js
@@ -115,7 +115,7 @@ Part.prototype.name = function(name){
 
 Part.prototype.attachment = function(name, filename){
   this.type(filename);
-  this.set('Content-Disposition', 'form-data; name="' + name + '"; filename="' + basename(filename) + '"');
+  this.set('Content-Disposition', 'attachment; name="' + name + '"; filename="' + basename(filename) + '"');
   return this;
 };
 
@@ -146,4 +146,3 @@ Part.prototype.end = function(){
   this.emit('end');
   this.complete = true;
 };
-


### PR DESCRIPTION
For the `.attachment()` function.

This must have been a copy+paste error, because the comment for
this function already specifies that it writes "attachment", it
just wasn't the case in the source code.
