### PR TITLE
Add "withCredentials" to Node API, fixes #586

### DIFF
--- a/lib/node/index.js
+++ b/lib/node/index.js
@@ -821,6 +821,16 @@ Request.prototype.callback = function(err, res){
  * @api public
  */
 
+/**
+* Client API parity, irrelevant in a Node context.
+*
+* @api public
+*/
+
+Request.prototype.withCredentials = function(){
+  return this;
+};
+
 Request.prototype.end = function(fn){
   var self = this;
   var data = this._data;

--- a/test/node/basic.js
+++ b/test/node/basic.js
@@ -165,6 +165,18 @@ describe('[node] request', function(){
     })
   })
 
+  describe('.withCredentials()', function(){
+    it('should not throw an error when using the client-side "withCredentials" method', function(done){
+      request
+      .get('http://localhost:5000/custom')
+      .withCredentials()
+      .end(function(err, res){
+        assert(null == err);
+        done();
+      });
+    })
+  })
+
   describe('.agent()', function(){
     it('should return the defaut agent', function(done){
       var req = request.post('http://localhost:5000/echo');


### PR DESCRIPTION
This is a fix for https://github.com/visionmedia/superagent/issues/586.

This change adds the equivalent of a no-op to the `Request` prototype, which simply returns `this`, as this method is irrelevant in a Node context.

I've also added a test for this, so hopefully this PR is pretty straightforward :)