### PR TITLE
Encode array values as key=1&key=2&key=3 etc...

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -97,9 +97,17 @@ function serialize(obj) {
   if (!isObject(obj)) return obj;
   var pairs = [];
   for (var key in obj) {
-    if (null != obj[key]) {
-      pairs.push(encodeURIComponent(key)
-        + '=' + encodeURIComponent(obj[key]));
+    var value = obj[key]
+    if (null != value) {
+      var encodedKey = encodeURIComponent(key)
+      if (Array.isArray(value)) {
+        for (var i = 0; i < value.length; i++) {
+          pairs.push(encodedKey + '=' + encodeURIComponent(value[i]))
+        }
+      } else {
+        pairs.push(encodedKey
+                  + '=' + encodeURIComponent(value));
+      }
     }
   }
   return pairs.join('&');

--- a/test/client/request.js
+++ b/test/client/request.js
@@ -451,6 +451,16 @@ it('POST shorthand without callback', function(next){
   });
 });
 
+it('GET querystring object with array', function(next){
+  request
+  .get('/querystring')
+  .query({ val: ['a', 'b', 'c'] })
+  .end(function(err, res){
+    assert.deepEqual(res.body, { val: ['a', 'b', 'c'] });
+    next();
+  });
+});
+
 it('GET querystring object', function(next){
   request
   .get('/querystring')

--- a/test/client/request.js
+++ b/test/client/request.js
@@ -461,6 +461,26 @@ it('GET querystring object with array', function(next){
   });
 });
 
+it('GET querystring object with array and primitives', function(next){
+  request
+  .get('/querystring')
+  .query({ array: ['a', 'b', 'c'], string: 'foo', number: 10 })
+  .end(function(err, res){
+    assert.deepEqual(res.body, { array: ['a', 'b', 'c'], string: 'foo', number: 10 });
+    next();
+  });
+});
+
+it('GET querystring object with two arrays', function(next){
+  request
+  .get('/querystring')
+  .query({ array1: ['a', 'b', 'c'], array2: [1, 2, 3]})
+  .end(function(err, res){
+    assert.deepEqual(res.body, { array1: ['a', 'b', 'c'], array2: [1, 2, 3]});
+    next();
+  });
+});
+
 it('GET querystring object', function(next){
   request
   .get('/querystring')


### PR DESCRIPTION
This partially addresses #670 for the specific case of array-valued query parameters without adding the `qs` module to the client side bundle. 

Unlike PR #698, it won't actually make the browser and node versions behave the same, since `qs` covers a LOT of different serialization possibilities, but it covers what's probably the most common case without the download hit of `qs`. 