### PR TITLE
Avoid preflight OPTIONS request caused by binding xhr.upload.onprogress even when doing simple CORS requests

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -907,7 +907,7 @@ Request.prototype.end = function(fn){
   };
 
   // progress
-  if (isCrossOrigin()) {
+  if (isCrossOrigin(xhr)) {
       // do not bind xhr.upload.onprogress
   } else {
     try {

--- a/lib/client.js
+++ b/lib/client.js
@@ -61,6 +61,18 @@ function getXHR() {
 }
 
 /**
+ * Determine if XHR is cross origin request or not
+ */
+
+function isCrossOrigin(xhr) {
+  var a = document.createElement('a');
+  a.href = location.href;
+  var b = document.createElement('a');
+  b.href = xhr.url;
+  return (a.protocol !== b.protocol) || (a.host !== b.host)
+}
+
+/**
  * Removes leading and trailing whitespace, added to support IE.
  *
  * @param {String} s
@@ -895,17 +907,24 @@ Request.prototype.end = function(fn){
   };
 
   // progress
-  try {
-    if (xhr.upload) {
-      xhr.upload.onprogress = function(e){
-        e.percent = e.loaded / e.total * 100;
-        self.emit('progress', e);
-      };
+  if (isCrossOrigin() || (xhr.addEventListener)) {
+    xhr.addEventListener("progress", function(e){
+      e.percent = e.loaded / e.total * 100;
+      self.emit('progress', e);
+    });
+  } else {
+    try {
+      if (xhr.upload) {
+        xhr.upload.onprogress = function(e){
+          e.percent = e.loaded / e.total * 100;
+          self.emit('progress', e);
+        };
+      }
+    } catch (e) {
+      // Accessing xhr.upload fails in IE from a web worker, so just pretend it doesn't exist.
+      // Reported here:
+      // https://connect.microsoft.com/IE/feedback/details/837245/xmlhttprequest-upload-throws-invalid-argument-when-used-from-web-worker-context
     }
-  } catch(e) {
-    // Accessing xhr.upload fails in IE from a web worker, so just pretend it doesn't exist.
-    // Reported here:
-    // https://connect.microsoft.com/IE/feedback/details/837245/xmlhttprequest-upload-throws-invalid-argument-when-used-from-web-worker-context
   }
 
   // timeout

--- a/lib/client.js
+++ b/lib/client.js
@@ -64,12 +64,12 @@ function getXHR() {
  * Determine if XHR is cross origin request or not
  */
 
-function isCrossOrigin(xhr) {
+function isCrossOrigin(url) {
   var a = document.createElement('a');
   a.href = location.href;
   var b = document.createElement('a');
-  b.href = xhr.url;
-  return (a.protocol !== b.protocol) || (a.host !== b.host)
+  b.href = url;
+  return (a.protocol !== b.protocol) || (a.host !== b.host);
 }
 
 /**
@@ -907,7 +907,7 @@ Request.prototype.end = function(fn){
   };
 
   // progress
-  if (isCrossOrigin(xhr)) {
+  if (isCrossOrigin(this.url)) {
       // do not bind xhr.upload.onprogress
   } else {
     try {

--- a/lib/client.js
+++ b/lib/client.js
@@ -907,11 +907,8 @@ Request.prototype.end = function(fn){
   };
 
   // progress
-  if (isCrossOrigin() || (xhr.addEventListener)) {
-    xhr.addEventListener("progress", function(e){
-      e.percent = e.loaded / e.total * 100;
-      self.emit('progress', e);
-    });
+  if (isCrossOrigin()) {
+      // do not bind xhr.upload.onprogress
   } else {
     try {
       if (xhr.upload) {


### PR DESCRIPTION
Fixes an issue where simple XHR requests which should not require a preflight, were still requiring a preflight due to how superagent binds xhr.upload.onprogress 

I believe this is the underlying cause of the problem in [issue 522](https://github.com/visionmedia/superagent/issues/522) 
I however ran into this issue when sending a post request to a webservice (that I do not control) which does not implement a handler for the preflight OPTIONS request. So the OPTIONS preflights always fail. The request I'm sending meets all the criteria for not needing a preflight, it is a simple POST request with no special headers and the content-type is application/x-www-form-urlencoded. Yet the way superagent binds xhr.upload.onprogress causes chrome to send a preflight. 

from the chrome source code:
"The presence of upload event listeners forces us to use preflighting because POSTing to an URL that does not permit cross origin requests should look exactly like POSTing to an URL that does not respond at all."

So the preflight can be avoided in the latest versions of chrome as long as xhr.upload.onprogress is not bound if we are doing a crossOrigin request.