### PR TITLE
client: add xhr2 file download

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -294,7 +294,9 @@ function Response(req, options) {
   options = options || {};
   this.req = req;
   this.xhr = this.req.xhr;
-  this.text = this.xhr.responseText;
+  if (this.xhr.responseType === '' || this.xhr.responseType === 'text') {
+    this.text = this.xhr.responseText;
+  }
   this.setStatusProperties(this.xhr.status);
   this.header = this.headers = parseHeader(this.xhr.getAllResponseHeaders());
   // getAllResponseHeaders sometimes falsely returns "" for CORS requests, but
@@ -303,7 +305,7 @@ function Response(req, options) {
   this.header['content-type'] = this.xhr.getResponseHeader('content-type');
   this.setHeaderProperties(this.header);
   this.body = this.req.method != 'HEAD'
-    ? this.parseBody(this.text)
+    ? this.parseBody(this.text ? this.text : this.xhr.response)
     : null;
 }
 

--- a/superagent.js
+++ b/superagent.js
@@ -690,7 +690,9 @@ function Response(req, options) {
   options = options || {};
   this.req = req;
   this.xhr = this.req.xhr;
-  this.text = this.xhr.responseText;
+  if (this.xhr.responseType === '' || this.xhr.responseType === 'text') {
+    this.text = this.xhr.responseText;
+  }
   this.setStatusProperties(this.xhr.status);
   this.header = this.headers = parseHeader(this.xhr.getAllResponseHeaders());
   // getAllResponseHeaders sometimes falsely returns "" for CORS requests, but
@@ -699,7 +701,7 @@ function Response(req, options) {
   this.header['content-type'] = this.xhr.getResponseHeader('content-type');
   this.setHeaderProperties(this.header);
   this.body = this.req.method != 'HEAD'
-    ? this.parseBody(this.text)
+    ? this.parseBody(this.text ? this.text : this.xhr.response)
     : null;
 }
 

--- a/test/server.js
+++ b/test/server.js
@@ -132,6 +132,12 @@ app.get('/xdomain', function(req, res){
   res.send(req.cookies.name);
 });
 
+app.get('/arraybuffer', function(req, res) {
+  var content = new ArrayBuffer(1000);
+  res.set('Content-Type', 'application/vnd.superagent');
+  res.send(content);
+});
+
 app.use(express.static(__dirname + '/../'));
 
 var server = app.listen(process.env.ZUUL_PORT, function() {

--- a/test/test.request.js
+++ b/test/test.request.js
@@ -535,3 +535,19 @@ test('basic auth', function(next){
     next();
   });
 });
+
+test('xhr2 download file', function(next) {
+  request.parse['application/vnd.superagent'] = function (obj) {
+    return obj;
+  };
+
+  request
+  .get('/arraybuffer')
+  .on('request', function () {
+    this.xhr.responseType = 'arraybuffer';
+  })
+  .end(function(res) {
+    assert(res.body instanceof ArrayBuffer);
+    next();
+  });
+});


### PR DESCRIPTION
Adds ability for the client to download files as ```arraybuffer``` or ```blob```.

First register a handler that will instruct superagent how to parse the response body. 

```javascript
request.parse['myFileMimetype'] = function(obj) {
  return obj;
}
```

then, you have to set up the responseType. The xhr object is available only after the request is available, therefore the handler has to be registered for each request:

```javascript
request
.get('/arraybuffer')
.on('request', function () {
  this.xhr.responseType = 'arraybuffer'; // or blob
})
.end(function(res) {
  // now res.body is an arraybuffer or a blob
});
```

