### PR TITLE
Don't index array keys in querystring

### DIFF
--- a/lib/node/index.js
+++ b/lib/node/index.js
@@ -772,7 +772,7 @@ Request.prototype.end = function(fn){
 
   // querystring
   try {
-    var querystring = qs.stringify(this.qs);
+    var querystring = qs.stringify(this.qs, { indices: false });
     req.path += querystring.length
       ? (~req.path.indexOf('?') ? '&' : '?') + querystring
       : '';

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "url": "git://github.com/visionmedia/superagent.git"
   },
   "dependencies": {
-    "qs": "1.2.0",
+    "qs": "2.3.3",
     "formidable": "1.0.14",
     "mime": "1.2.11",
     "component-emitter": "1.1.2",


### PR DESCRIPTION
Now it'll behave the same way that the querystring does by default and
should work with more parsers.

