### PR TITLE
Fix call to form-data, to allow the setting of filenames in the attachment

### DIFF
--- a/lib/node/index.js
+++ b/lib/node/index.js
@@ -197,7 +197,7 @@ Request.prototype.attach = function(field, file, filename){
     debug('creating `fs.ReadStream` instance for file: %s', filename);
     file = fs.createReadStream(filename);
   }
-  this._formData.append(field, file, filename);
+  this._formData.append(field, file, { filename: filename });
   return this;
 };
 


### PR DESCRIPTION
If you check https://github.com/felixge/node-form-data/blob/master/lib/form_data.js#L151

form-data append expects the third parameter to be an `options` object which _may_ have a `filename` property .

This is a blocking bug for us, because one API we are consuming needs filenames to be not null.
