### PR TITLE
Prefer XMLHttpRequest over ActiveX.

### DIFF
--- a/superagent.js
+++ b/superagent.js
@@ -444,7 +444,7 @@ function isHost(obj) {
  */
 
 function getXHR() {
-  if (root.XMLHttpRequest &&'file:' != root.location.protocol) {
+  if (root.XMLHttpRequest && 'file:' != root.location.protocol) {
     return new XMLHttpRequest;
   } else {
     try { return new ActiveXObject('Microsoft.XMLHTTP'); } catch(e) {}


### PR DESCRIPTION
There is no reason to give up XMLHttpRequest when it is available. This pull also makes it possible to use an XMLHttpRequest shim with SuperAgent.

Ref:
https://developer.mozilla.org/en-US/docs/AJAX/Getting_Started
http://www.quirksmode.org/js/xmlhttp.html
https://github.com/jquery/jquery/blob/1.x-master/src/ajax/xhr.js#L24
