### PR TITLE
Set the default response mime type to text/plain as specified by RFC1341.

### DIFF
--- a/lib/node/index.js
+++ b/lib/node/index.js
@@ -835,7 +835,7 @@ Request.prototype.end = function(fn){
   req.on('response', function(res){
     debug('%s %s -> %s', self.method, self.url, res.statusCode);
     var max = self._maxRedirects;
-    var mime = utils.type(res.headers['content-type'] || '');
+    var mime = utils.type(res.headers['content-type'] || '') || 'text/plain';
     var len = res.headers['content-length'];
     var type = mime.split('/');
     var subtype = type[1];

--- a/test/node/json.js
+++ b/test/node/json.js
@@ -160,7 +160,7 @@ describe('res.body', function(){
       .get('http://localhost:3005/no-content')
       .end(function(err, res){
         assert(err === null);
-        assert(res.text === undefined);
+        assert(res.text === '');
         assert(Object.keys(res.body).length === 0);
         done();
       });


### PR DESCRIPTION
If no Content-Type is specified by the server, superagent does not set the MIME type and the response does not get parsed at all. Neither `response.body` nor `response.text` are set.

[RFC1341](http://www.w3.org/Protocols/rfc1341/4_Content-Type.html) (or simply [Wikipedia](http://en.wikipedia.org/wiki/MIME)) documents that the default MIME type should be `text/plain` (superagent defaults to an empty string).

Using this patch, superagent can now fill the response with the default text parser even if the server does not set the Content-Type.

I had to fix the "no-content" test, since `res.text` is now filled with the empty string when no Content Type is specified. This sounds ok to me and to the RFC but **may be considered an API breakage**. Please review.

Also, 2 other tests are failing, but they were failing with or without my patch.
