### PR TITLE
Corrected superagent-no-cache require statement

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -51,7 +51,7 @@ Even though IE9 is supported, a polyfill `window.btoa` is needed to use basic au
 Superagent is easily extended via plugins.
 
 ```js
-var nocache = require('no-cache');
+var nocache = require('superagent-no-cache');
 var request = require('superagent');
 var prefix = require('superagent-prefix')('/static');
 


### PR DESCRIPTION
superagent-no-cache is published in NPM [under that same name](https://github.com/johntron/superagent-no-cache/blob/master/package.json#L2), as it is [with component](https://github.com/johntron/superagent-no-cache/blob/master/component.json#L2). Updated Readme to reflect that.