### PR TITLE
confusing behaviour of buffer setting for custom parsers

### DIFF
--- a/lib/node/index.js
+++ b/lib/node/index.js
@@ -948,7 +948,7 @@ Request.prototype.end = function(fn){
     // explicit parser
     if (parser) parse = parser;
 
-    // parse
+    // // parse
     if (parse) {
       try {
         parse(res, function(err, obj){
@@ -957,17 +957,27 @@ Request.prototype.end = function(fn){
           self.response = res;
           response.body = obj;
           response.redirects = self._redirectList;
+          self.emit('end');
           self.emit('response', response);
           self.callback(null, response);
-          self.emit('end');
-          return;
         });
       } catch (err) {
         self.callback(err);
         return;
       }
-      return this;
+      return;
     }
+    // if (parse) {
+    //   try {
+    //     parse(res, function(err, obj){
+    //       if (err) self.callback(err);
+    //       res.body = obj;
+    //     });
+    //   } catch (err) {
+    //     self.callback(err);
+    //     return;
+    //   }
+    // }
 
     // unbuffered
     if (!buffer) {

--- a/lib/node/index.js
+++ b/lib/node/index.js
@@ -948,36 +948,20 @@ Request.prototype.end = function(fn){
     // explicit parser
     if (parser) parse = parser;
 
-    // // parse
-    if (parse) {
+    // parse
+    if (parse) {//either add !buffer && parse to avoid confising
+              // behaviour when you set false but body still buffered
       try {
+        buffer=true// otherwise  using parser means access to body, req.body === buffering
         parse(res, function(err, obj){
           if (err) self.callback(err);
-          var response = new Response(self);
-          self.response = res;
-          response.body = obj;
-          response.redirects = self._redirectList;
-          self.emit('end');
-          self.emit('response', response);
-          self.callback(null, response);
+          res.body = obj;
         });
       } catch (err) {
         self.callback(err);
         return;
       }
-      return;
     }
-    // if (parse) {
-    //   try {
-    //     parse(res, function(err, obj){
-    //       if (err) self.callback(err);
-    //       res.body = obj;
-    //     });
-    //   } catch (err) {
-    //     self.callback(err);
-    //     return;
-    //   }
-    // }
 
     // unbuffered
     if (!buffer) {

--- a/lib/node/index.js
+++ b/lib/node/index.js
@@ -953,12 +953,20 @@ Request.prototype.end = function(fn){
       try {
         parse(res, function(err, obj){
           if (err) self.callback(err);
-          res.body = obj;
+          var response = new Response(self);
+          self.response = res;
+          response.body = obj;
+          response.redirects = self._redirectList;
+          self.emit('response', response);
+          self.callback(null, response);
+          self.emit('end');
+          return;
         });
       } catch (err) {
         self.callback(err);
         return;
       }
+      return this;
     }
 
     // unbuffered


### PR DESCRIPTION
Looks like custom parsing didn’t propagate correct response object back
