### PR TITLE
Use "self" to get the global scope in workers

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -10,7 +10,7 @@ var reduce = require('reduce');
  */
 
 var root = 'undefined' == typeof window
-  ? this
+  ? self
   : window;
 
 /**


### PR DESCRIPTION
When using superagent in a web worker with browserify and [webworkify](https://github.com/substack/webworkify), `this` points to the current module context rather than the global scope. Using `self` to access the global scope fixes this for me.
