### PR TITLE
Fix basic auth

### DIFF
--- a/lib/node/index.js
+++ b/lib/node/index.js
@@ -623,6 +623,12 @@ Request.prototype.redirect = function(res){
 /**
  * Set Authorization field value with `user` and `pass`.
  *
+ * Examples:
+ *
+ *   .auth('tobi', 'learnboost')
+ *   .auth('tobi:learnboost')
+ *   .auth('tobi')
+ *
  * @param {String} user
  * @param {String} pass
  * @return {Request} for chaining
@@ -630,8 +636,9 @@ Request.prototype.redirect = function(res){
  */
 
 Request.prototype.auth = function(user, pass){
-  if (pass) pass = ':' + pass;
-  var str = new Buffer(user + (pass || '')).toString('base64');
+  if (1 === arguments.length) pass = '';
+  if (!~user.indexOf(':')) user = user + ':';
+  var str = new Buffer(user + pass).toString('base64');
   return this.set('Authorization', 'Basic ' + str);
 };
 

--- a/test/node/basic-auth.js
+++ b/test/node/basic-auth.js
@@ -5,10 +5,12 @@ var EventEmitter = require('events').EventEmitter
   , assert = require('assert')
   , app = express();
 
-app.use(express.basicAuth('tobi', 'learnboost'));
-
-app.get('/', function(req, res){
+app.get('/', express.basicAuth('tobi', 'learnboost'), function(req, res){
   res.end('you win!');
+});
+
+app.get('/again', express.basicAuth('tobi', ''), function(req, res){
+  res.end('you win again!');
 });
 
 app.listen(3010);
@@ -40,8 +42,8 @@ describe('Basic auth', function(){
   describe('req.auth(user + ":" + pass)', function(){
     it('should set authorization', function(done){
       request
-      .get('http://localhost:3010')
-      .auth('tobi:learnboost')
+      .get('http://localhost:3010/again')
+      .auth('tobi')
       .end(function(res){
         res.status.should.eql(200);
         done();


### PR DESCRIPTION
We added the ability to emulate password-less auth in #329 (released in 0.16.0) for the cases where you want to use some sort of api key. However I don't believe it ever worked correctly as the trailing colon was not appended.

cc: @yields @travisjeffery
