### PR TITLE
Querystring serialize bug

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -4,6 +4,7 @@
 
 var Emitter = require('emitter');
 var reduce = require('reduce');
+var qs = require('qs');
 
 /**
  * Root reference for iframes.
@@ -93,15 +94,7 @@ function isObject(obj) {
  */
 
 function serialize(obj) {
-  if (!isObject(obj)) return obj;
-  var pairs = [];
-  for (var key in obj) {
-    if (null != obj[key]) {
-      pairs.push(encodeURIComponent(key)
-        + '=' + encodeURIComponent(obj[key]));
-    }
-  }
-  return pairs.join('&');
+  return (isObject(obj)) ? qs.stringify(obj) : obj;
 }
 
 /**
@@ -119,18 +112,7 @@ function serialize(obj) {
   */
 
 function parseString(str) {
-  var obj = {};
-  var pairs = str.split('&');
-  var parts;
-  var pair;
-
-  for (var i = 0, len = pairs.length; i < len; ++i) {
-    pair = pairs[i];
-    parts = pair.split('=');
-    obj[decodeURIComponent(parts[0])] = decodeURIComponent(parts[1]);
-  }
-
-  return obj;
+  return qs.parse(str);
 }
 
 /**

--- a/test/client/serialize.js
+++ b/test/client/serialize.js
@@ -23,13 +23,15 @@ describe('request.serializeObject()', function(){
     serialize('test', 'test');
     serialize('foo=bar', 'foo=bar');
     serialize({ foo: 'bar' }, 'foo=bar');
-    serialize({ foo: null }, '');
+    serialize({ foo: null }, 'foo=');
     serialize({ foo: 'null' }, 'foo=null');
     serialize({ foo: undefined }, '');
     serialize({ foo: 'undefined' }, 'foo=undefined');
     serialize({ name: 'tj', age: 24 }, 'name=tj&age=24');
-      serialize({ name: '&tj&' }, 'name=%26tj%26');
-      serialize({ '&name&': 'tj' }, '%26name%26=tj');
+    serialize({ name: '&tj&' }, 'name=%26tj%26');
+    serialize({ '&name&': 'tj' }, '%26name%26=tj');
+    serialize({foo:{bar: {baz: 100}}}, "foo%5Bbar%5D%5Bbaz%5D=100");
+    serialize({foo:{bar: 1, baz: 2}}, "foo%5Bbar%5D=1&foo%5Bbaz%5D=2");
   });
 });
 
@@ -37,8 +39,10 @@ describe('request.parseString()', function(){
   it('should parse', function() {
     parse('name=tj', { name: 'tj' });
     parse('name=Manny&species=cat', { name: 'Manny', species: 'cat' });
-    parse('redirect=/&ok', { redirect: '/', ok: 'undefined' });
+    parse('redirect=/&ok', { redirect: '/', ok: '' });
     parse('%26name=tj', { '&name': 'tj' });
     parse('name=tj%26', { name: 'tj&' });
+    parse("foo%5Bbar%5D%5Bbaz%5D=100", {foo:{bar: {baz: 100}}});
+    parse("foo%5Bbar%5D=1&foo%5Bbaz%5D=2", {foo:{bar: 1, baz: 2}});
   });
 });


### PR DESCRIPTION
incorrect serialization of nested objects

```js
{foo: {bar: {baz: 100}}}
```

to 

```
foo=[object Object]
```

- fixed  with qs module
- added some tests for nested objects
