### PR TITLE
Added bower.json

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -20,6 +20,14 @@ $ component install visionmedia/superagent
 
   with script tags use ./superagent.js
 
+  bower: 
+
+```
+$ bower install superagent
+```
+
+*Note: To use superagent with browserify + debowerify use `require('superagent/lib/client')`*
+
 ## Motivation
 
   This library spawned from my frustration with jQuery's weak & inconsistent Ajax support. jQuery's API, while having recently added some promise-like support, is largely static, forcing you to build up big objects containing all the header fields and options, not to mention most of the options are awkwardly named "type" instead of "method", etc. Onto examples!

--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,15 @@
+ {
+   "name": "superagent",
+   "main": [
+     "superagent.js"
+   ],
+   "ignore": [
+     "docs",
+     "examples",
+     "test"
+   ],
+   "dependencies": {
+     "emitter": "https://github.com/component/emitter.git",
+     "reduce": "https://github.com/component/reduce.git"
+   }
+ }

--- a/lib/client.js
+++ b/lib/client.js
@@ -3,7 +3,7 @@
  */
 
 var Emitter = require('emitter');
-var reduce = require('reduce');
+var reduce = require('reduce/index');
 
 /**
  * Root reference for iframes.


### PR DESCRIPTION
The changes in this commit make the module installable using bower.

The change to client.js is backwards compatible with `component build` but also enables installation with bower + browserify + debowerify (the caveat is that one must use `require('superagent/lib/client')` instead of `require('superagent')`)

Addresses #315 
