### PR TITLE
Updates node-mime dependency. 1.2.11->1.3.4, to fix webpack issue.

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "dependencies": {
     "qs": "2.3.3",
     "formidable": "1.0.14",
-    "mime": "1.2.11",
+    "mime": "1.3.4",
     "component-emitter": "1.1.2",
     "methods": "1.0.1",
     "cookiejar": "2.0.1",


### PR DESCRIPTION
The primary reason is that webpack has issues with including superagent on the server-side because in version 1.2.11, node-mime reads `./types/mime.types` and webpack does not recognize that dependency. In 1.3.4, it requires a `types.json` file which webpack can recognize.