### PR TITLE
Fix IE9 204 status bug

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -385,6 +385,11 @@ Response.prototype.parseBody = function(str){
  */
 
 Response.prototype.setStatusProperties = function(status){
+  // handle IE9 bug: http://stackoverflow.com/questions/10046972/msie-returns-status-code-of-1223-for-ajax-request
+  if (status === 1223) {
+   status = 204;
+  }
+
   var type = status / 100 | 0;
 
   // status / class


### PR DESCRIPTION
Status code can be (falsely) 1223, and should be safe to interpret as 204.

Fixes failing `.noContent` test for IE9.