### PR TITLE
Fixed optional filename parameter and updated documentation

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -703,7 +703,7 @@ Request.prototype.field = function(name, val){
  *
  * ``` js
  * request.post('/upload')
- *   .attach(new Blob(['<a id="a"><b id="b">hey!</b></a>'], { type: "text/html"}))
+ *   .attach('myfield', new Blob(['<a id="a"><b id="b">hey!</b></a>'], 'sample.html'))
  *   .end(callback);
  * ```
  *

--- a/lib/node/index.js
+++ b/lib/node/index.js
@@ -171,7 +171,7 @@ Request.prototype.field = function(name, val){
  *
  * ``` js
  * request.post('http://localhost/upload')
- *   .attach(new Buffer('<b>Hello world</b>'), 'hello.html')
+ *   .attach('myfield', new Buffer('<b>Hello world</b>'), 'hello.html')
  *   .end(callback);
  * ```
  *
@@ -193,7 +193,7 @@ Request.prototype.field = function(name, val){
 Request.prototype.attach = function(field, file, filename){
   if (!this._formData) this._formData = new FormData();
   if ('string' == typeof file) {
-    filename = file;
+    filename = filename || file; //If no filename is given derive from the filename
     debug('creating `fs.ReadStream` instance for file: %s', filename);
     file = fs.createReadStream(filename);
   }


### PR DESCRIPTION
The documentation indicates that a different filename could be provided despite what the logical file name is.

But this was not working as always the logical filename was used.
