### PR TITLE
Add "Found" to test. Tests now pass on io.js 3.0.0 and node.js 4.0.0

### DIFF
--- a/test/node/redirects.js
+++ b/test/node/redirects.js
@@ -229,7 +229,7 @@ describe('request', function(){
         arr.push('/movies');
         arr.push('/movies/all');
         redirects.should.eql(arr);
-        res.text.should.match(/Moved Temporarily/);
+        res.text.should.match(/Moved Temporarily|Found/);
         done();
       });
     })


### PR DESCRIPTION
In io.js version 3.0.0 the text of HTTP response code 302 was changed from "Moved Temporarily" to "Found" to bring it in line with the specification. See [1]. In order to support older Node versions (0.10, 0.12), older io.js versions (1.0.0, 2.0.0), and future versions (io.js 3.0.0 and Node 4.0.0). I changed the test to look for either message. Now the tests are passing on all versions of Node that I mentioned. 

Note: this PR addresses the stacktrace part of issue #773 (Node 4 support), but does not resolve that issue. I'm still wondering what the policy is for superagent supporting current versions on Node including the LTS release. 

[1] https://github.com/nodejs/node/wiki/Breaking-Changes