### PR TITLE
Clear timeout on callback

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -806,6 +806,7 @@ Request.prototype.send = function(data){
 
 Request.prototype.callback = function(err, res){
   var fn = this._callback;
+  this.clearTimeout();
   if (2 == fn.length) return fn(err, res);
   if (err) return this.emit('error', err);
   fn(res);

--- a/superagent.js
+++ b/superagent.js
@@ -1202,6 +1202,7 @@ Request.prototype.send = function(data){
 
 Request.prototype.callback = function(err, res){
   var fn = this._callback;
+  this.clearTimeout();
   if (2 == fn.length) return fn(err, res);
   if (err) return this.emit('error', err);
   fn(res);


### PR DESCRIPTION
The problem here was that `clearTimeout()` was not being called on the client in `Request.prototype.callback` as in the [node version](https://github.com/visionmedia/superagent/blob/master/lib/node/index.js#L743). The side effect of this was that the `abort` event was emitted on every request as reported in #234
