### PR TITLE
ensure query string is appended when doing stream.pipe(request)

### DIFF
--- a/lib/node/index.js
+++ b/lib/node/index.js
@@ -132,6 +132,7 @@ function Request(method, url) {
   this.qs = {};
   this.qsRaw = [];
   this._redirectList = [];
+  this._streamRequest = false;
   this.on('end', this.clearTimeout.bind(this));
 }
 
@@ -474,7 +475,17 @@ Request.prototype.send = function(data){
  */
 
 Request.prototype.write = function(data, encoding){
-  return this.request().write(data, encoding);
+  var req = this.request();
+  if (!this._streamRequest) {
+    this._streamRequest = true;
+    try {
+      // ensure querystring is appended before headers are sent
+      this.appendQueryString(req);
+    } catch (e) {
+      return this.emit('error', e);
+    }
+  }
+  return req.write(data, encoding);
 };
 
 /**
@@ -798,6 +809,21 @@ Request.prototype.callback = function(err, res){
 };
 
 /**
+ * Compose querystring to append to req.path
+ *
+ * @return {String} querystring
+ * @api private
+ */
+
+Request.prototype.appendQueryString = function(req){
+  var querystring = qs.stringify(this.qs, { indices: false });
+  querystring += ((querystring.length && this.qsRaw.length) ? '&' : '') + this.qsRaw.join('&');
+  req.path += querystring.length
+    ? (~req.path.indexOf('?') ? '&' : '?') + querystring
+    : '';
+};
+
+/**
  * Initiate request, invoking callback `fn(err, res)`
  * with an instanceof `Response`.
  *
@@ -820,11 +846,7 @@ Request.prototype.end = function(fn){
 
   // querystring
   try {
-    var querystring = qs.stringify(this.qs, { indices: false });
-    querystring += ((querystring.length && this.qsRaw.length) ? '&' : '') + this.qsRaw.join('&');
-    req.path += querystring.length
-      ? (~req.path.indexOf('?') ? '&' : '?') + querystring
-      : '';
+    this.appendQueryString(req);
   } catch (e) {
     return this.callback(e);
   }

--- a/test/node/query.js
+++ b/test/node/query.js
@@ -2,6 +2,7 @@
 var request = require('../..')
   , express = require('express')
   , assert = require('better-assert')
+  , fs = require('fs')
   , app = express();
 
 app.get('/', function(req, res){
@@ -9,6 +10,10 @@ app.get('/', function(req, res){
 });
 
 app.delete('/', function(req, res){
+  res.status(200).send(req.query);
+});
+
+app.put('/', function(req, res){
   res.status(200).send(req.query);
 });
 
@@ -139,5 +144,17 @@ describe('req.query(Object)', function(){
       res.body.should.eql({ name: 'tobi' });
       done();
     });
+  });
+
+  it('query-string should be sent on pipe', function(done){
+    var req = request.put('http://localhost:3006/?name=tobi');
+    var stream = fs.createReadStream('test/node/fixtures/user.json');
+
+    req.on('response', function(res){
+      res.body.should.eql({ name: 'tobi' });
+      done();
+    });
+
+    stream.pipe(req);
   });
 })


### PR DESCRIPTION
Query string is missing from request path when using stream.pipe(request)

node repl test case:
```
var express = require('express'), fs = require('fs'), request = require('superagent');
express().put('/', function(req,res){ console.log("url=" + req.url) }).listen(3006);
fs.createReadStream('README.md').pipe(request.put('http://localhost:3006/?foo=bar'));
```
expected output: url=/?foo=bar
actual output: url=/

The problem: the query is appended to req.path in end() which is run after the 
headers have been sent when the request is treated as a writable stream, so the
path sent to the server is always missing the query.

My attempt at a fix: the first time write() is called, set a flag indicating
that the request is being treated as a writable stream.  If this is the case we 
need to append the query string to req.path before the first write() causes 
the headers to be sent.

I'm not super familiar with this library, but this seemed like decent
fix that would solve the problem while keeping the existing behavior of 
passing any query-related error to the end() callback, for the more common
case of calling req.end() rather than stream.pipe(req) to send the request.