### PR TITLE
req.response: store Response instance on req.response

### DIFF
--- a/lib/node/index.js
+++ b/lib/node/index.js
@@ -833,6 +833,7 @@ Request.prototype.end = function(fn){
         response.body = fields;
         response.files = files;
         response.redirects = self._redirectList;
+        self.response = response;
         self.emit('end');
         self.callback(null, response);
       });
@@ -844,6 +845,7 @@ Request.prototype.end = function(fn){
       exports.parse.image(res, function(err, obj){
         if (err) return self.callback(err);
         var response = new Response(req, res);
+        self.response = response;
         response.body = obj;
         response.redirects = self._redirectList;
         self.emit('end');
@@ -886,6 +888,7 @@ Request.prototype.end = function(fn){
       debug('unbuffered %s %s', self.method, self.url);
       self.res = res;
       var response = new Response(self.req, self.res);
+      self.response = response;
       response.redirects = self._redirectList;
       self.emit('response', response);
       if (multipart) return // allow multipart to handle end event
@@ -902,6 +905,7 @@ Request.prototype.end = function(fn){
       debug('end %s %s', self.method, self.url);
       // TODO: unless buffering emit earlier to stream
       var response = new Response(self.req, self.res);
+      self.response = response;
       response.redirects = self._redirectList;
       self.emit('response', response);
       self.emit('end');

--- a/test/node/basic.js
+++ b/test/node/basic.js
@@ -100,6 +100,17 @@ describe('request', function(){
     })
   })
 
+  describe('req.response', function(){
+    it('should eql Response', function(done){
+      var req = request
+      .post(':5000/xml')
+      .end(function(err, res){
+        req.response.should.equal(res);
+        done();
+      });
+    });
+  });
+
   describe('res.error', function(){
     it('should should be an Error object', function(done){
       request


### PR DESCRIPTION
Useful when you have a list of requests, you just know they were ended and you want to reach into `Response`.
