### PR TITLE
cope with nock not allowing connection

### DIFF
--- a/lib/node/index.js
+++ b/lib/node/index.js
@@ -755,9 +755,11 @@ Request.prototype.end = function(fn){
   // querystring
   try {
     var querystring = qs.stringify(this.qs);
+    if(req.path){
     req.path += querystring.length
       ? (~req.path.indexOf('?') ? '&' : '?') + querystring
       : '';
+    }
   } catch (e) {
     return this.callback(e);
   }

--- a/package.json
+++ b/package.json
@@ -33,11 +33,12 @@
     "readable-stream": "1.0.27-1"
   },
   "devDependencies": {
-    "zuul": "~1.6.0",
-    "express": "3.5.0",
     "better-assert": "~0.1.0",
+    "express": "3.5.0",
+    "mocha": "*",
+    "nock": "^0.42.1",
     "should": "3.1.3",
-    "mocha": "*"
+    "zuul": "~1.6.0"
   },
   "browser": {
     "./lib/node/index.js": "./lib/client.js",

--- a/test/node/network-error.js
+++ b/test/node/network-error.js
@@ -1,8 +1,8 @@
-
 var request = require('../..')
   , express = require('express')
   , assert = require('assert')
-  , net = require('net');
+  , net = require('net')
+  , nock = require('nock');
 
 function getFreePort(fn) {
   var server = net.createServer();
@@ -14,7 +14,7 @@ function getFreePort(fn) {
   });
 };
 
-describe('with network error', function(){
+describe('with network error', function (){
   before(function(done){
     var self = this;
     // connecting to a free port
@@ -32,5 +32,29 @@ describe('with network error', function(){
       assert(err, 'expected an error');
       done();
     });
+  });
+});
+describe('with nock connection not allowed and query', function () {
+  before(function () {
+    var self = this;
+    //mock out the client **from nock.js code https://github.com/pgte/nock
+    nock.disableNetConnect();
+  });
+
+  it('should error', function (done) {
+    request
+      .get('http://localhost:' + this.port + '/')
+      .query({
+        key: 'val'
+      })
+      .end(function (err, res) {
+        
+        assert(err, 'expected an error');
+        err.name.should.eql('NetConnectNotAllowedError');
+        done();
+      });
+  });
+  after(function () {
+    nock.enableNetConnect();
   });
 });


### PR DESCRIPTION
I don't know if this is worth putting in or not but if you disable net connect using nock (which replaces standard functions and throws an error on attempting non-mocked calls) and try and do a request with a query string you should get back a NetConnectNotAllowedError but instead you get a TypeError due to req.path not existing.

This is the simplest test case I can think of but requires a devDependency on nock.js so I don't know if it'll be allowed...
