### PR TITLE
Allow HEAD method to send body data

### DIFF
--- a/lib/node/index.js
+++ b/lib/node/index.js
@@ -773,7 +773,7 @@ Request.prototype.end = function(fn){
   }
 
   // body
-  if ('HEAD' != method && !req._headerSent) {
+  if (!req._headerSent) {
     // serialize stuff
     if ('string' != typeof data) {
       var contentType = req.getHeader('Content-Type')


### PR DESCRIPTION
I could be mixed up, but I think that the HEAD method really should allow body content to be sent.  My understanding is that the only difference between HEAD and GET is that the server should send the same headers as a GET, but must not return a message body.  See:

http://www.w3.org/Protocols/rfc2616/rfc2616-sec9.html
