### PR TITLE
Updates node-form-data dependency, 0.1.3->0.2.0, to fix webpack issue.

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "debug": "2",
     "reduce-component": "1.0.1",
     "extend": "1.2.1",
-    "form-data": "0.1.3",
+    "form-data": "0.2.0",
     "readable-stream": "1.0.27-1"
   },
   "devDependencies": {


### PR DESCRIPTION
SuperAgent depends on node-form-data@0.1.3, which uses node-mime@1.3.4 which has issues with webpack on the server-side (Ref: https://github.com/visionmedia/superagent/pull/615).

node-form-data@0.2.0 uses another library, mime-types@2.0.3, which does not have these issues.