### PR TITLE
Fix: end callback called before saving cookies

### DIFF
--- a/lib/node/index.js
+++ b/lib/node/index.js
@@ -132,9 +132,6 @@ function Request(method, url) {
   this.qsRaw = [];
   this._redirectList = [];
   this.on('end', this.clearTimeout.bind(this));
-  this.on('response', function(res){
-    self.callback(null, res);
-  });
 }
 
 /**
@@ -855,6 +852,7 @@ Request.prototype.end = function(fn){
       self.response = response;
       response.redirects = self._redirectList;
       self.emit('response', response);
+      self.callback(null, response);
       self.emit('end');
       return;
     }
@@ -945,6 +943,7 @@ Request.prototype.end = function(fn){
       self.response = response;
       response.redirects = self._redirectList;
       self.emit('response', response);
+      self.callback(null, response);
       if (multipart) return // allow multipart to handle end event
       res.on('end', function(){
         debug('end %s %s', self.method, self.url);
@@ -962,6 +961,7 @@ Request.prototype.end = function(fn){
       self.response = response;
       response.redirects = self._redirectList;
       self.emit('response', response);
+      self.callback(null, response);
       self.emit('end');
     });
   });

--- a/test/node/agency.js
+++ b/test/node/agency.js
@@ -18,6 +18,15 @@ app.post('/signin', function(req, res) {
   res.redirect('/dashboard');
 });
 
+app.post('/setcookie', function(req, res) {
+  res.cookie('cookie', 'jar');
+  res.sendStatus(200);
+});
+
+app.get('/getcookie', function(req, res) {
+  res.status(200).send(req.cookies.cookie);
+});
+
 app.get('/dashboard', function(req, res) {
   if (req.session.user) return res.status(200).send('dashboard');
   res.status(401).send('dashboard');
@@ -49,6 +58,7 @@ describe('request', function() {
     var agent1 = request.agent();
     var agent2 = request.agent();
     var agent3 = request.agent();
+    var agent4 = request.agent();
 
     it('should gain a session on POST', function(done) {
       agent3
@@ -92,6 +102,21 @@ describe('request', function() {
           should.not.exist(err);
           res.should.have.status(200);
           done();
+        });
+    });
+
+    it('should have the cookie set in the end callback', function(done) {
+      agent4
+        .post('http://localhost:4000/setcookie')
+        .end(function(err, res) {
+          agent4
+            .get('http://localhost:4000/getcookie')
+            .end(function(err, res) {
+              should.not.exist(err);
+              res.should.have.status(200);
+              assert(res.text === 'jar');
+              done();
+            });
         });
     });
 


### PR DESCRIPTION
Now calling the end callback manually so that the end callback handler doesn't superseed cookie saving logic in `.on('response')`.