### PR TITLE
605: adds delete verb support and maintains del verb support

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -1076,11 +1076,14 @@ request.head = function(url, data, fn){
  * @api public
  */
 
-request.del = function(url, fn){
+function del(url, fn){
   var req = request('DELETE', url);
   if (fn) req.end(fn);
   return req;
 };
+
+request.del = del;
+request.delete = del;
 
 /**
  * PATCH `url` with optional `data` and callback `fn(res)`.

--- a/lib/node/agent.js
+++ b/lib/node/agent.js
@@ -55,9 +55,10 @@ Agent.prototype.attachCookies = function(req){
 };
 
 // generate HTTP verb methods
-
+methods.indexOf('del') == -1 && methods.push('del');
 methods.forEach(function(method){
-  var name = 'delete' == method ? 'del' : method;
+  var name = method;
+  method = 'del' == method ? 'delete' : method;
 
   method = method.toUpperCase();
   Agent.prototype[name] = function(url, fn){

--- a/lib/node/index.js
+++ b/lib/node/index.js
@@ -1088,9 +1088,11 @@ function request(method, url) {
 }
 
 // generate HTTP verb methods
-
+methods.indexOf('del') == -1 && methods.push('del');
 methods.forEach(function(method){
-  var name = 'delete' == method ? 'del' : method;
+  var name = method;
+  method = 'del' == method ? 'delete' : method;
+
   method = method.toUpperCase();
   request[name] = function(url, data, fn){
     var req = request(method, url);

--- a/test/client/request.js
+++ b/test/client/request.js
@@ -175,6 +175,13 @@ it('del()', function(next){
   });
 });
 
+it('delete()', function(next){
+  request.delete('/user/12').end(function(err, res){
+    assert('deleted' == res.text, 'response text');
+    next();
+  });
+});
+
 it('post() data', function(next){
   request.post('/todo/item')
   .type('application/octet-stream')


### PR DESCRIPTION
Addresses #605. This maintains support for 'del' while adding 'delete' so that it's not a breaking change. On the client side it maps the same function that was used for 'del' to both verbs. On the server side it adds 'del' to the list of methods if it isn't there and maps them both to the 'DELETE' request. Added a test for the client that's the same as del. Doesn't seem like this should be an issue with 'use strict' but I could easily add a test for that since it can be scoped to a function.