### PR TITLE
Do not set Content-Type for host objects

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -798,7 +798,7 @@ Request.prototype.send = function(data){
     this._data = data;
   }
 
-  if (!obj) return this;
+  if (!obj || isHost(data)) return this;
   if (!type) this.type('json');
   return this;
 };

--- a/test/client/request.js
+++ b/test/client/request.js
@@ -350,6 +350,24 @@ it('POST multiple .send() strings', function(next){
   })
 });
 
+it('POST native FormData', function(next){
+  if (!window.FormData) {
+    // Skip test if FormData is not supported by browser
+    return next();
+  }
+
+  var data = new FormData();
+  data.append('foo', 'bar');
+
+  request
+    .post('/echo')
+    .send(data)
+    .end(function(err, res){
+      assert('multipart/form-data' == res.type);
+      next();
+    });
+});
+
 it('GET .type', function(next){
   request
   .get('/pets')


### PR DESCRIPTION
When passing a host object such as a File or FormData to `send()`, it identifies the data as being an object. Since no `Content-Type`-header is set (and should not be set, if we want the browser to automatically construct a `multipart/form-data`-request with boundaries and all), superagent currently sets the `Content-Type` to JSON. This overrides the browsers constructed boundary, and the server is unable to parse the request.

This PR adds an `isHost()` check to prevent setting the wrong content type, and also adds a test to ensure we don't encounter any regressions. 

Please let me know if you want anything changed (method of doing this, coding style etc).