### PR TITLE
Pass options object along with request.attach.

### DIFF
--- a/lib/node/index.js
+++ b/lib/node/index.js
@@ -167,11 +167,11 @@ Request.prototype.field = function(name, val){
 
 /**
  * Queue the given `file` as an attachment to the specified `field`,
- * with optional `filename`.
+ * with optional `options`.
  *
  * ``` js
  * request.post('http://localhost/upload')
- *   .attach(new Buffer('<b>Hello world</b>'), 'hello.html')
+ *   .attach('file', new Buffer('<b>Hello world</b>'), 'hello.html')
  *   .end(callback);
  * ```
  *
@@ -183,21 +183,26 @@ Request.prototype.field = function(name, val){
  *   .end(callback);
  * ```
  *
+ * Available options:
+ * - `filename` - A custom filename for the attached file.
+ * - `contentType` - A custom mime-type for the attached file.
+ * - `knownLength` - A custom length (in bytes) for the attached file.
+ *
  * @param {String} field
  * @param {String|fs.ReadStream|Buffer} file
- * @param {String} filename
+ * @param {Object} options
  * @return {Request} for chaining
  * @api public
  */
 
-Request.prototype.attach = function(field, file, filename){
+Request.prototype.attach = function(field, file, options){
   if (!this._formData) this._formData = new FormData();
   if ('string' == typeof file) {
-    filename = file;
-    debug('creating `fs.ReadStream` instance for file: %s', filename);
-    file = fs.createReadStream(filename);
+    options = { filename: file };
+    debug('creating `fs.ReadStream` instance for file: %s', file);
+    file = fs.createReadStream(file);
   }
-  this._formData.append(field, file, filename);
+  this._formData.append(field, file, options);
   return this;
 };
 


### PR DESCRIPTION
While form-data expects an object, .attach was previously trying to pass the string filename along as-is. Now, the object is preserved.

This addresses #403.

RFC: @defunctzombie 
