### PR TITLE
do not set cookie header if not available for node client

### DIFF
--- a/lib/node/index.js
+++ b/lib/node/index.js
@@ -703,7 +703,7 @@ Request.prototype.request = function(){
   this.query(url.query);
 
   // add cookies
-  req.setHeader('Cookie', this.cookies);
+  if (this.cookies) req.setHeader('Cookie', this.cookies);
 
   // set default UA
   req.setHeader('User-Agent', 'node-superagent/' + pkg.version);


### PR DESCRIPTION
`Cookie: \r\n` or `Cookie: undefined` may cause some backend server exception:

```
Severe:   An exception or error occurred in the container during the request processing
java.lang.IllegalArgumentException
  at org.glassfish.grizzly.http.util.CookieParserUtils.parseClientCookies(CookieParserUtils.java:353)
  at org.glassfish.grizzly.http.util.CookieParserUtils.parseClientCookies(CookieParserUtils.java:336)
  at org.glassfish.grizzly.http.Cookies.processClientCookies(Cookies.java:220)
  at org.glassfish.grizzly.http.Cookies.get(Cookies.java:131)

```
