### PR TITLE
Fix IE 10/11 issue with `XMLHttpRequest.send(undefined)`

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -992,7 +992,19 @@ Request.prototype.end = function(fn){
 
   // send stuff
   this.emit('request', this);
-  xhr.send(data);
+
+  if (typeof data !== 'undefined') {
+    xhr.send(data);
+  } else {
+    // The XMLHttpRequest specification does not explicitly define `send(undefined)`, but `send()`
+    // or `send(null)` are accepted. While most browsers treat `undefined` and `null` as acceptable,
+    // IE 10/11 convert `undefined` into the body "undefined" with text/plain as the content type.
+    //
+    // XMLHttpRequest Level 1: http://www.w3.org/TR/XMLHttpRequest/#the-send()-method
+    // XMLHttpRequest Living Standard: https://xhr.spec.whatwg.org/#the-send()-method
+    xhr.send();
+  }
+
   return this;
 };
 

--- a/test/client/request.js
+++ b/test/client/request.js
@@ -185,6 +185,15 @@ it('post() data', function(next){
   });
 });
 
+it('post() with no data', function(next){
+  request.post('/echo')
+  .send()
+  .end(function(err, res){
+    assert('' == res.text, 'response text');
+    next();
+  });
+});
+
 it('request .type()', function(next){
   request
   .post('/user/12/pet')


### PR DESCRIPTION
### What's the goal of this change?

Fixes an issue where `Request#end` would call `XMLHttpRequest.send(undefined)`, causing an issue in Internet Explorer 10 and 11. In these browsers, `XMLHttpRequest.send(undefined)` will cause a request body of "undefined" to be sent by the browser (e.g. on a POST). This causes the `XMLHttpRequest` to assume a request body of type `text/plain` (as Content-Type), which confuses some server software.

### What's the change?

Before this change, calling `Request#end` without supplying a request body would cause a call to `XMLHttpRequest.send(undefined)`. After the change, `Request#end` calls `XMLHttpRequest.send(data)` if data is defined for the request, or `XMLHttpRequest.send()` if no data is defined.

### How do you reproduce the browser behavior?

You can make a call to http://httpbin.org/post, which returns the HTTP request that it's sent. Here's how you can verify:

```javascript
 function requestListener () {
  var json = JSON.parse(this.responseText);
  console.log({
    data: json.data,
    contentLength: json.headers['Content-Length'],
    contentType: json.headers['Content-Type']
  })
}

var request = new XMLHttpRequest();
request.addEventListener("load", requestListener);
request.open("POST", "https://httpbin.org/post");
request.send(undefined);
```

On IE 11, you'll get this:

```javascript
{
   data: "undefined"
   contentLength: "9",
   contentType: "text/plain;charset=UTF-8",
}
```

On Chrome (I'm running `47.0.2526.58 beta (64-bit)`), you'll get this:

```javascript
{
  data: "",
  contentLength: "0",
  contentType: undefined
}
```

If you then change `send(undefined)` to `send()`...

```javascript
 function requestListener () {
  var json = JSON.parse(this.responseText);
  console.log({
    data: json.data,
    contentLength: json.headers['Content-Length'],
    contentType: json.headers['Content-Type']
  })
}

var request = new XMLHttpRequest();
request.addEventListener("load", requestListener);
request.open("POST", "https://httpbin.org/post");
request.send();
```

As you might intuitively expect, this is now what you'll get from IE 11:

```javascript
{
  data: "",
  contentLength: "0",
  contentType: undefined
}
```

And you still get the same from Chrome 47 (obviously not a very comprehensive test, but a regression in the content delivered in other browsers than IE is covered by the test I added):

```javascript
{
  data: "",
  contentLength: "0",
  contentType: undefined
}
```

### Is this change correct?

This change is in compliance with the "Level 1" and "Living Standard" standards documents for [XMLHttpRequest] (https://xhr.spec.whatwg.org/#the-send()-method), which permits a call to `send()` without parameters. It also appears that calling `send(undefined)` is not explicitly permitted by the standard, although most browsers seem to treat `null` and `undefined` equally.

I've added a test to verify the behavior. Before the fix, I verified that the test did not run on IE 10/11 prior to the fix (using the Sauce Labs setup locally).