### PR TITLE
Update mime package to support browserify

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "dependencies": {
     "qs": "2.3.3",
     "formidable": "1.0.14",
-    "mime": "1.2.11",
+    "mime": "~1.3.4",
     "component-emitter": "1.1.2",
     "methods": "1.0.1",
     "cookiejar": "2.0.1",


### PR DESCRIPTION
We can not use `superagent` with `browserify` without additional transform (`brfs`) because of `readFileSync`.

Latest version of `mime` uses `mime-db` and compiles well via `browserify`.