### PR TITLE
Fix bug where cookies aren't been set when hostname requires a port appended

### DIFF
--- a/lib/node/agent.js
+++ b/lib/node/agent.js
@@ -49,7 +49,7 @@ Agent.prototype.saveCookies = function(res){
 
 Agent.prototype.attachCookies = function(req){
   var url = parse(req.url);
-  var access = CookieAccess(url.host, url.pathname, 'https:' == url.protocol);
+  var access = CookieAccess(url.hostname, url.pathname, 'https:' == url.protocol);
   var cookies = this.jar.getCookies(access).toValueString();
   req.cookies = cookies;
 };

--- a/lib/node/agent.js
+++ b/lib/node/agent.js
@@ -49,7 +49,7 @@ Agent.prototype.saveCookies = function(res){
 
 Agent.prototype.attachCookies = function(req){
   var url = parse(req.url);
-  var access = CookieAccess(url.hostname, url.pathname, 'https:' == url.protocol);
+  var access = CookieAccess(url.host, url.pathname, 'https:' == url.protocol);
   var cookies = this.jar.getCookies(access).toValueString();
   req.cookies = cookies;
 };

--- a/lib/node/agent.js
+++ b/lib/node/agent.js
@@ -49,7 +49,7 @@ Agent.prototype.saveCookies = function(res){
 
 Agent.prototype.attachCookies = function(req){
   var url = parse(req.url);
-  var access = CookieAccess(url.hostname, url.pathname, 'https:' == url.protocol);
+  var access = CookieAccess(url.hostname + (url.port == "80" ? "" : ":" + url.port), url.pathname, 'https:' == url.protocol);
   var cookies = this.jar.getCookies(access).toValueString();
   req.cookies = cookies;
 };


### PR DESCRIPTION
A previous change from req.host to req.hostname removed the :PORT section of the host, which caused cookies not to be set. Broke Express 3.8.x when using a local port.