### PR TITLE
Do not apply JSON heuristics if already have a valid parser

### DIFF
--- a/lib/node/index.js
+++ b/lib/node/index.js
@@ -940,7 +940,7 @@ Request.prototype.end = function(fn){
       : exports.parse[mime];
 
     // everyone wants their own white-labeled json
-    if (isJSON(mime)) parse = exports.parse['application/json'];
+    if (!parse && isJSON(mime)) parse = exports.parse['application/json'];
 
     // buffered response
     if (buffer) parse = parse || exports.parse.text;


### PR DESCRIPTION
This PR addresses #724. On a side note, code on the browser side is wildly different (this bug didn't seem to exist there).