### PR TITLE
Fix responeType checks without xhr2 and ie9 tests

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -294,8 +294,8 @@ function Response(req, options) {
   options = options || {};
   this.req = req;
   this.xhr = this.req.xhr;
-  // responseText is accessible only if responseType is '' or 'text'
-  this.text = (this.req.method !='HEAD' && (this.xhr.responseType === '' || this.xhr.responseType === 'text'))
+  // responseText is accessible only if responseType is '' or 'text' and on older browsers
+  this.text = ((this.req.method !='HEAD' && (this.xhr.responseType === '' || this.xhr.responseType === 'text')) || typeof this.xhr.responseType === 'undefined')
      ? this.xhr.responseText
      : null;
   this.statusText = this.req.xhr.statusText;

--- a/test/client/request.js
+++ b/test/client/request.js
@@ -628,19 +628,22 @@ it('no progress event listener on xhr object when none registered on request', f
   }
 });
 
-it('xhr2 download file', function(next) {
-  request.parse['application/vnd.superagent'] = function (obj) {
-    return obj;
-  };
+// Don't run on browsers without xhr2 support
+if ('FormData' in window) {
+  it('xhr2 download file', function(next) {
+    request.parse['application/vnd.superagent'] = function (obj) {
+      return obj;
+    };
 
-  request
-  .get('/arraybuffer')
-  .on('request', function () {
-    this.xhr.responseType = 'arraybuffer';
-  })
-  .on('response', function(res) {
-    assert(res.body instanceof ArrayBuffer);
-    next();
-  })
-  .end();
-});
+    request
+    .get('/arraybuffer')
+    .on('request', function () {
+      this.xhr.responseType = 'arraybuffer';
+    })
+    .on('response', function(res) {
+      assert(res.body instanceof ArrayBuffer);
+      next();
+    })
+    .end();
+  });
+}


### PR DESCRIPTION
We should never be looking at `xhr.response` on IE9 and other non-xhr2 browsers.

Also only running the xhr2 file download test where xhr2 is available (effectively excluding the test on IE9)

cc @defunctzombie 