### PR TITLE
Use qs for query string serialization in the browser (addresses #670)

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -4,6 +4,7 @@
 
 var Emitter = require('emitter');
 var reduce = require('reduce');
+var qs = require('qs');
 
 /**
  * Root reference for iframes.
@@ -95,14 +96,7 @@ function isObject(obj) {
 
 function serialize(obj) {
   if (!isObject(obj)) return obj;
-  var pairs = [];
-  for (var key in obj) {
-    if (null != obj[key]) {
-      pairs.push(encodeURIComponent(key)
-        + '=' + encodeURIComponent(obj[key]));
-    }
-  }
-  return pairs.join('&');
+  return qs.stringify(obj, { indices: false });
 }
 
 /**

--- a/test/client/request.js
+++ b/test/client/request.js
@@ -451,6 +451,16 @@ it('POST shorthand without callback', function(next){
   });
 });
 
+it('GET querystring object with array', function(next){
+  request
+  .get('/querystring')
+  .query({ val: ['a', 'b', 'c'] })
+  .end(function(err, res){
+    assert.deepEqual(res.body, { val: ['a', 'b', 'c'] });
+    next();
+  });
+});
+
 it('GET querystring object', function(next){
   request
   .get('/querystring')

--- a/test/client/serialize.js
+++ b/test/client/serialize.js
@@ -23,7 +23,7 @@ describe('request.serializeObject()', function(){
     serialize('test', 'test');
     serialize('foo=bar', 'foo=bar');
     serialize({ foo: 'bar' }, 'foo=bar');
-    serialize({ foo: null }, '');
+    serialize({ foo: null }, 'foo=');
     serialize({ foo: 'null' }, 'foo=null');
     serialize({ foo: undefined }, '');
     serialize({ foo: 'undefined' }, 'foo=undefined');


### PR DESCRIPTION
This addresses issue #670 by using `qs` to serialize values in the browser just like the node implementation does, rather than a hand-rolled loop of `encodeURIComponent`. 

This changes one test case - `{foo: null}` no longer serializes to `''`, it serializes to `foo=`, which matches the node version (and is generally what would be expected). 