### PR TITLE
705: examples/simple-get.js url endpoint invalid

### DIFF
--- a/examples/simple-get.js
+++ b/examples/simple-get.js
@@ -5,7 +5,7 @@
 
 var request = require('..');
 
-var url = 'https://gist.github.com/visionmedia/9fff5b23c1bf1791c349/raw/3e588e0c4f762f15538cdaf9882df06b3f5b3db6/works.js';
+var url = 'https://gist.githubusercontent.com/reinaldo13/cdbb4d663ba23410a77b/raw/0345267767d50790051951ddc460e2699649de2b/it-works.txt';
 
 request.get(url, function(err, res){
   if (err) throw err;


### PR DESCRIPTION
Added a valid `gist` link so `node examples/simple-get.js` can run successfully. This is to fix: https://github.com/visionmedia/superagent/issues/705