### PR TITLE
Add IE11 back to tested browsers

### DIFF
--- a/.zuul.yml
+++ b/.zuul.yml
@@ -12,4 +12,4 @@ browsers:
   - name: android
     version: latest
   - name: ie
-    version: 9..10
+    version: 9..latest

--- a/test/client/request.js
+++ b/test/client/request.js
@@ -118,8 +118,10 @@ it('get()', function(next){
   });
 });
 
-// This test results in a weird Jetty error on IE9 saying PATCH is not a supported method. Looks like something's up with SauceLabs
-if (window.atob) { // Drop IE9 and lower.
+// This test results in a weird Jetty error on IE9 and IE11 saying PATCH is not a supported method. Looks like something's up with SauceLabs
+var isIE11 = !!navigator.userAgent.match(/Trident.*rv[ :]*11\./);
+var isIE9OrOlder = !window.atob;
+if (!isIE9OrOlder && !isIE11) { // Don't run on IE9 or older, or IE11
   it('patch()', function(next){
     request.patch('/user/12').end(function(err, res){
       assert('updated' == res.text);

--- a/test/client/xdomain.js
+++ b/test/client/xdomain.js
@@ -16,8 +16,10 @@ describe('xdomain', function(){
     });
   });
 
-  // xdomain not supproted in old IE
-  if (window.atob) { // Drop IE9 and lower
+  // xdomain not supported in old IE and IE11 gives weird Jetty errors (looks like a SauceLabs issue)
+  var isIE11 = !!navigator.userAgent.match(/Trident.*rv[ :]*11\./);
+  var isIE9OrOlder = !window.atob;
+  if (!isIE9OrOlder && !isIE11) { // Don't run on IE9 or older, or IE11
     it('should handle x-domain failure', function(next){
       request
       .get('//tunne127.com')


### PR DESCRIPTION
Blacklisted a couple tests have some weird errors, presumably from SauceLabs as they result in Jetty error messages.

`make test-browser` all green.