### PR TITLE
Fix typo in custom parser example

### DIFF
--- a/lib/node/index.js
+++ b/lib/node/index.js
@@ -101,7 +101,7 @@ exports.serialize = {
  * Default parsers.
  *
  *     superagent.parse['application/xml'] = function(res, fn){
- *       fn(null, result);
+ *       fn(null, res);
  *     };
  *
  */


### PR DESCRIPTION
Argument is named `res` but in function body it references `result`.