### PR TITLE
Fix IE9 204 status bug

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -385,6 +385,11 @@ Response.prototype.parseBody = function(str){
  */
 
 Response.prototype.setStatusProperties = function(status){
+  // handle IE9 bug: http://stackoverflow.com/questions/10046972/msie-returns-status-code-of-1223-for-ajax-request
+  if (status === 1223) {
+    status = 204;
+  }
+
   var type = status / 100 | 0;
 
   // status / class
@@ -402,7 +407,7 @@ Response.prototype.setStatusProperties = function(status){
 
   // sugar
   this.accepted = 202 == status;
-  this.noContent = 204 == status || 1223 == status;
+  this.noContent = 204 == status;
   this.badRequest = 400 == status;
   this.unauthorized = 401 == status;
   this.notAcceptable = 406 == status;


### PR DESCRIPTION
Fixes failing `.noContent` test on IE9.

Just setting `.noContent` to use the possible falsy `1223` status code is not enough with the new error checking introduced, since `1223` is interpreted as an error (since it doesn't fit the proper status code range). 

I think we should just completely set any `1223` status to `204` (implemented in this PR). Alternatively we could specifically check for `1223` when determining if the status code is an error or not, but I feel like this is a better solution.

Thoughts @defunctzombie?