### PR TITLE
Allow custom parser in Request [was: Fixes #740]

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -640,6 +640,20 @@ Request.prototype.type = function(type){
 };
 
 /**
+ * Force given parser
+ * 
+ * Sets the body parser no matter type.
+ * 
+ * @param {Function}
+ * @api public
+ */
+
+Request.prototype.parse = function(fn){
+  this._parser = fn;
+  return this;
+};
+
+/**
  * Set Accept to `type`, mapping values from `request.types`.
  *
  * Examples:
@@ -961,7 +975,7 @@ Request.prototype.end = function(fn){
   if ('GET' != this.method && 'HEAD' != this.method && 'string' != typeof data && !isHost(data)) {
     // serialize stuff
     var contentType = this.getHeader('Content-Type');
-    var serialize = request.serialize[contentType ? contentType.split(';')[0] : ''];
+    var serialize = this._parser || request.serialize[contentType ? contentType.split(';')[0] : ''];
     if (serialize) data = serialize(data);
   }
 

--- a/test/client/request.js
+++ b/test/client/request.js
@@ -659,6 +659,26 @@ it('no progress event listener on xhr object when none registered on request', f
   }
 });
 
+it('Request#parse overrides body parser no matter Content-Type', function(done){
+  var runParser = false;
+  
+  function testParser(data){
+    runParser = true;
+    return JSON.stringify(data);
+  }
+  
+  var req = request
+  .post('/user')
+  .parse(testParser)
+  .type('json')
+  .send({ foo: 123 })
+  .end(function(err) {
+    if (err) return done(err);
+    assert(runParser);
+    done();
+  });
+});
+
 // Don't run on browsers without xhr2 support
 if ('FormData' in window) {
   it('xhr2 download file', function(next) {


### PR DESCRIPTION
Added parse method to Request class instead of Response