### PR TITLE
Add 'direction' property to 'progress' events

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -965,6 +965,7 @@ Request.prototype.end = function(fn){
     if (e.total > 0) {
       e.percent = e.loaded / e.total * 100;
     }
+    e.direction = 'download';
     self.emit('progress', e);
   };
   if (this.hasListeners('progress')) {

--- a/lib/node/index.js
+++ b/lib/node/index.js
@@ -1052,6 +1052,7 @@ Request.prototype.end = function(fn){
         progress._transform = function (chunk, encoding, cb) {
           loaded += chunk.length;
           self.emit('progress', {
+            direction: 'upload',
             lengthComputable: lengthComputable,
             loaded: loaded,
             total: total

--- a/test/node/multipart.js
+++ b/test/node/multipart.js
@@ -148,12 +148,14 @@ describe('Request', function(){
     it('should fire progress event', function(done){
       var loaded = 0;
       var total = 0;
+      var direction = '';
       request
       .post(':3005/echo')
       .attach('document', 'test/node/fixtures/user.html')
       .on('progress', function (event) {
         total = event.total;
         loaded = event.loaded;
+        direction = event.direction;
       })
       .end(function(err, res){
         if (err) return done(err);
@@ -163,6 +165,7 @@ describe('Request', function(){
         read(html.path).should.equal('<h1>name</h1>');
         total.should.equal(221);
         loaded.should.equal(221);
+        direction.should.equal('upload');
         done();
       })
     })

--- a/test/node/multipart.js
+++ b/test/node/multipart.js
@@ -148,14 +148,16 @@ describe('Request', function(){
     it('should fire progress event', function(done){
       var loaded = 0;
       var total = 0;
-      var direction = '';
+      var uploadEventWasFired = false;
       request
       .post(':3005/echo')
       .attach('document', 'test/node/fixtures/user.html')
       .on('progress', function (event) {
         total = event.total;
         loaded = event.loaded;
-        direction = event.direction;
+        if (event.direction === 'upload') {
+          uploadEventWasFired = true;
+        }
       })
       .end(function(err, res){
         if (err) return done(err);
@@ -165,7 +167,7 @@ describe('Request', function(){
         read(html.path).should.equal('<h1>name</h1>');
         total.should.equal(221);
         loaded.should.equal(221);
-        direction.should.equal('upload');
+        uploadEventWasFired.should.equal(true);
         done();
       })
     })


### PR DESCRIPTION
Fixes #803. (The docs should be added during #807.)

So the client only emits `'progress'` during a download, and the node version only emits `'progress'` during an upload?
I was under the impression that the node version would emit `'progress'` during uploads and downloads, but it doesn't look like it does. And the changelog seems to back that up.

I wonder if `'upload'` and `'download'` are the wrong terms, because they imply where the request/response is going, but what we actually know is whether it is a request or a response.