### PR TITLE
Fixes a locally failing server test

### DIFF
--- a/test/node/redirects.js
+++ b/test/node/redirects.js
@@ -31,9 +31,9 @@ app.get('/movies/random', function(req, res){
 });
 
 app.get('/movie/4', function(req, res){
-  setTimeout(function(err, res){
+  setTimeout(function(){
     res.send('not-so-random movie');
-  }, 1000, res);
+  }, 1000);
 });
 
 app.post('/movie', function(req, res){


### PR DESCRIPTION
Previously `res` was not defined when `.send` was called and this caused the test to fail for me locally, although travis looks fine.

What was there previously didn't really make sense to me, but maybe I'm missing something?