### PR TITLE
Superagent 2.0.0 - superagent with less suck (revert 1.0.0 API changes in end)

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,3 +1,7 @@
+2.0.0 / 2015-03-21
+==================
+* reverted API change from 1.0.0. See "All non-200 responses are treated as errors now"
+
 # 1.1.0 (2015-03-13)
 
  * Fix responeType checks without xhr2 and ie9 tests (rase-)

--- a/component.json
+++ b/component.json
@@ -2,7 +2,7 @@
   "name": "superagent",
   "repo": "visionmedia/superagent",
   "description": "awesome http requests",
-  "version": "1.1.0",
+  "version": "2.0.0",
   "keywords": [
     "http",
     "ajax",

--- a/lib/client.js
+++ b/lib/client.js
@@ -472,16 +472,7 @@ function Request(method, url) {
       return self.callback(err, res);
     }
 
-    if (res.status >= 200 && res.status < 300) {
-      return self.callback(err, res);
-    }
-
-    var new_err = new Error(res.statusText || 'Unsuccessful HTTP response');
-    new_err.original = err;
-    new_err.response = res;
-    new_err.status = res.status;
-
-    self.callback(err || new_err, res);
+    self.callback(err, res);
   });
 }
 

--- a/lib/node/index.js
+++ b/lib/node/index.js
@@ -774,20 +774,7 @@ Request.prototype.callback = function(err, res){
     return fn(err, res);
   }
 
