### PR TITLE
Add support for use within Web Workers

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -10,7 +10,7 @@ var reduce = require('reduce');
  */
 
 var root = 'undefined' == typeof window
-  ? this
+  ? (this || self)
   : window;
 
 /**


### PR DESCRIPTION
This pull request assumes the context of a Web Worker when both `window` and `this` are undefined. The global scope within a dedicated web worker is `self`, so we will just need set root to `self` in order for `root.XMLHttpRequest` to be found.

https://developer.mozilla.org/en-US/docs/Web/API/DedicatedWorkerGlobalScope