### PR TITLE
Wrap try-catch around xhr.status access to fix IE9 JS error c00c023f

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -883,7 +883,13 @@ Request.prototype.end = function(fn){
   // state change
   xhr.onreadystatechange = function(){
     if (4 != xhr.readyState) return;
-    if (0 == xhr.status) {
+
+    // In IE9, reads to any property (e.g. status) off of an aborted XHR will
+    // result in the error "Could not complete the operation due to error c00c023f"
+    var status;
+    try { status = xhr.status } catch(e) { status = 0; }
+
+    if (0 == status) {
       if (self.aborted) return self.timeoutError();
       return self.crossDomainError();
     }


### PR DESCRIPTION
In IE9, if the following steps occur:
1. Create a XMLHttpRequest object
2. Assign an onreadystatechanged event handler
3. Execute a request
4. Abort the request before the response has been handled

Then:
Any attempt to read any properties off the XMLHttpRequest will cause the error:
"Could not complete the operation due to error c00c023f"

Solution:
Catch the error and assume the status is 0.

See:
http://stackoverflow.com/questions/7287706/ie-9-javascript-error-c00c023f
http://www.enkeladress.com/article/internetexplorer9jscripterror
