### PR TITLE
Fixing "undefined is not a function"

### DIFF
--- a/lib/node/index.js
+++ b/lib/node/index.js
@@ -768,6 +768,10 @@ Request.prototype.callback = function(err, res){
   this.clearTimeout();
   if (this.called) return console.warn('double callback!');
   this.called = true;
+  
+  if (typeof fn != 'function') {
+    fn = function() { console.warn('request without a callback!'); };
+  }
 
   if (err) {
     err.response = res;


### PR DESCRIPTION
Whenever no callback is privided to the superagent request, it crashes with `TypeError: undefined is not a function`