### PR TITLE
Make tests pass on iojs

### DIFF
--- a/test/node/basic.js
+++ b/test/node/basic.js
@@ -202,7 +202,7 @@ describe('[node] request', function(){
 
   describe('.agent(undefined)', function(){
     it('should set an agent to undefined and ensure it is chainable', function(done){
-      var req = request.get();
+      var req = request.get('http://localhost:5000/echo');
       var ret = req.agent(undefined);
       ret.should.equal(req);
       assert(req.agent() === undefined);
@@ -213,7 +213,7 @@ describe('[node] request', function(){
   describe('.agent(new http.Agent())', function(){
     it('should set passed agent', function(done){
       var http = require('http');
-      var req = request.get();
+      var req = request.get('http://localhost:5000/echo');
       var agent = new http.Agent();
       var ret = req.agent(agent);
       ret.should.equal(req);


### PR DESCRIPTION
A change introduced in
https://github.com/iojs/io.js/commit/abb00cc915b2e336afb73210298f673a00d
ad9f0 throws if the url being
formatted is not an object or a string.