### PR TITLE
Don't modify the query string, but preserve its encoding

### DIFF
--- a/lib/node/index.js
+++ b/lib/node/index.js
@@ -650,6 +650,7 @@ Request.prototype.redirect = function(res){
   this._redirectList.push(url);
   this.emit('redirect', res);
   this.qs = {};
+  this.qsRaw = [];
   this.set(headers);
   this.end(this._callback);
   return this;
@@ -716,7 +717,7 @@ Request.prototype.request = function(){
 
   // default to http://
   if (0 != url.indexOf('http')) url = 'http://' + url;
-  url = parse(url, true);
+  url = parse(url);
 
   // options
   options.method = this.method;
@@ -756,7 +757,8 @@ Request.prototype.request = function(){
   }
 
   // query
-  this.query(url.query);
+  if (url.search)
+    this.query(url.search.substr(1));
 
   // add cookies
   if (this.cookies) req.setHeader('Cookie', this.cookies);

--- a/test/node/basic.js
+++ b/test/node/basic.js
@@ -8,6 +8,17 @@ var request = require('../../');
 
 describe('[node] request', function(){
 
+  describe('with an url', function(){
+    it('should preserve the encoding of the url', function(done){
+      request
+      .get('http://localhost:5000/url?a=(b%29')
+      .end(function(err, res){
+        assert('/url?a=(b%29' == res.text);
+        done();
+      })
+    })
+  })
+
   describe('with an object', function(){
     it('should format the url', function(done){
       request

--- a/test/support/server.js
+++ b/test/support/server.js
@@ -9,6 +9,10 @@ app.use(function(req, res, next) {
   next();
 });
 
+app.all('/url', function(req, res){
+  res.send(req.url);
+});
+
 app.all('/echo', function(req, res){
   res.writeHead(200, req.headers);
   req.pipe(res);


### PR DESCRIPTION
Currently, if you pass an URL as string, the **query string is parsed and regenerated**.

On the one hand, this **introduces overhead**, because such parsing and generation is not necessary.

More importantly, however, it **destroys the original encoding of the passed URL**. Therefore, it is currently impossible to use superagent with servers that are sensitive to encoding. In particular, we cannot use superagent (and thus supertest) to verify whether a server correctly reacts to different encodings. For instance, if we want to try `http://example.org/a?q=(b)` and `http://example.org/a?q=%28b%29`, superagent would in both cases send `http://example.org/a?q=(b)` to the server.

This commit preserves the original URL encoding by adding the query string to `qsRaw` rather than `qs`.