### PR TITLE
Fix 307 redirects

### DIFF
--- a/lib/node/index.js
+++ b/lib/node/index.js
@@ -608,23 +608,39 @@ Request.prototype.redirect = function(res){
   // this is required for Node v0.10+
   res.resume();
 
-  // strip Content-* related fields
-  // in case of POST etc
-  var header = utils.cleanHeader(this.req._headers);
+  var headers = this.req._headers;
+
+  // implementation of 302 following defacto standard
+  if (res.statusCode == 301 || res.statusCode == 302){
+    // strip Content-* related fields
+    // in case of POST etc
+    headers = utils.cleanHeader(this.req._headers);
+
+    // force GET
+    this.method = 'HEAD' == this.method
+      ? 'HEAD'
+      : 'GET';
+
+    // clear data
+    this._data = null;
+  }
+  // 303 is always GET
+  if (res.statusCode == 303) {
+    // force method
+    this.method = 'GET';
+    // clear data
+    this._data = null;
+  }
+  // 307 preserves method
+
   delete this.req;
 
-  // force GET
-  this.method = 'HEAD' == this.method
-    ? 'HEAD'
-    : 'GET';
-
   // redirect
-  this._data = null;
   this.url = url;
   this._redirectList.push(url);
   this.emit('redirect', res);
   this.qs = {};
-  this.set(header);
+  this.set(headers);
   this.end(this._callback);
   return this;
 };

--- a/test/node/redirects.js
+++ b/test/node/redirects.js
@@ -40,6 +40,19 @@ app.post('/movie', function(req, res){
   res.redirect('/movies/all/0');
 });
 
+app.put('/redirect-303', function(req, res){
+  res.redirect(303, '/reply-method');
+});
+
+app.put('/redirect-307', function(req, res){
+  res.redirect(307, '/reply-method');
+});
+
+
+app.all('/reply-method', function(req, res){
+  res.send('method=' + req.method.toLowerCase());
+});
+
 app.get('/tobi', function(req, res){
   res.send('tobi');
 });
@@ -218,6 +231,38 @@ describe('request', function(){
         res.text.should.equal('first movie page');
         done();
       });
+    })
+  })
+
+  describe('on 303', function(){
+    it('should redirect with same method', function(done){
+      request
+      .put('http://localhost:3003/redirect-303')
+      .send({msg: "hello"})
+      .redirects(1)
+      .on('redirect', function(res) {
+        res.headers.location.should.equal('/reply-method')
+      })
+      .end(function(res){
+        res.text.should.equal('method=get');
+        done();
+      })
+    })
+  })
+
+  describe('on 307', function(){
+    it('should redirect with same method', function(done){
+      request
+      .put('http://localhost:3003/redirect-307')
+      .send({msg: "hello"})
+      .redirects(1)
+      .on('redirect', function(res) {
+        res.headers.location.should.equal('/reply-method')
+      })
+      .end(function(res){
+        res.text.should.equal('method=put');
+        done();
+      })
     })
   })
 })


### PR DESCRIPTION
Adds tests that `307` redirects with the same method.

Note, this is not really a perfect implementation. The specification says that anything other than `HEAD` or `GET` must not automatically redirect, which is what this does.

Ideally, we should add a feature similar to `-L` on `curl` which tells superagent that we trust the site and is willing follow `POST`, `PUT`, etc. redirects. Ie. it should be an option, or a user-supplied called back that is used to decide if a 307 redirect should be followed with anything other than `GET` or `HEAD`.

Note, automatically following a 307 `PUT` with a `GET` as superagent didn't before is all bad. If interested I would happily implement a `.trustRedirect(true || false)` option. Other (better) names for such a option would be great though :)