### PR TITLE
Default filename to files name

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -791,7 +791,7 @@ Request.prototype.field = function(name, val){
 
 Request.prototype.attach = function(field, file, filename){
   if (!this._formData) this._formData = new root.FormData();
-  this._formData.append(field, file, filename);
+  this._formData.append(field, file, filename || file.name);
   return this;
 };
 

--- a/lib/node/index.js
+++ b/lib/node/index.js
@@ -197,6 +197,8 @@ Request.prototype.attach = function(field, file, filename){
     if (!filename) filename = file;
     debug('creating `fs.ReadStream` instance for file: %s', file);
     file = fs.createReadStream(file);
+  } else if(!filename && file.path) {
+    filename = file.path;
   }
   this._formData.append(field, file, { filename: filename });
   return this;

--- a/test/client/request.js
+++ b/test/client/request.js
@@ -46,6 +46,24 @@ it('POST native FormData', function(next){
     });
 });
 
+it('defaults attached files to original file names', function(next){
+  if (!window.FormData) {
+    // Skip test if FormData is not supported by browser
+    return next();
+  }
+
+  var file = new File([""], "image.jpg", { type: "image/jpeg" });
+
+  request
+    .post('/echo')
+    .attach('image', file)
+    .end(function(err, res){
+      var regx = new RegExp('filename="' + file.name + '"');
+      assert(res.text.match(regx) !== null);
+      next();
+    });
+});
+
 it('GET invalid json', function(next) {
   request
   .get('/invalid-json')

--- a/test/client/request.js
+++ b/test/client/request.js
@@ -48,11 +48,16 @@ it('POST native FormData', function(next){
 
 it('defaults attached files to original file names', function(next){
   if (!window.FormData) {
-    // Skip test if FormData is not supported by browser
+    // Skip test if FormData is are not supported by browser
     return next();
   }
 
-  var file = new File([""], "image.jpg", { type: "image/jpeg" });
+  try {
+    var file = new File([""], "image.jpg", { type: "image/jpeg" });
+  } catch(e) {
+    // Skip if file constructor not supported.
+    return next();
+  }
 
   request
     .post('/echo')


### PR DESCRIPTION
This fixes #843 

I didn't add tests because I was unsure how to get them running. I got some error about no saucelabs credentials when I tried to run the tests.

__client__
I am assuming the file param is always expected to be a `File` object.

__node__
I am assuming the file param is expected to be an `fs.ReadStream` if not a string.

