### PR TITLE
Make method function shorthand consistent

### DIFF
--- a/lib/node/index.js
+++ b/lib/node/index.js
@@ -1052,8 +1052,10 @@ function request(method, url) {
 methods.forEach(function(method){
   var name = 'delete' == method ? 'del' : method;
   method = method.toUpperCase();
-  request[name] = function(url, fn){
+  request[name] = function(url, data, fn){
     var req = request(method, url);
+    if ('function' == typeof data) fn = data, data = null;
+    if (data) req.send(data);
     fn && req.end(fn);
     return req;
   };

--- a/test/node/basic.js
+++ b/test/node/basic.js
@@ -43,6 +43,33 @@ describe('[node] request', function(){
     })
   })
 
+  describe('should allow the send shorthand', function() {
+    it('with callback in the method call', function(done) {
+      request
+      .get('http://localhost:5000/login', function(err, res) {
+          assert(res.status == 200);
+          done();
+      });
+    })
+
+    it('with data in the method call', function(done) {
+      request
+      .post('http://localhost:5000/echo', { foo: 'bar' })
+      .end(function(err, res) {
+        assert('{"foo":"bar"}' == res.text);
+        done();
+      });
+    })
+
+    it('with callback and data in the method call', function(done) {
+      request
+      .post('http://localhost:5000/echo', { foo: 'bar' }, function(err, res) {
+        assert('{"foo":"bar"}' == res.text);
+        done();
+      });
+    })
+  })
+
   describe('res.toJSON()', function(){
     it('should describe the response', function(done){
       request


### PR DESCRIPTION
Implemented the `request.post(url, data, fn)`-type shorthand for all method functions.

Unsure if this is the best place to add the new tests.

Fixes https://github.com/visionmedia/superagent/issues/172

cc @defunctzombie 