### PR TITLE
allow rejectUnauthorized to be set to false for https request

### DIFF
--- a/lib/node/index.js
+++ b/lib/node/index.js
@@ -691,6 +691,18 @@ Request.prototype.ca = function(cert){
 };
 
 /**
+ * Set the `rejectUnauthorized` option for underlying https request options.
+ *
+ * @return {Request} for chaining
+ * @api public
+ */
+
+Request.prototype.disableStrictSSL = function(){
+  this._rejectUnauthorized = false;
+  return this;
+};
+
+/**
  * Allow for extension
  */
 
@@ -725,6 +737,7 @@ Request.prototype.request = function(){
   options.host = url.hostname;
   options.ca = this._ca;
   options.agent = this._agent;
+  options.rejectUnauthorized = this._rejectUnauthorized;
 
   // initiate request
   var mod = exports.protocols[url.protocol];

--- a/test/node/https.js
+++ b/test/node/https.js
@@ -35,6 +35,17 @@ describe('https', function(){
         done();
       });
     });
+
+    it('should give a good response without strict SSL', function(done){
+      request
+      .get('https://localhost:8443/')
+      .disableStrictSSL()
+      .end(function(err, res){
+        assert(res.ok);
+        assert('Safe and secure!' === res.text);
+        done();
+      });
+    });
   });
 
   describe('.agent', function () {


### PR DESCRIPTION
use `.disableStrictSSL()`, otherwise defaults to true

This is a valid use case, because simply ignoring security for the entire process with `process.env.NODE_TLS_REJECT_UNAUTHORIZED = 0` is unacceptable, and should be allowed to be set on a per request basis.

Related: https://github.com/visionmedia/superagent/issues/188 and https://github.com/visionmedia/superagent/issues/205