### PR TITLE
Fix redirects to other hosts with 303, 307 and 308

### DIFF
--- a/lib/node/index.js
+++ b/lib/node/index.js
@@ -619,13 +619,19 @@ Request.prototype.redirect = function(res){
   }
   // 303 is always GET
   if (res.statusCode == 303) {
+    // strip Content-* related fields
+    // in case of POST etc
+    headers = utils.cleanHeader(this.req._headers);
+
     // force method
     this.method = 'GET';
+
     // clear data
     this._data = null;
   }
   // 307 preserves method
   // 308 preserves method
+  delete headers.host;
 
   delete this.req;
 

--- a/test/node/redirects-other-host.js
+++ b/test/node/redirects-other-host.js
@@ -3,23 +3,164 @@ var request = require('../../')
   , express = require('express')
   , assert = require('assert')
   , app = express()
+  , app2 = express()
   , should = require('should');
 
-app.get('/test', function(req, res){
-  res.redirect('https://github.com/');
+app.all('/test-301', function(req, res){
+  res.redirect(301, 'http://localhost:3211/');
+});
+app.all('/test-302', function(req, res){
+  res.redirect(302, 'http://localhost:3211/');
+});
+app.all('/test-303', function(req, res){
+  res.redirect(303, 'http://localhost:3211/');
+});
+app.all('/test-307', function(req, res){
+  res.redirect(307, 'http://localhost:3211/');
+});
+app.all('/test-308', function(req, res){
+  res.redirect(308, 'http://localhost:3211/');
 });
 
 app.listen(3210);
 
-describe('request', function(){
-  describe('on redirect', function(){
-    it('should follow Location even when the host changes', function(done){
+
+app2.all('/', function(req, res) {
+  res.send(req.method);
+});
+
+app2.listen(3211);
+
+describe('request.get', function(){
+  describe('on 301 redirect', function(){
+    it('should follow Location with a GET request', function(done){
       var req = request
-        .get('http://localhost:3210/test')
+        .get('http://localhost:3210/test-301')
         .redirects(1)
         .end(function(err, res){
-          req.req._headers.host.should.eql('github.com');
+          req.req._headers.host.should.eql('localhost:3211');
           res.status.should.eql(200);
+          res.text.should.eql('GET');
+          done();
+        });
+    })
+  });
+  describe('on 302 redirect', function(){
+    it('should follow Location with a GET request', function(done){
+      var req = request
+        .get('http://localhost:3210/test-302')
+        .redirects(1)
+        .end(function(err, res){
+          req.req._headers.host.should.eql('localhost:3211');
+          res.status.should.eql(200);
+          res.text.should.eql('GET');
+          done();
+        });
+    })
+  });
+  describe('on 303 redirect', function(){
+    it('should follow Location with a GET request', function(done){
+      var req = request
+        .get('http://localhost:3210/test-303')
+        .redirects(1)
+        .end(function(err, res){
+          req.req._headers.host.should.eql('localhost:3211');
+          res.status.should.eql(200);
+          res.text.should.eql('GET');
+          done();
+        });
+    })
+  });
+  describe('on 307 redirect', function(){
+    it('should follow Location with a GET request', function(done){
+      var req = request
+        .get('http://localhost:3210/test-307')
+        .redirects(1)
+        .end(function(err, res){
+          req.req._headers.host.should.eql('localhost:3211');
+          res.status.should.eql(200);
+          res.text.should.eql('GET');
+          done();
+        });
+    })
+  });
+  describe('on 308 redirect', function(){
+    it('should follow Location with a GET request', function(done){
+      var req = request
+        .get('http://localhost:3210/test-308')
+        .redirects(1)
+        .end(function(err, res){
+          req.req._headers.host.should.eql('localhost:3211');
+          res.status.should.eql(200);
+          res.text.should.eql('GET');
+          done();
+        });
+    })
+  });
+});
+
+describe('request.post', function(){
+  describe('on 301 redirect', function(){
+    it('should follow Location with a GET request', function(done){
+      var req = request
+        .post('http://localhost:3210/test-301')
+        .redirects(1)
+        .end(function(err, res){
+          req.req._headers.host.should.eql('localhost:3211');
+          res.status.should.eql(200);
+          res.text.should.eql('GET');
+          done();
+        });
+    })
+  });
+  describe('on 302 redirect', function(){
+    it('should follow Location with a GET request', function(done){
+      var req = request
+        .post('http://localhost:3210/test-302')
+        .redirects(1)
+        .end(function(err, res){
+          req.req._headers.host.should.eql('localhost:3211');
+          res.status.should.eql(200);
+          res.text.should.eql('GET');
+          done();
+        });
+    })
+  });
+  describe('on 303 redirect', function(){
+    it('should follow Location with a GET request', function(done){
+      var req = request
+        .post('http://localhost:3210/test-303')
+        .redirects(1)
+        .end(function(err, res){
+          req.req._headers.host.should.eql('localhost:3211');
+          res.status.should.eql(200);
+          res.text.should.eql('GET');
+          done();
+        });
+    })
+  });
+  describe('on 307 redirect', function(){
+    it('should follow Location with a POST request', function(done){
+      var req = request
+        .post('http://localhost:3210/test-307')
+        .redirects(1)
+        .end(function(err, res){
+          req.req._headers.host.should.eql('localhost:3211');
+          res.status.should.eql(200);
+          res.text.should.eql('POST');
+          done();
+        });
+    })
+  });
+  describe('on 308 redirect', function(){
+    it('should follow Location with a POST request', function(done){
+      var req = request
+        .post('http://localhost:3210/test-308')
+        .redirects(1)
+        .end(function(err, res){
+          req.req._headers.host.should.eql('localhost:3211');
+          res.status.should.eql(200);
+          res.text.should.eql('POST');
           done();
         });
     })


### PR DESCRIPTION
Also added a bunch of test cases. And removed external requests to github in `redirects-other-host.js` tests, now using localhost with different ports for different hosts.

For some reason not deleting the `host` header causes bad things to happen...
I can't actually find the place where it fails to overwrite the host header with the hostname from the url. But it has got to be there somewhere.

Anyways, existing code depends on headers being deleted. So that probably a good solution.