-  if (res && res.status >= 200 && res.status < 300) {
-    return fn(err, res);
-  }
-
-  var msg = 'Unsuccessful HTTP response';
-  if (res) {
-    msg = http.STATUS_CODES[res.status] || msg;
-  }
-  var new_err = new Error(msg);
-  new_err.original = err;
-  new_err.response = res;
-  new_err.status = (res) ? res.status : undefined;
-
-  fn(err || new_err, res);
+  fn(err, res);
 };
 
 /**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "superagent",
-  "version": "1.1.0",
+  "version": "2.0.0",
   "description": "elegant & feature rich browser / node HTTP with a fluent API",
   "scripts": {
     "test": "make test"

--- a/test/basic.js
+++ b/test/basic.js
@@ -51,8 +51,7 @@ describe('request', function(){
           res.error.message.should.equal('cannot GET ' + uri + '/error (500)');
         }
         assert(res.error.status === 500);
-        assert(err, 'should have an error for 500');
-        assert.equal(err.message, 'Internal Server Error');
+        assert(!err, 'should not have an error if a response is successfully received and processed');
         done();
       });
     })

--- a/test/client/request.js
+++ b/test/client/request.js
@@ -30,7 +30,7 @@ it('request() simple HEAD', function(next){
 
 it('request() error object', function(next) {
   request('GET', '/error').end(function(err, res) {
-    assert(err);
+    assert(!err, 'should not have an error if a response is successfully received and processed');
     assert(res.error, 'response should be an error');
     assert(res.error.message == 'cannot GET /error (500)');
     assert(res.error.status == 500);
@@ -42,8 +42,7 @@ it('request() error object', function(next) {
 
 it('request() GET 5xx', function(next){
   request('GET', '/error').end(function(err, res){
-    assert(err);
-    assert(err.message == 'Internal Server Error');
+    assert(!err, 'should not have an error if a response is successfully received and processed');
     assert(!res.ok, 'response should not be ok');
     assert(res.error, 'response should be an error');
     assert(!res.clientError, 'response should not be a client error');
@@ -54,8 +53,7 @@ it('request() GET 5xx', function(next){
 
 it('request() GET 4xx', function(next){
   request('GET', '/notfound').end(function(err, res){
-    assert(err);
-    assert.equal(err.message, 'Not Found');
+    assert(!err, 'should not have an error if a response is successfully received and processed');
     assert(!res.ok, 'response should not be ok');
     assert(res.error, 'response should be an error');
     assert(res.clientError, 'response should be a client error');
@@ -66,7 +64,7 @@ it('request() GET 4xx', function(next){
 
 it('request() GET 404 Not Found', function(next){
   request('GET', '/notfound').end(function(err, res){
-    assert(err);
+    assert(!err, 'should not have an error if a response is successfully received and processed');
     assert(res.notFound, 'response should be .notFound');
     next();
   });
@@ -74,7 +72,7 @@ it('request() GET 404 Not Found', function(next){
 
 it('request() GET 400 Bad Request', function(next){
   request('GET', '/bad-request').end(function(err, res){
-    assert(err);
+    assert(!err, 'should not have an error if a response is successfully received and processed');
     assert(res.badRequest, 'response should be .badRequest');
     next();
   });
@@ -82,7 +80,7 @@ it('request() GET 400 Bad Request', function(next){
 
 it('request() GET 401 Bad Request', function(next){
   request('GET', '/unauthorized').end(function(err, res){
-    assert(err);
+    assert(!err, 'should not have an error if a response is successfully received and processed');
     assert(res.unauthorized, 'response should be .unauthorized');
     next();
   });
@@ -90,7 +88,7 @@ it('request() GET 401 Bad Request', function(next){
 
 it('request() GET 406 Not Acceptable', function(next){
   request('GET', '/not-acceptable').end(function(err, res){
-    assert(err);
+    assert(!err, 'should not have an error if a response is successfully received and processed');
     assert(res.notAcceptable, 'response should be .notAcceptable');
     next();
   });
@@ -105,7 +103,7 @@ it('request() GET 204 No Content', function(next){
 
 it('request() header parsing', function(next){
   request('GET', '/notfound').end(function(err, res){
-    assert(err);
+    assert(!err, 'should not have an error if a response is successfully received and processed');
     assert('text/html; charset=utf-8' == res.header['content-type']);
     assert('Express' == res.header['x-powered-by']);
     next();
@@ -114,7 +112,7 @@ it('request() header parsing', function(next){
 
 it('request() .status', function(next){
   request('GET', '/notfound').end(function(err, res){
-    assert(err);
+    assert(!err, 'should not have an error if a response is successfully received and processed');
     assert(404 == res.status, 'response .status');
     assert(4 == res.statusType, 'response .statusType');
     next();
@@ -123,7 +121,7 @@ it('request() .status', function(next){
 
 it('get()', function(next){
   request.get('/notfound').end(function(err, res){
-    assert(err);
+    assert(!err, 'should not have an error if a response is successfully received and processed');
     assert(404 == res.status, 'response .status');
     assert(4 == res.statusType, 'response .statusType');
     next();

--- a/test/node/agency.js
+++ b/test/node/agency.js
@@ -76,7 +76,7 @@ describe('request', function() {
       agent1
         .get('http://localhost:4000/dashboard')
         .end(function(err, res) {
-          should.exist(err);
+          should.not.exist(err);
           res.should.have.status(401);
           should.exist(res.headers['set-cookie']);
           done();
@@ -124,7 +124,7 @@ describe('request', function() {
       agent2
         .get('http://localhost:4000/dashboard')
         .end(function(err, res) {
-          should.exist(err);
+          should.not.exist(err);
           res.should.have.status(401);
           done();
         });
@@ -169,7 +169,7 @@ describe('request', function() {
         .get('http://localhost:4000/')
         .redirects(0)
         .end(function(err, res) {
-          should.exist(err);
+          should.not.exist(err);
           res.should.have.status(302);
           res.redirects.should.eql([]);
           res.header.location.should.equal('/dashboard');
@@ -192,7 +192,7 @@ describe('request', function() {
       agent1
         .get('http://localhost:4000/dashboard')
         .end(function(err, res) {
-          should.exist(err);
+          should.not.exist(err);
           res.should.have.status(401);
           should.not.exist(res.headers['set-cookie']);
           done();

--- a/test/node/flags.js
+++ b/test/node/flags.js
@@ -38,7 +38,7 @@ describe('flags', function(){
       request
       .get('http://localhost:3004/notfound')
       .end(function(err, res){
-        assert(err);
+        assert(!err, 'should not have an error if a response is successfully received and processed');
         assert(!res.ok, 'response should not be ok');
         assert(res.error, 'response should be an error');
         assert(res.clientError, 'response should be a client error');
@@ -53,7 +53,7 @@ describe('flags', function(){
       request
       .get('http://localhost:3004/error')
       .end(function(err, res){
-        assert(err);
+        assert(!err, 'should not have an error if a response is successfully received and processed');
         assert(!res.ok, 'response should not be ok');
         assert(!res.notFound, 'response should not be notFound');
         assert(res.error, 'response should be an error');
@@ -69,7 +69,7 @@ describe('flags', function(){
       request
       .get('http://localhost:3004/notfound')
       .end(function(err, res){
-        assert(err);
+        assert(!err, 'should not have an error if a response is successfully received and processed');
         assert(res.notFound, 'response should be .notFound');
         done();
       });
@@ -81,7 +81,7 @@ describe('flags', function(){
       request
       .get('http://localhost:3004/bad-request')
       .end(function(err, res){
-        assert(err);
+        assert(!err, 'should not have an error if a response is successfully received and processed');
         assert(res.badRequest, 'response should be .badRequest');
         done();
       });
@@ -93,7 +93,7 @@ describe('flags', function(){
       request
       .get('http://localhost:3004/unauthorized')
       .end(function(err, res){
-        assert(err);
+        assert(!err, 'should not have an error if a response is successfully received and processed');
         assert(res.unauthorized, 'response should be .unauthorized');
         done();
       });
@@ -105,7 +105,7 @@ describe('flags', function(){
       request
       .get('http://localhost:3004/not-acceptable')
       .end(function(err, res){
-        assert(err);
+        assert(!err, 'should not have an error if a response is successfully received and processed');
         assert(res.notAcceptable, 'response should be .notAcceptable');
         done();
       });
@@ -117,7 +117,7 @@ describe('flags', function(){
       request
       .get('http://localhost:3004/no-content')
       .end(function(err, res){
-        assert(!err);
+        assert(!err, 'should not have an error if a response is successfully received and processed');
         assert(res.noContent, 'response should be .noContent');
         done();
       });


### PR DESCRIPTION
Let's make the superagent community happy by doing the right thing and revert the API changes introduced in 1.0.0. 

The API changes in 1.0.0:

1) break Node callback conventions
2) are against the wisdom of the original superagent design
3) break so much code depending on superagent without a clear benefit that a majority of users of superagent agreeing with it (many do and many do not). The amount of time and effort to upgrade and test libraries and applications across the superagent userbase is enormous and non-trivial. 
4) could be implemented differently using the `success/error` pattern that would not break backwards compatibility

For people who prefer the old API and want to benefit from the latest version of superagent, I've [forked superagent to superagent-ls (for less suck)](https://github.com/kmalakoff/superagent-ls).

Fork: https://github.com/kmalakoff/superagent-ls
Released on npm: https://www.npmjs.com/package/superagent-ls and component.io.

Please star and use [the superagent-ls repo]( https://github.com/kmalakoff/superagent-ls ) to show your support for reverting the 1.x API  :smirk: 

The ship has not sailed and there's a life raft in the short term!
