### PR TITLE
Small improvement to work without CORS

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -860,6 +860,17 @@ Request.prototype.withCredentials = function(){
 };
 
 /**
+ * Disable 'progress' event that triggers CORS.
+ *
+ * @api public
+ */
+
+Request.prototype.withoutProgress = function(){
+  this._withoutProgress = true;
+  return this;
+};
+
+/**
  * Initiate request, invoking callback `fn(res)`
  * with an instanceof `Response`.
  *
@@ -895,17 +906,19 @@ Request.prototype.end = function(fn){
   };
 
   // progress
-  try {
-    if (xhr.upload) {
-      xhr.upload.onprogress = function(e){
-        e.percent = e.loaded / e.total * 100;
-        self.emit('progress', e);
-      };
+  if (this._withoutProgress !== true) {
+    try {
+      if (xhr.upload) {
+        xhr.upload.onprogress = function(e){
+          e.percent = e.loaded / e.total * 100;
+          self.emit('progress', e);
+        };
+      }
+    } catch(e) {
+      // Accessing xhr.upload fails in IE from a web worker, so just pretend it doesn't exist.
+      // Reported here:
+      // https://connect.microsoft.com/IE/feedback/details/837245/xmlhttprequest-upload-throws-invalid-argument-when-used-from-web-worker-context
     }
-  } catch(e) {
-    // Accessing xhr.upload fails in IE from a web worker, so just pretend it doesn't exist.
-    // Reported here:
-    // https://connect.microsoft.com/IE/feedback/details/837245/xmlhttprequest-upload-throws-invalid-argument-when-used-from-web-worker-context
   }
 
   // timeout

--- a/test/client/xdomain.js
+++ b/test/client/xdomain.js
@@ -16,6 +16,16 @@ describe('xdomain', function(){
     })
   })
 
+  if('should allow to disable progress', function(next){
+    request
+    .get('http://ip.jsontest.com/')
+    .withoutProgress()
+    .end(function(err, res){
+      assert(200 == res.status);
+      next();
+    });
+  });
+
   it('should handle x-domain failure', function(next){
     request
     .get('//tunne127.com')


### PR DESCRIPTION
Hello.

Thanks for amazing lib!
I found a strange thing in CORS specification: if you add 'upload' handler, browser will trigger CORS (and send OPTIONS preflight) even for "simple" GET and POST requests (http://goo.gl/ojJq85, http://goo.gl/XB42c0). Since sometimes it's required to a
void CORS in order to minimize latency, I created a simple patch that adds 'withoutProgress()' builder method.
What do you think?