### PR TITLE
Retain cookies on redirect when hosts match

### DIFF
--- a/lib/node/index.js
+++ b/lib/node/index.js
@@ -603,11 +603,13 @@ Request.prototype.redirect = function(res){
 
   var headers = this.req._headers;
 
+  var shouldStripCookie = parse(url).host !== parse(this.url).host;
+
   // implementation of 302 following defacto standard
   if (res.statusCode == 301 || res.statusCode == 302){
     // strip Content-* related fields
     // in case of POST etc
-    headers = utils.cleanHeader(this.req._headers);
+    headers = utils.cleanHeader(this.req._headers, shouldStripCookie);
 
     // force GET
     this.method = 'HEAD' == this.method
@@ -621,7 +623,7 @@ Request.prototype.redirect = function(res){
   if (res.statusCode == 303) {
     // strip Content-* related fields
     // in case of POST etc
-    headers = utils.cleanHeader(this.req._headers);
+    headers = utils.cleanHeader(this.req._headers, shouldStripCookie);
 
     // force method
     this.method = 'GET';

--- a/lib/node/utils.js
+++ b/lib/node/utils.js
@@ -130,11 +130,13 @@ exports.unzip = function(req, res){
  * @api private
  */
 
-exports.cleanHeader = function(header){
+exports.cleanHeader = function(header, shouldStripCookie){
   delete header['content-type'];
   delete header['content-length'];
   delete header['transfer-encoding'];
-  delete header['cookie'];
   delete header['host'];
+  if (shouldStripCookie) {
+    delete header['cookie'];
+  }
   return header;
 };

--- a/test/node/redirects.js
+++ b/test/node/redirects.js
@@ -134,6 +134,16 @@ describe('request', function(){
       });
     })
 
+    it('should retain cookies', function(done){
+      request
+      .get('http://localhost:3003/header')
+      .set('Cookie', 'foo=bar;')
+      .end(function(err, res){
+        res.body.should.have.property('cookie', 'foo=bar;');
+        done();
+      });
+    })
+
     it('should preserve timeout across redirects', function(done){
       request
       .get('http://localhost:3003/movies/random')


### PR DESCRIPTION
The problem case for this is cookie-based authentication. In my case the Wordpress REST API `/users/me` redirects to `/users/{id}` based on authentication. This works fine in the browser (it sends the cookies to the redirected path), but on the server superagent strips the cookies and the call to `/users/{id}` results in a 401 Unauthorized response.