### PR TITLE
travis: add node 4.0,4.1 and iojs to travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,12 @@
 sudo: false
-
 language: node_js
+node_js:
+  - "4.1"
+  - "4.0"
+  - "0.12"
+  - "0.11"
+  - "0.10"
+  - "iojs"
 
 env:
   global:
@@ -9,7 +15,5 @@ env:
 
 matrix:
   include:
-    - node_js: "0.10"
-    - node_js: "0.12"
     - node_js: "0.10"
       env: BROWSER=1


### PR DESCRIPTION
WIP - don't merge

Fixes #787 

I tested on https://travis-ci.org/olalonde/superagent but I'm getting this error on the browser test (could be a temporary bug with localtunnel.me):

```sh
- passed: <firefox 42 on Mac 10.8>
- queuing: <android 5.1 on Linux>
events.js:72
        throw er; // Unhandled 'error' event
              ^
Error: connection refused: localtunnel.me:43772 (check your firewall settings)
    at Socket.<anonymous> (/home/travis/build/olalonde/superagent/node_modules/zuul/node_modules/zuul-localtunnel/node_modules/localtunnel/client.js:84:32)
    at Socket.emit (events.js:95:17)
    at net.js:441:14
    at process._tickCallback (node.js:448:13)
    at Socket.Readable.on (_stream_readable.js:708:33)
    at TunnelCluster.open (/home/travis/build/olalonde/superagent/node_modules/zuul/node_modules/zuul-localtunnel/node_modules/localtunnel/client.js:80:12)
    at null.<anonymous> (/home/travis/build/olalonde/superagent/node_modules/zuul/node_modules/zuul-localtunnel/node_modules/localtunnel/client.js:269:17)
    at emit (events.js:92:17)
```

Also, tests fail in node 4.1. 