### PR TITLE
Error While Trying to Emit an Error

### DIFF
--- a/lib/node/index.js
+++ b/lib/node/index.js
@@ -735,7 +735,7 @@ Request.prototype.callback = function(err, res){
   this.clearTimeout();
   if (this.called) return console.warn('double callback!');
   this.called = true;
-  if (2 == fn.length) return fn(err, res);
+  if (fn && 2 == fn.length) return fn(err, res);
   if (err) return this.emit('error', err);
   fn(res);
 };


### PR DESCRIPTION
The fn variable can be undefined so the function was wasn't emitting err as intended but instead was failing with `TypeError: Cannot read property 'length' of undefined`.

_Note_: that this change applied to the npm package 0.18.2 (cdbf2a5bb2a32e85) works, but I am having other troubles with master as it is. Perhaps this scenario is no longer possible. I just can't get to that point yet to test it.
