### PR TITLE
Invoke end callback with all arguments if arity is not 1.

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -811,7 +811,7 @@ Request.prototype.send = function(data){
 Request.prototype.callback = function(err, res){
   var fn = this._callback;
   this.clearTimeout();
-  if (2 == fn.length) return fn(err, res);
+  if (1 !== fn.length) return fn(err, res);
   if (err) return this.emit('error', err);
   fn(res);
 };


### PR DESCRIPTION
You will probably have to reject this pull request as it involves breaking changes in superagent.

But you might want to consider returning the error as well in the end callback when its arity is not 1.
This could allow superagent to be plugged more easily with other libs.
Libs such as [vows](https://github.com/flatiron/vows/blob/master/lib/vows/context.js#L11) which gives us a callback without parameters and use the `arguments`.
So for instance we could write in vows:

```
topic: function() {
    request.get('/hello').end(this.callback);
},
'without error': function(err, res) {
    assert.equal(err, null);
}
```
