### PR TITLE
IE9 XDR will abort some requests if you do not attach all event handlers

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -850,6 +850,17 @@ Request.prototype.withCredentials = function(){
 };
 
 /**
+ * Emit progress event.
+ *
+ * @api private
+ */
+
+Request.prototype.progress = function(){
+  e.percent = e.loaded / e.total * 100;
+  self.emit('progress', e);
+};
+
+/**
  * Initiate request, invoking callback `fn(res)`
  * with an instanceof `Response`.
  *
@@ -902,13 +913,16 @@ Request.prototype.end = function(fn){
     xhr.ontimeout = function () {
       return self.timeoutError();
     }
+
+    xhr.onprogress = function (e) {
+      self.progress(e);
+    }
   }
 
   // progress
   if (xhr.upload) {
     xhr.upload.onprogress = function(e){
-      e.percent = e.loaded / e.total * 100;
-      self.emit('progress', e);
+      self.progress(e);
     };
   }
 


### PR DESCRIPTION
I'm seeing this in our own app our initial xdr post will abort, setting onprogress event handler fixes this.

See thread on [IE Dev Forum](http://social.msdn.microsoft.com/Forums/ie/en-US/30ef3add-767c-4436-b8a9-f1ca19b4812e/ie9-rtm-xdomainrequest-issued-requests-may-abort-if-all-event-handlers-not-specified).

I refactored out the progress method as upload and download both support progress events.
