### PR TITLE
Raise error if end() is called with undefined argument instead of noop-ing

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -896,7 +896,9 @@ Request.prototype.end = function(fn){
   var data = this._formData || this._data;
 
   // store callback
-  this._callback = fn || noop;
+  if ( fn ) {
+    this._callback = fn;
+  }
 
   // state change
   xhr.onreadystatechange = function(){


### PR DESCRIPTION
I expect Request.end() to raise an error if you pass it an undefined argument. Instead, it calls a no op.

If this change is acceptable, I can add a test for it.