### PR TITLE
[React Native Compat] Don't require window.location to be set

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -49,7 +49,8 @@ function isHost(obj) {
 
 request.getXHR = function () {
   if (root.XMLHttpRequest
-    && ('file:' != root.location.protocol || !root.ActiveXObject)) {
+      && (!root.location || 'file:' != root.location.protocol
+          || !root.ActiveXObject)) {
     return new XMLHttpRequest;
   } else {
     try { return new ActiveXObject('Microsoft.XMLHTTP'); } catch(e) {}


### PR DESCRIPTION
React Native, is a browser-like environement but some browser properties
don't currently make sense in React Native. For example the location
object. However, we want our users to be able to use superagent, we even
recommend it on our website.

https://facebook.github.io/react-native/docs/network.html