### PR TITLE
Correct broken Readme example.

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -60,7 +60,7 @@ prefix(request); // Prefixes *all* requests
 request
 .get('/some-url')
 .use(nocache) // Prevents caching of *only* this request
-.end(function(res){
+.end(function(err, res){
     // Do something
 });
 ```


### PR DESCRIPTION
The response handler is passed the error as the first argument,
not the response.