### PR TITLE
Add error code for timeouts

### DIFF
--- a/lib/node/index.js
+++ b/lib/node/index.js
@@ -784,6 +784,7 @@ Request.prototype.end = function(fn){
     this._timer = setTimeout(function(){
       var err = new Error('timeout of ' + timeout + 'ms exceeded');
       err.timeout = timeout;
+      err.code = 'ECONNABORTED';
       self.abort();
       self.callback(err);
     }, timeout);

--- a/test/node/timeout.js
+++ b/test/node/timeout.js
@@ -22,6 +22,7 @@ describe('.timeout(ms)', function(){
       .end(function(err, res){
         assert(err, 'expected an error');
         assert('number' == typeof err.timeout, 'expected an error with .timeout');
+        assert('ECONNABORTED' == err.code, 'expected abort error code')
         done();
       });
     })


### PR DESCRIPTION
I don't like relying on `err.timeout` as an error code of some sort, so figured I'd tack on an error code for timeouts. Which error code is debatable and I'm open to changing... I saw that [request/request](https://github.com/request/request/blob/master/request.js#L920) uses `ETIMEDOUT` but I kinda felt like that should be more representative of connection timeouts. Meh?

CC: @defunctzombie 
