### PR TITLE
Failed to set `Content-Type` internally with the xhr's `getResponseHeader`

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -305,7 +305,7 @@ function Response(req, options) {
   // getAllResponseHeaders sometimes falsely returns "" for CORS requests, but
   // getResponseHeader still works. so we get content-type even if getting
   // other headers fails.
-  this.header['content-type'] = this.xhr.getResponseHeader('content-type');
+  this.header['content-type'] = this.xhr.getResponseHeader('content-type') || this.xhr.getResponseHeader('Content-Type');
   this.setHeaderProperties(this.header);
   this.body = this.req.method != 'HEAD'
     ? this.parseBody(this.text ? this.text : this.xhr.response)

--- a/lib/client.js
+++ b/lib/client.js
@@ -305,7 +305,7 @@ function Response(req, options) {
   // getAllResponseHeaders sometimes falsely returns "" for CORS requests, but
   // getResponseHeader still works. so we get content-type even if getting
   // other headers fails.
-  this.header['content-type'] = this.xhr.getResponseHeader('content-type') || this.xhr.getResponseHeader('Content-Type');
+  this.header['content-type'] = this.xhr.getResponseHeader('Content-Type');
   this.setHeaderProperties(this.header);
   this.body = this.req.method != 'HEAD'
     ? this.parseBody(this.text ? this.text : this.xhr.response)


### PR DESCRIPTION
In response to [an issue](https://github.com/visionmedia/superagent/issues/636) in which `res.body` is `null` ...`superagent` Failed to correctly set `Content-Type` header from the xhr with `getResponseHeader` due to case-sensitivity