### PR TITLE
Serialize JSON variations content types

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -171,6 +171,22 @@ request.types = {
  };
 
  /**
+ * Content subtype serialization.
+ * http://www.iana.org/assignments/media-types/media-types.xhtml
+ *
+ *     superagent.serializeSubtypes('application/json-patch+json') = function(obj){
+ *       return 'generated json here';
+ *     };
+ *
+ */
+
+request.serializeSubtypes = function(type) {
+  if (!type || typeof type !== 'string') return null;
+  if (type.match(/(application\/(.*)\+json)/)) return JSON.stringify;
+  return null;
+};
+
+ /**
   * Default parsers.
   *
   *     superagent.parse['application/xml'] = function(str){
@@ -961,8 +977,12 @@ Request.prototype.end = function(fn){
   if ('GET' != this.method && 'HEAD' != this.method && 'string' != typeof data && !isHost(data)) {
     // serialize stuff
     var contentType = this.getHeader('Content-Type');
-    var serialize = request.serialize[contentType ? contentType.split(';')[0] : ''];
-    if (serialize) data = serialize(data);
+    if (contentType) {
+      // Parse out just the content type from the header (ignore the charset)
+      contentType = contentType.split(';')[0];
+      var serialize = request.serialize[contentType] || request.serializeSubtypes(contentType);
+      if (serialize) data = serialize(data);
+    }
   }
 
   // set header fields

--- a/lib/node/index.js
+++ b/lib/node/index.js
@@ -98,6 +98,23 @@ exports.serialize = {
 };
 
 /**
+ * Content subtype serialization.
+ * http://www.iana.org/assignments/media-types/media-types.xhtml
+ *
+ *     superagent.serializeSubtypes('application/json-patch+json') = function(obj){
+ *       return 'generated json here';
+ *     };
+ *
+ */
+
+exports.serializeSubtypes = function(type) {
+  if (!type || typeof type !== 'string') return null;
+  if (type.match(/(application\/(.*)\+json)/)) return JSON.stringify;
+  return null;
+};
+
+
+/**
  * Default parsers.
  *
  *     superagent.parse['application/xml'] = function(res, fn){
@@ -845,11 +862,13 @@ Request.prototype.end = function(fn){
   if ('HEAD' != method && !req._headerSent) {
     // serialize stuff
     if ('string' != typeof data) {
-      var contentType = req.getHeader('Content-Type')
-      // Parse out just the content type from the header (ignore the charset)
-      if (contentType) contentType = contentType.split(';')[0]
-      var serialize = exports.serialize[contentType];
-      if (serialize) data = serialize(data);
+      var contentType = req.getHeader('Content-Type');
+      if (contentType) {
+        // Parse out just the content type from the header (ignore the charset)
+        contentType = contentType.split(';')[0];
+        var serialize = exports.serialize[contentType] || exports.serializeSubtypes(contentType);
+        if (serialize) data = serialize(data);
+      }
     }
 
     // content-length

--- a/test/client/request.js
+++ b/test/client/request.js
@@ -343,6 +343,18 @@ it('POST json array', function(next){
   });
 });
 
+it('PATCH json-patch', function(next){
+  request
+  .patch('/echo')
+  .type('application/json-patch+json')
+  .send({name: 'tobi'})
+  .end(function(err, res){
+    assert('application/json-patch+json' == res.header['content-type'].split(';')[0]);
+    assert('{"name":"tobi"}' == res.text);
+    next();
+  });
+});
+
 it('POST json default', function(next){
   request
   .post('/pet')

--- a/test/node/json.js
+++ b/test/node/json.js
@@ -66,6 +66,44 @@ describe('req.send(Object) as "json"', function(){
     });
   });
 
+  it('should work with type json-patch', function(done){
+    request
+    .patch('http://localhost:3005/echo')
+    .type('application/json-patch+json')
+    .send([{ "op": "remove", "path": "/foo"}])
+    .end(function(err, res){
+      res.headers['content-type'].should.equal('application/json-patch+json');
+      res.text.should.equal('[{"op":"remove","path":"/foo"}]');
+      done();
+    });
+  });
+
+  it('should throw error with invalid type', function(done){
+    try {
+      request
+      .patch('http://localhost:3005/echo')
+      .type('application/json-patch')
+      .send([{ "op": "remove", "path": "/foo"}])
+      .end();
+    } catch(e) {
+      assert(e);
+      assert(e.name === 'TypeError');
+      done();
+    }
+  });
+
+  it('should work with type jsonapi', function(done){
+    request
+    .patch('http://localhost:3005/echo')
+    .type('application/vnd.api+json')
+    .send({ name: 'tobi' })
+    .end(function(err, res){
+      res.headers['content-type'].should.equal('application/vnd.api+json');
+      res.text.should.equal('{"name":"tobi"}');
+      done();
+    });
+  });
+
   it('should work with value false', function(done){
     request
     .post('http://localhost:3005/echo')


### PR DESCRIPTION
HTTP header Content-Type can contain variations of `application/json` media type.

See the [IANA list](http://www.iana.org/assignments/media-types/media-types.xhtml) for more information. This enables parsing of popular additional media types such as [JSON Patch](http://jsonpatch.com/) and [JSON API](http://jsonapi.org/).

The regex used that matched this schema is `/(application\/(.*)\+json)/`,

Fixes #660 and #689.
