### PR TITLE
lib: added fake promises

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -978,6 +978,20 @@ Request.prototype.end = function(fn){
 };
 
 /**
+ * Faux promise support
+ *
+ * @param {Function} fulfill
+ * @param {Function} reject
+ * @return {Request}
+ */
+
+Request.prototype.then = function (fulfill, reject) {
+  return this.end(function(err, res) {
+    err ? reject(err) : fulfill(res);
+  });
+}
+
+/**
  * Expose `Request`.
  */
 

--- a/lib/node/index.js
+++ b/lib/node/index.js
@@ -1024,6 +1024,20 @@ Request.prototype.end = function(fn){
 };
 
 /**
+ * Faux promise support
+ *
+ * @param {Function} fulfill
+ * @param {Function} reject
+ * @return {Request}
+ */
+
+Request.prototype.then = function (fulfill, reject) {
+  return this.end(function(err, res) {
+    err ? reject(err) : fulfill(res);
+  });
+}
+
+/**
  * To json.
  *
  * @return {Object}

--- a/test/basic.js
+++ b/test/basic.js
@@ -283,6 +283,28 @@ describe('request', function(){
     })
   })
 
+  describe('.then(fulfill, reject)', function() {
+    it('should support successful fulfills with .then(fulfill)', function(done) {
+      request
+      .post(uri + '/echo')
+      .send({ name: 'tobi' })
+      .then(function(res) {
+        res.text.should.equal('{"name":"tobi"}');
+        done();
+      })
+    })
+
+    it('should reject an error with .then(null, reject)', function(done) {
+      request
+      .get(uri + '/error')
+      .then(null, function(err) {
+        assert(err.status == 500);
+        assert(err.response.text == 'boom');
+        done();
+      })
+    })
+  })
+
   describe('.abort()', function(){
     it('should abort the request', function(done){
       var req = request


### PR DESCRIPTION
This is helpful for working with co-routine control flow libraries like `co()`:

```js
var res = yield request
  .get('http://localhost:8080')
  .type('json')
```

No idea if I'm committing blasphemy in the promise world or if this will quiet the promise people down a bit. 

Don't really mind if this gets merged or not, but if people are happy with it, I'll add some tests.