### PR TITLE
fix `delete` breaking on ie8

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -1126,8 +1126,8 @@ function del(url, fn){
   return req;
 };
 
-request.del = del;
-request.delete = del;
+request['del'] = del;
+request['delete'] = del;
 
 /**
  * PATCH `url` with optional `data` and callback `fn(res)`.


### PR DESCRIPTION
Please check if mergeable.

I want to use this nice library on Ie8 with no error...
(I know it supports `>=ie9`)

Thank you.
