### PR TITLE
Fix Callback of if you specify the parser

### DIFF
--- a/lib/node/index.js
+++ b/lib/node/index.js
@@ -947,8 +947,14 @@ Request.prototype.end = function(fn){
       try {
         parse(res, function(err, obj){
           if (err) self.callback(err);
-          res.body = obj;
+          var response = new Response(self);
+          self.response = response;
+          response.body = obj;
+          response.redirects = self._redirectList;
+          self.emit('end');
+          self.callback(null, response);
         });
+        return;
       } catch (err) {
         self.callback(err);
         return;


### PR DESCRIPTION
I want to get res.body after parse.