### PR TITLE
Add xhr upload listener only if present on the request

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -897,7 +897,7 @@ Request.prototype.end = function(fn){
 
   // progress
   try {
-    if (xhr.upload) {
+    if (xhr.upload && this.hasListeners('progress')) {
       xhr.upload.onprogress = function(e){
         e.percent = e.loaded / e.total * 100;
         self.emit('progress', e);

--- a/test/client/request.js
+++ b/test/client/request.js
@@ -593,3 +593,25 @@ it('response event', function(next){
   })
   .end();
 });
+
+it('progress event listener on xhr object registered when some on the request', function(){
+  var req = request
+  .get('/foo')
+  .on('progress', function(data) {
+  })
+  .end();
+
+  if (req.xhr.upload) { // Only run assertion on capable browsers
+    assert(null !== req.xhr.upload.onprogress);
+  }
+});
+
+it('no progress event listener on xhr object when none registered on request', function(){
+  var req = request
+  .get('/foo')
+  .end();
+
+  if (req.xhr.upload) { // Only run assertion on capable browsers
+    assert(null === req.xhr.upload.onprogress);
+  }
+});


### PR DESCRIPTION
This way we can avoid awkward OPTIONS requests.

Should deal with https://github.com/visionmedia/superagent/issues/442

cc @defunctzombie 
