### PR TITLE
Test case for request.get(...).send(...) querystring

### DIFF
--- a/test/client/request.js
+++ b/test/client/request.js
@@ -293,7 +293,16 @@ it('GET request .send querystring', function(next){
   .get('/echo-querystring')
   .send({foo: "bar"})
   .end(function(err, res){
-    console.log(res.text);
+    assert('{"foo":"bar"}' == res.text);
+    next();
+  });
+})
+
+it('GET request .query querystring', function(next){
+  request
+  .get('/echo-querystring')
+  .query({foo: "bar"})
+  .end(function(err, res){
     assert('{"foo":"bar"}' == res.text);
     next();
   });

--- a/test/client/request.js
+++ b/test/client/request.js
@@ -288,6 +288,17 @@ it('request .send()', function(next){
   });
 });
 
+it('GET request .send querystring', function(next){
+  request
+  .get('/echo-querystring')
+  .send({foo: "bar"})
+  .end(function(err, res){
+    console.log(res.text);
+    assert('{"foo":"bar"}' == res.text);
+    next();
+  });
+})
+
 it('request .set()', function(next){
   request
   .get('/echo-header/content-type')

--- a/test/support/server.js
+++ b/test/support/server.js
@@ -124,6 +124,10 @@ app.get('/querystring', function(req, res){
   res.send(req.query);
 });
 
+app.get('/echo-querystring', function(req, res) {
+  res.send(req.query);
+});
+
 app.get('/echo-header/:field', function(req, res){
   res.send(req.headers[req.params.field]);
 });


### PR DESCRIPTION
Test case for issue #606; test currently fails for ``.send``, but passes for ``.query``.