### PR TITLE
Add `.acceptedStatus()` to allow specific status codes (that won't result in an error)

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -458,6 +458,8 @@ function Request(method, url) {
   this.url = url;
   this.header = {};
   this._header = {};
+  this.statusFilter = null;
+
   this.on('end', function(){
     var err = null;
     var res = null;
@@ -477,7 +479,7 @@ function Request(method, url) {
       return self.callback(err, res);
     }
 
-    if (res.status >= 200 && res.status < 300) {
+    if (self.isAcceptedStatus(res.status)) {
       return self.callback(err, res);
     }
 
@@ -596,6 +598,79 @@ Request.prototype.set = function(field, val){
 Request.prototype.unset = function(field){
   delete this._header[field.toLowerCase()];
   delete this.header[field];
+  return this;
+};
+
+/**
+ * Checks if the received status code is expected. By default only 2xx status codes are expected and don't produce an error
+ *
+ * @param {Number} status
+ * @api private
+ */
+
+Request.prototype.isAcceptedStatus = function(status) {
+  if (this.statusFilter) {
+    return this.statusFilter(status);
+  }
+
+  // By default 2xx status codes may pass
+  return status >= 200 && status < 300;
+};
+
+/**
+ * Set a filter for accepted status codes (that don't result in an error)
+ *
+ * Examples:
+ *
+ *      req.get('/')
+ *        .set('Accept', 'application/json')
+ *        .set('X-API-Key', 'foobar')
+ *        .acceptedStatus(['2xx', '4xx', 500])
+ *        .end(callback);
+ *
+ *      req.get('/')
+ *        .set({ Accept: 'application/json', 'X-API-Key': 'foobar' })
+ *        .acceptedStatus(function(status) { return status === 200; })
+ *        .end(callback);
+ *
+ * @param {Array|Function} field
+ * @return {Request} for chaining
+ * @api public
+ */
+
+Request.prototype.acceptedStatus = function(filter) {
+  if (filter instanceof Array) {
+    this.statusFilter = function(status) {
+      for (var i = 0; i < filter.length; i++) {
+        if (typeof filter[i] === 'string') {
+          var regexStr = [].map.call(filter[i].toLowerCase(), function(x) {
+            if (x === 'x') {
+              return '\\d';
+            }
+
+            return x;
+          }).join('');
+
+          var regex = new RegExp(regexStr);
+          if (regex.test(String(status))) {
+            return true;
+          }
+
+          continue;
+        }
+
+        if (filter[i] === status) {
+          return true;
+        }
+      }
+
+      return false;
+    };
+
+    return this;
+  }
+
+  this.statusFilter = filter;
   return this;
 };
 

--- a/lib/node/index.js
+++ b/lib/node/index.js
@@ -133,6 +133,7 @@ function Request(method, url) {
   this.qsRaw = [];
   this._redirectList = [];
   this.on('end', this.clearTimeout.bind(this));
+  this.statusFilter = null;
 }
 
 /**
@@ -292,6 +293,79 @@ Request.prototype.set = function(field, val){
 Request.prototype.unset = function(field){
   debug('unset %s', field);
   this.request().removeHeader(field);
+  return this;
+};
+
+/**
+ * Checks if the received status code is expected. By default only 2xx status codes are expected and don't produce an error
+ *
+ * @param {Number} status
+ * @api private
+ */
+
+Request.prototype.isAcceptedStatus = function(status) {
+  if (this.statusFilter) {
+    return this.statusFilter(status);
+  }
+
+  // By default 2xx status codes may pass
+  return status >= 200 && status < 300;
+};
+
+/**
+ * Set a filter for accepted status codes (that don't result in an error)
+ *
+ * Examples:
+ *
+ *      req.get('/')
+ *        .set('Accept', 'application/json')
+ *        .set('X-API-Key', 'foobar')
+ *        .acceptedStatus(['2xx', '4xx', 500])
+ *        .end(callback);
+ *
+ *      req.get('/')
+ *        .set({ Accept: 'application/json', 'X-API-Key': 'foobar' })
+ *        .acceptedStatus(function(status) { return status === 200; })
+ *        .end(callback);
+ *
+ * @param {Array|Function} field
+ * @return {Request} for chaining
+ * @api public
+ */
+
+Request.prototype.acceptedStatus = function(filter) {
+  if (filter instanceof Array) {
+    this.statusFilter = function(status) {
+      for (var i = 0; i < filter.length; i++) {
+        if (typeof filter[i] === 'string') {
+          var regexStr = [].map.call(filter[i].toLowerCase(), function(x) {
+            if (x === 'x') {
+              return '\\d';
+            }
+
+            return x;
+          }).join('');
+
+          var regex = new RegExp(regexStr);
+          if (regex.test(String(status))) {
+            return true;
+          }
+
+          continue;
+        }
+
+        if (filter[i] === status) {
+          return true;
+        }
+      }
+
+      return false;
+    };
+
+    return this;
+  }
+
+  this.statusFilter = filter;
   return this;
 };
 
@@ -775,7 +849,7 @@ Request.prototype.callback = function(err, res){
     return fn(err, res);
   }
 
-  if (res && res.status >= 200 && res.status < 300) {
+  if (this.isAcceptedStatus(res.status)) {
     return fn(err, res);
   }
 

--- a/test/client/request.js
+++ b/test/client/request.js
@@ -80,8 +80,17 @@ it('request() GET 400 Bad Request', function(next){
   });
 });
 
+it('results in bad request if 400 not specifically allowed', function(next) {
+  request('GET', '/bad-request').end(function(err, res){
+    assert(err);
+    assert(res.badRequest, 'response should be .badRequest');
+    next();
+  });
+
+});
+
 it('request() GET 401 Bad Request', function(next){
-  request('GET', '/unauthorized').end(function(err, res){
+  request('GET', '/unauthorized').acceptedStatus([200]).end(function(err, res){
     assert(err);
     assert(res.unauthorized, 'response should be .unauthorized');
     next();
@@ -92,6 +101,22 @@ it('request() GET 406 Not Acceptable', function(next){
   request('GET', '/not-acceptable').end(function(err, res){
     assert(err);
     assert(res.notAcceptable, 'response should be .notAcceptable');
+    next();
+  });
+});
+
+it('should let 406 through if 4xx allowed', function(next) {
+  request('GET', '/not-acceptable').acceptedStatus(['4xx']).end(function(err, res){
+    assert(!err);
+    assert(res.status == 406);
+    next();
+  });
+});
+
+it('should let 406 through if 406 allowed', function(next) {
+  request('GET', '/not-acceptable').acceptedStatus(function(status) { return status == 406; }).end(function(err, res){
+    assert(!err);
+    assert(res.status == 406);
     next();
   });
 });

--- a/test/node/accepted-status.js
+++ b/test/node/accepted-status.js
@@ -1,0 +1,116 @@
+var request = require('../..')
+  , express = require('express')
+  , assert = require('better-assert')
+  , app = express()
+  , url = require('url');
+
+app.get('/ok', function(req, res) {
+  res.status(200).send('OK');
+});
+
+app.get('/210', function(req, res) {
+  res.sendStatus(210);
+});
+
+app.get('/500', function(req, res) {
+  res.sendStatus(500);
+});
+
+app.get('/400', function(req, res){
+  res.sendStatus(400);
+});
+
+
+app.listen(8889);
+
+describe('request.acceptedStatus()', function(){
+  it('let 200 through by default', function(done){
+    request
+    .get('http://localhost:8889/ok')
+    .end(function(err, res) {
+      assert(!err);
+      assert(res.text == 'OK');
+      assert(res.status == 200);
+      done();
+    });
+  });
+
+  it('shouldn\'t let 400 through by default', function(done){
+    request
+    .get('http://localhost:8889/400')
+    .end(function(err, res) {
+      assert(err);
+      assert(err.status == 400);
+      done();
+    });
+  });
+
+  it('should allow 400 if configured via function', function(done) {
+    request
+    .get('http://localhost:8889/400')
+    .acceptedStatus(function(status) { return true; })
+    .end(function(err, res) {
+      assert(!err);
+      assert(res.status == 400);
+      done();
+    });
+  });
+
+  it('should allow 400 if configured via array', function(done) {
+    request
+    .get('http://localhost:8889/400')
+    .acceptedStatus([400])
+    .end(function(err, res) {
+      assert(!err);
+      assert(res.status == 400);
+      done();
+    });
+  });
+
+  it('should not allow other than specified status codes when set', function(done) {
+    request
+    .get('http://localhost:8889/ok')
+    .acceptedStatus([400])
+    .end(function(err, res) {
+      assert(err);
+      assert(err.status == 200);
+      done();
+    });
+  });
+
+  it('should allow 200 and 400 and disallow 210 and 500 with [20x, 4XX] format', function(done) {
+    request
+    .get('http://localhost:8889/ok')
+    .acceptedStatus(['20x', '4XX'])
+    .end(function(err, res) {
+      assert(!err);
+      assert(res.status == 200);
+
+      request
+      .get('http://localhost:8889/400')
+      .acceptedStatus(['20x', '4XX'])
+      .end(function(err, res) {
+        assert(!err);
+        assert(res.status == 400);
+
+        request
+        .get('http://localhost:8889/210')
+        .acceptedStatus(['20x', '4XX'])
+        .end(function(err, res) {
+          assert(err);
+          assert(err.status == 210);
+
+          request
+          .get('http://localhost:8889/500')
+          .acceptedStatus(['20x', '4XX'])
+          .end(function(err, res) {
+            assert(err);
+            assert(err.status == 500);
+
+            done();
+          });
+        });
+      });
+    });
+  });
+});


### PR DESCRIPTION
A suggestion to implement the feature discussed in https://github.com/visionmedia/superagent/issues/613

With this patch a new method, `.acceptedStatus()` is added, that let's you configure the accepted status codes in two ways:

With a function:

```
request
.get('http://localhost:8888/test')
.acceptedStatus(function(status) {
    return status >= 200 && status <= 208;
})
.end(endfn);
```

With an array syntax:

```
request
.get('http://localhost:8888/test')
.acceptedStatus(['40x', '2xx', 500])
.end(endfn);
```

The above will accept any status code that starts with 40, any status code that starts with 2 and 500.

By "accepting" a status code I mean that the specified status codes will lead to a successful respons, and others will result in an error. The default range of 2xx status codes can be reconfigured with this method.

Tests seem to fail currently due to what I suspect are issues with `localtunnel`, since using `ngrok` also browser tests are passing.

Thoughts on this API as it is? cc: @defunctzombie 