### PR TITLE
add option for synchronous requests to client lib

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -449,6 +449,7 @@ function Request(method, url) {
   this.url = url;
   this.header = {};
   this._header = {};
+  this._asynchronous = true;
   this.on('end', function(){
     var res = new Response(self);
     if ('HEAD' == method) res.text = null;
@@ -825,6 +826,11 @@ Request.prototype.withCredentials = function(){
   return this;
 };
 
+Request.prototype.synchronous = function(){
+  this._asynchronous = false;
+  return this;
+};
+
 /**
  * Initiate request, invoking callback `fn(res)`
  * with an instanceof `Response`.
@@ -878,7 +884,7 @@ Request.prototype.end = function(fn){
   }
 
   // initiate request
-  xhr.open(this.method, this.url, true);
+  xhr.open(this.method, this.url, this._asynchronous);
 
   // CORS
   if (this._withCredentials) xhr.withCredentials = true;


### PR DESCRIPTION
This would add an option to the client lib to switch the XHR to synchronous behaviour. 

I just needed this for a client that switched from some other xhr lib to the superagent client lib but had one weird feature where synchronous was definitely needed.

I do understand that synchronous ajax requests are usually a total no-go and you probably might not want to have this in superagent at all.

If you, against all odds, consider to merge this one I'd be happy to provide more changes to round this up (docs, tests).

Might be related to #34, but the discussion there is about node, I believe. 
