### PR TITLE
node: ability to .attach() a `fs.ReadStream` instance

### DIFF
--- a/lib/node/index.js
+++ b/lib/node/index.js
@@ -81,6 +81,20 @@ function isObject(obj) {
 }
 
 /**
+ * Checks if `obj` looks like an `fs.ReadStream` instance.
+ *
+ * @param {Object} obj
+ * @return {Boolean}
+ * @api private
+ */
+
+function isFsReadStream(obj) {
+  return isObject(obj)
+    && 'function' == typeof obj.close
+    && 'string' == typeof obj.path;
+}
+
+/**
  * Default serialization map.
  *
  *     superagent.serialize['application/xml'] = function(obj){
@@ -140,24 +154,37 @@ function Request(method, url) {
 Request.prototype.__proto__ = Stream.prototype;
 
 /**
- * Queue the given `file` as an attachment
+ * Queue the given file `path` as an attachment
  * with optional `filename`.
  *
+ * An existing `fs.ReadStream` may also be passed in for the `path`.
+ *
  * @param {String} field
- * @param {String} file
+ * @param {String} path
  * @param {String} filename
  * @return {Request} for chaining
  * @api public
  */
 
-Request.prototype.attach = function(field, file, filename){
-  debug('attach %s %s', field, file);
-  this.attachments.push({
+Request.prototype.attach = function(field, path, filename){
+  var file = {
     field: field,
-    path: file,
-    part: new Part(this),
-    filename: filename || file
-  });
+    part: new Part(this)
+  };
+
+  if ('string' == typeof path) {
+    file.path = path;
+  } else if (isFsReadStream(path)) {
+    file.path = path.path;
+    file.stream = path; // save the readable so that we don't have to re-create one
+  } else {
+    throw new TypeError('a `string` or `fs.ReadStream` is required');
+  }
+  debug('attach %s %s', field, file.path);
+
+  file.filename = filename || file.path;
+
+  this.attachments.push(file);
   return this;
 };
 
@@ -875,7 +902,7 @@ Request.prototype.attachmentSize = function(fn){
       if (s) bytes += s.size;
       --pending || fn(bytes);
     });
-  })
+  });
 };
 
 /**
@@ -899,7 +926,7 @@ Request.prototype.writeAttachments = function(){
       }
 
       file.part.attachment(file.field, file.filename);
-      var stream = fs.createReadStream(file.path);
+      var stream = file.stream || fs.createReadStream(file.path);
 
       // TODO: pipe
       // TODO: handle errors
@@ -917,7 +944,7 @@ Request.prototype.writeAttachments = function(){
     }
 
     next();
-  })
+  });
 };
 
 /**


### PR DESCRIPTION
This allows us to do, i.e.:

``` js
request.post('/upload')
  .attach('file', fs.createReadStream('foo.txt'))
  .end(fn);
```

Eventually it would be better to add support for arbitrary `stream.Readable` instances, but this is good enough for now.
