### PR TITLE
package: update "debug" to v2.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "component-emitter": "1.1.2",
     "methods": "1.0.1",
     "cookiejar": "2.0.1",
-    "debug": "~1.0.1",
+    "debug": "~2.0.0",
     "reduce-component": "1.0.1",
     "extend": "~1.2.1",
     "form-data": "0.1.3",


### PR DESCRIPTION
For better de-duping with modules that are using the latest version of `debug` module.
There were no breaking API changes, so just updating the version number should work fine.

Cheers!
