### PR TITLE
misc fixes found at twitter

### DIFF
--- a/lib/node/index.js
+++ b/lib/node/index.js
@@ -978,8 +978,11 @@ Request.prototype.end = function(fn){
       return;
     }
 
-    // end event
+    // terminating events
     self.res = res;
+    res.on('error', function(err){
+      self.callback(err, null);
+    });
     res.on('end', function(){
       debug('end %s %s', self.method, self.url);
       // TODO: unless buffering emit earlier to stream

--- a/lib/node/parsers/json.js
+++ b/lib/node/parsers/json.js
@@ -5,8 +5,7 @@ module.exports = function parseJSON(res, fn){
   res.on('data', function(chunk){ res.text += chunk;});
   res.on('end', function(){
     try {
-      var text = res.text && res.text.replace(/^\s*|\s*$/g, '');
-      var body = text && JSON.parse(text);
+      var body = res.text && JSON.parse(res.text);
     } catch (e) {
       var err = e;
     } finally {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "superagent",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "elegant & feature rich browser / node HTTP with a fluent API",
   "scripts": {
     "test": "make test"

--- a/test/node/inflate.js
+++ b/test/node/inflate.js
@@ -1,5 +1,6 @@
 
 var request = require('../../')
+  , assert = require('assert')
   , express = require('express')
   , zlib
 
@@ -23,6 +24,10 @@ if (zlib) {
       res.send(buf);
     });
   });
+  app.get('/corrupt', function(req, res){
+    res.set('Content-Encoding', 'gzip');
+    res.send(buf);
+  });
 
   app.get('/', function (req, res, next){
     zlib.deflate(subject, function (err, buf){
@@ -40,6 +45,16 @@ if (zlib) {
           res.should.have.status(200);
           res.text.should.equal(subject);
           res.headers['content-length'].should.be.below(subject.length);
+          done();
+        });
+    });
+
+    it('should handle corrupted responses', function(done){
+      request
+        .get('http://localhost:3080/corrupt')
+        .end(function(err, res){
+          assert(err, 'missing error');
+          assert(!res, 'response should not be defined');
           done();
         });
     });


### PR DESCRIPTION
- don't strip json before parsing (slow on large strings, not needed)
- fix error-triggering on corrupted compressed streams (issue #776)

This test is failing in master and is not fixed
```
  1) request req.redirects(n) should alter the default number of redirects to follow:
     Uncaught AssertionError: expected 'Found. Redirecting to /movies/all/0' to match /Moved Temporarily/
      at Assertion.prop.(anonymous function) (/Users/jbellenger/workspace/superagent/node_modules/should/lib/should.js:60:14)
      at /Users/jbellenger/workspace/superagent/test/node/redirects.js:232:25
      at Request.callback (/Users/jbellenger/workspace/superagent/lib/node/index.js:797:3)
      at IncomingMessage.<anonymous> (/Users/jbellenger/workspace/superagent/lib/node/index.js:993:12)
      at emitNone (events.js:72:20)
      at IncomingMessage.emit (events.js:166:7)
      at endReadableNT (_stream_readable.js:893:12)
      at doNTCallback2 (node.js:429:9)
      at process._tickCallback (node.js:343:17)
```