### PR TITLE
Fix detection of root object

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -9,9 +9,14 @@ var reduce = require('reduce');
  * Root reference for iframes.
  */
 
-var root = 'undefined' == typeof window
-  ? (this || self)
-  : window;
+var root;
+if (typeof window !== 'undefined') { // Browser window
+  root = window;
+} else if (typeof self !== 'undefined') { // Web Worker
+  root = self;
+} else { // Other environments
+  root = this;
+}
 
 /**
  * Noop.


### PR DESCRIPTION
`self` is compatible with Window and Web Workers (see [this article](https://developer.mozilla.org/en-US/docs/Web/API/Window/self)).
Checking for `this` is breaking browserify builds that run in Workers.

Another solution is to simply do `var root = self;`. What is the reason to have a fallback to `this` ?