### PR TITLE
Generalize xhr status 0 error

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -839,14 +839,15 @@ Request.prototype.callback = function(err, res){
 };
 
 /**
- * Invoke callback with x-domain error.
+ * Invoke callback with xhr status 0 error.
  *
  * @api private
  */
 
-Request.prototype.crossDomainError = function(){
-  var err = new Error('Origin is not allowed by Access-Control-Allow-Origin');
-  err.crossDomain = true;
+Request.prototype.outBoundError = function(){
+  var err = new Error('Error with outbound request');
+  err.outBound = true;
+  err.info = 'Possible causes: CORS error, network error, fetch termination';
   this.callback(err);
 };
 
@@ -910,7 +911,7 @@ Request.prototype.end = function(fn){
     if (0 == status) {
       if (self.timedout) return self.timeoutError();
       if (self.aborted) return;
-      return self.crossDomainError();
+      return self.outBoundError();
     }
     self.emit('end');
   };

--- a/test/client/xdomain.js
+++ b/test/client/xdomain.js
@@ -25,7 +25,8 @@ describe('xdomain', function(){
       .get('//tunne127.com')
       .end(function(err, res){
         assert(err, 'error missing');
-        assert(err.crossDomain, 'not .crossDomain');
+        assert(err.info, 'missing info on xhr status 0');
+        assert(err.outBound, 'not .outBound');
         next();
       });
     });


### PR DESCRIPTION
Fixes: https://github.com/visionmedia/superagent/issues/484

**Changes:**
- Rename `.crossDomainError()` ---> `outBoundError()`
- Reword the error to blanket other causes of `xhr status 0`
- Add `info` property onto `err` that outlines common causes.
- Update tests to reflect the above.

`xhr.status` of 0 is not always a CORS error. According to the [wc3 spec](http://www.w3.org/TR/XMLHttpRequest/#the-status-attribute), other possible causes include network errors or fetch termination (page reload/redirect), the latter of which seems to be affecting many people.

I think a general blanket error for all scenarios of the xhr status 0 is that something went wrong with the outbound request and have named it as such. However I'm not completely enamored by it, so discussion and other suggestions are welcome!
