### PR TITLE
Avoid the error which is emitted from 'socket hang up' to cause the fn undefined error on JS runtime.

### DIFF
--- a/lib/node/index.js
+++ b/lib/node/index.js
@@ -764,7 +764,8 @@ Request.prototype.request = function(){
  */
 
 Request.prototype.callback = function(err, res){
-  var fn = this._callback;
+  // Avoid the error which is omitted from 'socket hang up' to cause the fn undefined error on JS runtime.
+  var fn = this._callback || noop; 
   this.clearTimeout();
   if (this.called) return console.warn('double callback!');
   this.called = true;

--- a/lib/node/index.js
+++ b/lib/node/index.js
@@ -764,7 +764,7 @@ Request.prototype.request = function(){
  */
 
 Request.prototype.callback = function(err, res){
-  // Avoid the error which is omitted from 'socket hang up' to cause the fn undefined error on JS runtime.
+  // Avoid the error which is emitted from 'socket hang up' to cause the fn undefined error on JS runtime.
   var fn = this._callback || noop; 
   this.clearTimeout();
   if (this.called) return console.warn('double callback!');


### PR DESCRIPTION
Avoid the error which is emitted from 'socket hang up' to cause the `fn undefined error` on JS runtime.

while event `req.error` is emitted:

```
req.on('error', function(err){
    // flag abortion here for out timeouts
    // because node will emit a faux-error "socket hang up"
    // when request is aborted before a connection is made
    if (self._aborted) return;
    self.callback(err);
  });
```

because only `prototype.end()` and `prototype.redirect()` had assigned the value to `this._callback`, so if the `req.on('error')` event is fired -> `self.callback(error)`, it will cause `prototype.callback()` to throw the `undefined` runtime error.
