### PR TITLE
Update qs to 1.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "url": "git://github.com/visionmedia/superagent.git"
   },
   "dependencies": {
-    "qs": "0.6.6",
+    "qs": "1.2.0",
     "formidable": "1.0.14",
     "mime": "1.2.11",
     "component-emitter": "1.1.2",
@@ -35,7 +35,7 @@
   "devDependencies": {
     "zuul": "~1.6.0",
     "express": "3.5.0",
-    "better-assert": "~0.1.0",
+    "better-assert": "~1.0.1",
     "should": "3.1.3",
     "mocha": "*"
   },

--- a/test/node/form.js
+++ b/test/node/form.js
@@ -40,7 +40,7 @@ describe('req.send(Object) as "form"', function(){
       .send({ age: '1' })
       .end(function(res){
         res.header['content-type'].should.equal('application/x-www-form-urlencoded');
-        res.text.should.equal('name[first]=tobi&name[last]=holowaychuk&age=1');
+        res.text.should.equal('name%5Bfirst%5D=tobi&name%5Blast%5D=holowaychuk&age=1');
         done();
       });
     })

--- a/test/node/query.js
+++ b/test/node/query.js
@@ -111,7 +111,7 @@ describe('req.query(Object)', function(){
     .del('http://localhost:3006/')
     .query({ at: date })
     .end(function(res){
-      assert(String(date) == res.body.at);
+      assert(date.toISOString() == res.body.at);
       done();
     });
   })


### PR DESCRIPTION
qs had the following breaking changes:
- Square brackets get urlencoded (see: hapijs/qs#8)
- Use date.toISOString() for date serialization (see: hapijs/qs@e4731562502b8c4b5c1a505514dcfa083bedf12c)
  Also update better-assert
