### PR TITLE
Fire 'response' events when run in the browser.

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -463,6 +463,10 @@ function Request(method, url) {
       err.original = e;
     }
 
+    if (res) {
+      self.emit('response', res);
+    }
+
     self.callback(err, res);
   });
 }

--- a/test/node/basic.js
+++ b/test/node/basic.js
@@ -420,6 +420,17 @@ describe('request', function(){
       });
       req.end();
     })
+
+    it('should emit response', function(done){
+      request
+      .post('http://localhost:5000/echo')
+      .send({ name: 'tobi' })
+      .on('response', function(res){
+        res.text.should.equal('{"name":"tobi"}');
+        done();
+      })
+      .end();
+    })
   })
 
   describe('.buffer()', function(){

--- a/test/test.request.js
+++ b/test/test.request.js
@@ -548,3 +548,23 @@ test('basic auth', function(next){
     next();
   });
 });
+
+test('request event', function(next){
+  request
+  .get('/foo')
+  .on('request', function(req){
+    assert('/foo' == req.url);
+    next();
+  })
+  .end();
+});
+
+test('response event', function(next){
+  request
+  .get('/foo')
+  .on('response', function(res){
+    assert('bar' == res.body.foo);
+    next();
+  })
+  .end();
+});


### PR DESCRIPTION
This allows module and plugin authors to build upon `superagent` in less-obtrusive ways. For example, this event facilitates logging the response without changing the callback associated with the request.
