### PR TITLE
Avoid misleading CORS error message

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -894,8 +894,13 @@ Request.prototype.callback = function(err, res){
  */
 
 Request.prototype.crossDomainError = function(){
-  var err = new Error('Origin is not allowed by Access-Control-Allow-Origin');
+  var err = new Error('Request has been terminated\nPossible causes: the network is offline, Origin is not allowed by Access-Control-Allow-Origin, the page is being unloaded, etc.');
   err.crossDomain = true;
+
+  err.status = this.status;
+  err.method = this.method;
+  err.url = this.url;
+
   this.callback(err);
 };
 


### PR DESCRIPTION
A backward-compatible fix for #484

I still think it should be changed to a completely different error in 2.0, but I also want to fix it quickly for 1.x users.