### PR TITLE
Add support for ES6 promise with fallback on es6-promise

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ superagent.js: lib/node/*.js lib/node/parsers/*.js
 		--outfile superagent.js .
 
 test-server:
-	@node test/server
+	@node test/support/server
 
 docs: test-docs
 

--- a/lib/client.js
+++ b/lib/client.js
@@ -4,6 +4,7 @@
 
 var Emitter = require('emitter');
 var reduce = require('reduce');
+var Promise = global.Promise || require('es6-promise').Promise;
 
 /**
  * Root reference for iframes.
@@ -888,7 +889,7 @@ Request.prototype.withCredentials = function(){
  * @api public
  */
 
-Request.prototype.end = function(fn){
+Request.prototype._end = function(fn){
   var self = this;
   var xhr = this.xhr = request.getXHR();
   var query = this._query.join('&');
@@ -978,6 +979,25 @@ Request.prototype.end = function(fn){
 };
 
 /**
+ * Initiate request, invoking callback `fn(err, res)`
+ * with an instanceof `Response`.
+ *
+ * @param {Function} fn
+ * @return {Promise}
+ * @api public
+ */
+
+Request.prototype.end = function (fn) {
+  var self = this;
+  return new Promise(function (resolve, reject) {
+    self._end(function(err, res) {
+      fn && fn(err, res);
+      err ? reject(err) : resolve(res);
+    });
+  });
+};
+
+/**
  * Faux promise support
  *
  * @param {Function} fulfill
@@ -986,7 +1006,7 @@ Request.prototype.end = function(fn){
  */
 
 Request.prototype.then = function (fulfill, reject) {
-  return this.end(function(err, res) {
+  return this._end(function(err, res) {
     err ? reject(err) : fulfill(res);
   });
 }
@@ -1015,7 +1035,7 @@ request.Request = Request;
 function request(method, url) {
   // callback
   if ('function' == typeof url) {
-    return new Request('GET', method).end(url);
+    return new Request('GET', method)._end(url);
   }
 
   // url first
@@ -1040,7 +1060,7 @@ request.get = function(url, data, fn){
   var req = request('GET', url);
   if ('function' == typeof data) fn = data, data = null;
   if (data) req.query(data);
-  if (fn) req.end(fn);
+  if (fn) req._end(fn);
   return req;
 };
 
@@ -1058,7 +1078,7 @@ request.head = function(url, data, fn){
   var req = request('HEAD', url);
   if ('function' == typeof data) fn = data, data = null;
   if (data) req.send(data);
-  if (fn) req.end(fn);
+  if (fn) req._end(fn);
   return req;
 };
 
@@ -1073,7 +1093,7 @@ request.head = function(url, data, fn){
 
 request.del = function(url, fn){
   var req = request('DELETE', url);
-  if (fn) req.end(fn);
+  if (fn) req._end(fn);
   return req;
 };
 
@@ -1091,7 +1111,7 @@ request.patch = function(url, data, fn){
   var req = request('PATCH', url);
   if ('function' == typeof data) fn = data, data = null;
   if (data) req.send(data);
-  if (fn) req.end(fn);
+  if (fn) req._end(fn);
   return req;
 };
 
@@ -1109,7 +1129,7 @@ request.post = function(url, data, fn){
   var req = request('POST', url);
   if ('function' == typeof data) fn = data, data = null;
   if (data) req.send(data);
-  if (fn) req.end(fn);
+  if (fn) req._end(fn);
   return req;
 };
 
@@ -1127,7 +1147,7 @@ request.put = function(url, data, fn){
   var req = request('PUT', url);
   if ('function' == typeof data) fn = data, data = null;
   if (data) req.send(data);
-  if (fn) req.end(fn);
+  if (fn) req._end(fn);
   return req;
 };
 

--- a/lib/node/index.js
+++ b/lib/node/index.js
@@ -23,6 +23,7 @@ var qs = require('qs');
 var zlib = require('zlib');
 var util = require('util');
 var pkg = require('../../package.json');
+var Promise = global.Promise || require('es6-promise').Promise;
 
 /**
  * Expose the request function.
@@ -490,7 +491,7 @@ Request.prototype.pipe = function(stream, options){
   this.piped = true; // HACK...
   this.buffer(false);
   var self = this;
-  this.end().req.on('response', function(res){
+  this._end().req.on('response', function(res){
     // redirect
     var redirect = isRedirect(res.statusCode);
     if (redirect && self._redirects++ != self._maxRedirects) {
@@ -641,7 +642,7 @@ Request.prototype.redirect = function(res){
   this.emit('redirect', res);
   this.qs = {};
   this.set(headers);
-  this.end(this._callback);
+  this._end(this._callback);
   return this;
 };
 
@@ -806,7 +807,7 @@ Request.prototype.callback = function(err, res){
  * @api public
  */
 
-Request.prototype.end = function(fn){
+Request.prototype._end = function(fn){
   var self = this;
   var data = this._data;
   var req = this.request();
@@ -1024,6 +1025,26 @@ Request.prototype.end = function(fn){
 };
 
 /**
+ * Initiate request, invoking callback `fn(err, res)`
+ * with an instanceof `Response`.
+ *
+ * @param {Function} fn
+ * @return {Promise}
+ * @api public
+ */
+
+Request.prototype.end = function (fn) {
+  var self = this;
+  return new Promise(function (resolve, reject) {
+    self._end(function(err, res) {
+      fn && fn(err, res);
+      err ? reject(err) : resolve(res);
+    });
+  });
+};
+
+
+/**
  * Faux promise support
  *
  * @param {Function} fulfill
@@ -1032,10 +1053,10 @@ Request.prototype.end = function(fn){
  */
 
 Request.prototype.then = function (fulfill, reject) {
-  return this.end(function(err, res) {
+  return this._end(function(err, res) {
     err ? reject(err) : fulfill(res);
   });
-}
+};
 
 /**
  * To json.
@@ -1076,7 +1097,7 @@ exports.Request = Request;
 function request(method, url) {
   // callback
   if ('function' == typeof url) {
-    return new Request('GET', method).end(url);
+    return new Request('GET', method)._end(url);
   }
 
   // url first
@@ -1096,7 +1117,7 @@ methods.forEach(function(method){
     var req = request(method, url);
     if ('function' == typeof data) fn = data, data = null;
     if (data) req.send(data);
-    fn && req.end(fn);
+    fn && req._end(fn);
     return req;
   };
 });

--- a/package.json
+++ b/package.json
@@ -21,17 +21,18 @@
     "url": "git://github.com/visionmedia/superagent.git"
   },
   "dependencies": {
-    "qs": "2.3.3",
-    "formidable": "1.0.14",
-    "mime": "1.3.4",
     "component-emitter": "1.1.2",
-    "methods": "1.0.1",
     "cookiejar": "2.0.1",
     "debug": "2",
-    "reduce-component": "1.0.1",
+    "es6-promise": "3.0.2",
     "extend": "1.2.1",
     "form-data": "0.2.0",
-    "readable-stream": "1.0.27-1"
+    "formidable": "1.0.14",
+    "methods": "1.0.1",
+    "mime": "1.3.4",
+    "qs": "2.3.3",
+    "readable-stream": "1.0.27-1",
+    "reduce-component": "1.0.1"
   },
   "devDependencies": {
     "basic-auth-connect": "~1.0.0",

--- a/test/basic.js
+++ b/test/basic.js
@@ -309,8 +309,9 @@ describe('request', function(){
   describe('.abort()', function(){
     it('should abort the request', function(done){
       var req = request
-      .get(uri + '/delay/3000')
-      .end(function(err, res){
+      .get(uri + '/delay/3000');
+
+      req.end(function(err, res){
         assert(false, 'should not complete the request');
       });
 

--- a/test/client/request.js
+++ b/test/client/request.js
@@ -500,8 +500,9 @@ it('GET querystring multiple objects', function(next){
 it('GET querystring empty objects', function(next){
   var req = request
   .get('/querystring')
-  .query({})
-  .end(function(err, res){
+  .query({});
+
+  req.end(function(err, res){
     assert.deepEqual(req._query, []);
     assert.deepEqual(res.body, {});
     next();
@@ -633,8 +634,9 @@ it('progress event listener on xhr object registered when some on the request', 
   var req = request
   .get('/foo')
   .on('progress', function(data) {
-  })
-  .end();
+  });
+
+  req.end();
 
   if (req.xhr.upload) { // Only run assertion on capable browsers
     assert(null !== req.xhr.upload.onprogress);
@@ -643,8 +645,9 @@ it('progress event listener on xhr object registered when some on the request', 
 
 it('no progress event listener on xhr object when none registered on request', function(){
   var req = request
-  .get('/foo')
-  .end();
+  .get('/foo');
+
+  req.end();
 
   if (req.xhr.upload) { // Only run assertion on capable browsers
     assert(null === req.xhr.upload.onprogress);

--- a/test/node/redirects-other-host.js
+++ b/test/node/redirects-other-host.js
@@ -36,8 +36,9 @@ describe('request.get', function(){
     it('should follow Location with a GET request', function(done){
       var req = request
         .get('http://localhost:3210/test-301')
-        .redirects(1)
-        .end(function(err, res){
+        .redirects(1);
+
+      req.end(function(err, res){
           req.req._headers.host.should.eql('localhost:3211');
           res.status.should.eql(200);
           res.text.should.eql('GET');
@@ -49,8 +50,9 @@ describe('request.get', function(){
     it('should follow Location with a GET request', function(done){
       var req = request
         .get('http://localhost:3210/test-302')
-        .redirects(1)
-        .end(function(err, res){
+        .redirects(1);
+
+      req.end(function(err, res){
           req.req._headers.host.should.eql('localhost:3211');
           res.status.should.eql(200);
           res.text.should.eql('GET');
@@ -62,8 +64,9 @@ describe('request.get', function(){
     it('should follow Location with a GET request', function(done){
       var req = request
         .get('http://localhost:3210/test-303')
-        .redirects(1)
-        .end(function(err, res){
+        .redirects(1);
+
+      req.end(function(err, res){
           req.req._headers.host.should.eql('localhost:3211');
           res.status.should.eql(200);
           res.text.should.eql('GET');
@@ -75,8 +78,9 @@ describe('request.get', function(){
     it('should follow Location with a GET request', function(done){
       var req = request
         .get('http://localhost:3210/test-307')
-        .redirects(1)
-        .end(function(err, res){
+        .redirects(1);
+
+      req.end(function(err, res){
           req.req._headers.host.should.eql('localhost:3211');
           res.status.should.eql(200);
           res.text.should.eql('GET');
@@ -88,8 +92,8 @@ describe('request.get', function(){
     it('should follow Location with a GET request', function(done){
       var req = request
         .get('http://localhost:3210/test-308')
-        .redirects(1)
-        .end(function(err, res){
+        .redirects(1);
+      req.end(function(err, res){
           req.req._headers.host.should.eql('localhost:3211');
           res.status.should.eql(200);
           res.text.should.eql('GET');
@@ -104,8 +108,9 @@ describe('request.post', function(){
     it('should follow Location with a GET request', function(done){
       var req = request
         .post('http://localhost:3210/test-301')
-        .redirects(1)
-        .end(function(err, res){
+        .redirects(1);
+
+      req.end(function(err, res){
           req.req._headers.host.should.eql('localhost:3211');
           res.status.should.eql(200);
           res.text.should.eql('GET');
@@ -117,8 +122,9 @@ describe('request.post', function(){
     it('should follow Location with a GET request', function(done){
       var req = request
         .post('http://localhost:3210/test-302')
-        .redirects(1)
-        .end(function(err, res){
+        .redirects(1);
+
+      req.end(function(err, res){
           req.req._headers.host.should.eql('localhost:3211');
           res.status.should.eql(200);
           res.text.should.eql('GET');
@@ -130,8 +136,9 @@ describe('request.post', function(){
     it('should follow Location with a GET request', function(done){
       var req = request
         .post('http://localhost:3210/test-303')
-        .redirects(1)
-        .end(function(err, res){
+        .redirects(1);
+
+      req.end(function(err, res){
           req.req._headers.host.should.eql('localhost:3211');
           res.status.should.eql(200);
           res.text.should.eql('GET');
@@ -143,8 +150,9 @@ describe('request.post', function(){
     it('should follow Location with a POST request', function(done){
       var req = request
         .post('http://localhost:3210/test-307')
-        .redirects(1)
-        .end(function(err, res){
+        .redirects(1);
+
+      req.end(function(err, res){
           req.req._headers.host.should.eql('localhost:3211');
           res.status.should.eql(200);
           res.text.should.eql('POST');
@@ -156,8 +164,9 @@ describe('request.post', function(){
     it('should follow Location with a POST request', function(done){
       var req = request
         .post('http://localhost:3210/test-308')
-        .redirects(1)
-        .end(function(err, res){
+        .redirects(1);
+
+        req.end(function(err, res){
           req.req._headers.host.should.eql('localhost:3211');
           res.status.should.eql(200);
           res.text.should.eql('POST');


### PR DESCRIPTION
End doesn't return anymore the request instance but a promise.
End still support callbacks.
End is usually the end of a call chain so i believe make it return a promise makes sense
Ex : 
```js
request.post('api/pet')
.end()
.then(function (res) { console.log(res) })
.catch(function (err) { console.log(err) })
```