### PR TITLE
Don't let request error override responses

### DIFF
--- a/lib/node/index.js
+++ b/lib/node/index.js
@@ -735,6 +735,9 @@ Request.prototype.request = function(){
     // because node will emit a faux-error "socket hang up"
     // when request is aborted before a connection is made
     if (self._aborted) return;
+    // if we've recieved a response then we don't want to let
+    // an error in the request blow up the response
+    if (self.response) return;
     self.callback(err);
   });
 


### PR DESCRIPTION
Talking to certain servers I was seeing the following error, even when the response was 200 OK

```
Error: read ECONNRESET
    at exports._errnoException (util.js:855:11)
    at TCP.onread (net.js:544:26)
```