### PR TITLE
Fixed Prefix usage

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -55,10 +55,9 @@ var nocache = require('no-cache');
 var request = require('superagent');
 var prefix = require('superagent-prefix')('/static');
 
-prefix(request); // Prefixes *all* requests
-
 request
 .get('/some-url')
+.use(prefix) // Prefixes *only* this request
 .use(nocache) // Prevents caching of *only* this request
 .end(function(err, res){
     // Do something


### PR DESCRIPTION
According to the [superagent-prefix example in the repo](https://github.com/johntron/superagent-prefix/blob/master/example/index.js), the usage is only as an addition to the request chain, not as a file-wide prefix. The file-wide prefix returns an error currently. I've opened [an issue with superagent-prefix](https://github.com/johntron/superagent-prefix/issues/2) to see if this type of global usage is intended or available, but until then, this syntax should be corrected to reflect the plugin API.