### PR TITLE
Added pipe redirection

### DIFF
--- a/lib/node/index.js
+++ b/lib/node/index.js
@@ -397,9 +397,14 @@ Request.prototype.write = function(data, encoding){
  */
 
 Request.prototype.pipe = function(stream, options){
+  this.stream = stream;
   this.piped = true; // HACK...
   this.buffer(false);
   this.end().req.on('response', function(res){
+    if (isRedirect(res.statusCode)) {
+      // Don't pipe yet; redirecting.
+      return;
+    }
     if (/^(deflate|gzip)$/.test(res.headers['content-encoding'])) {
       res.pipe(zlib.createUnzip()).pipe(stream, options);
     } else {
@@ -518,7 +523,11 @@ Request.prototype.redirect = function(res){
   this.clearTimeout();
   this.emit('redirect', res);
   this.set(header);
-  this.end(this._callback);
+  if (this.piped) {
+    this.pipe(this.stream);
+  } else {
+    this.end(this._callback);
+  }
   return this;
 };
 
@@ -688,16 +697,16 @@ Request.prototype.end = function(fn){
     var multipart = 'multipart' == type;
     var redirect = isRedirect(res.statusCode);
 
+    // redirect
+    if (redirect && self._redirects++ != max) {
+      return self.redirect(res);
+    }
+
     if (self.piped) {
       res.on('end', function(){
         self.emit('end');
       });
       return;
-    }
-
-    // redirect
-    if (redirect && self._redirects++ != max) {
-      return self.redirect(res);
     }
 
     // zlib support

--- a/test/node/redirects.js
+++ b/test/node/redirects.js
@@ -4,7 +4,8 @@ var EventEmitter = require('events').EventEmitter
   , express = require('express')
   , assert = require('assert')
   , app = express()
-  , should = require('should');
+  , should = require('should')
+  , fs = require('fs');
 
 app.get('/', function(req, res){
   res.redirect('/movies');
@@ -95,6 +96,19 @@ describe('request', function(){
         res.body.should.not.have.property('transfer-encoding');
         done();
       });
+    })
+
+    it('should pipe properly', function(done){
+      var stream = fs.createWriteStream('test/node/fixtures/tmp.html');
+      var req = request.get('http://localhost:3003/movies/all');
+
+      stream.on('close', function(){
+        fs.readFileSync('test/node/fixtures/tmp.html', 'utf8')
+          .should.equal('first movie page')
+        fs.unlink('test/node/fixtures/tmp.html');
+        done();
+      });
+      req.pipe(stream);
     })
 
     describe('when relative', function(){


### PR DESCRIPTION
This is a fix for issue #298. Simple pipe redirection was not working; this makes it instead keep track of the stream past redirects.
