### PR TITLE
Fix to avoid throwing errors on aborted requests

### DIFF
--- a/lib/node/index.js
+++ b/lib/node/index.js
@@ -952,7 +952,7 @@ Request.prototype.end = function(fn){
     if (parse) {
       try {
         parse(res, function(err, obj){
-          if (err) self.callback(err);
+          if (err && !self._aborted) self.callback(err);
           res.body = obj;
         });
       } catch (err) {

--- a/test/node/parsers.js
+++ b/test/node/parsers.js
@@ -20,7 +20,6 @@ app.get('/image', function(req, res){
 app.get('/chunked-json', function(req, res){
   res.set('content-type', 'application/json');
   res.set('Transfer-Encoding', 'chunked');
-  res.flushHeaders();
 
   var chunk = 0;
   var interval = setInterval(function(){


### PR DESCRIPTION
I'm downloading large sets of json files using superagent from a slow server. In some cases, I need to abort the request using `.abort()` method.
When the json is in the middle of the transfer, I get a syntax error when superagent tries to parse the partially transfered json string. 
I think that on aborted requests, the parser shouldn't throw any error.

Thanks for the good work, and let me know if I can help fixing this.