### PR TITLE
Add per-request plugin support within Node.

### DIFF
--- a/lib/node/index.js
+++ b/lib/node/index.js
@@ -143,6 +143,15 @@ function Request(method, url) {
 util.inherits(Request, Stream);
 
 /**
+ * Allow for extension
+ */
+
+Request.prototype.use = function(fn) {
+  fn(this);
+  return this;
+}
+
+/**
  * Write the field `name` and `val` for "multipart/form-data"
  * request bodies.
  *


### PR DESCRIPTION
Previously, `request.use` was only available to browsers. This PR replicates the _exact same behaviour_ in Node, allowing plugins to be shared between the two.
