### PR TITLE
Add .dataFilter function prior to parsing of body

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -328,6 +328,7 @@ function params(str){
 
 function Response(req, options) {
   options = options || {};
+
   this.req = req;
   this.xhr = this.req.xhr;
   // responseText is accessible only if responseType is '' or 'text' and on older browsers
@@ -343,7 +344,7 @@ function Response(req, options) {
   this.header['content-type'] = this.xhr.getResponseHeader('content-type');
   this.setHeaderProperties(this.header);
   this.body = this.req.method != 'HEAD'
-    ? this.parseBody(this.text ? this.text : this.xhr.response)
+    ? this.parseBody(this.text ? this.text : this.xhr.response, options.dataFilter)
     : null;
 }
 
@@ -387,13 +388,21 @@ Response.prototype.setHeaderProperties = function(header){
  * Used for auto-parsing of bodies. Parsers
  * are defined on the `superagent.parse` object.
  *
+ * If a dataFilter function is passed to the request, the return from that function is
+ * what is parsed. If nothing is returned, use the original str.
+ *
  * @param {String} str
  * @return {Mixed}
  * @api private
  */
 
-Response.prototype.parseBody = function(str){
+Response.prototype.parseBody = function(str, dataFilter){
   var parse = request.parse[this.type];
+
+  if (Object.prototype.toString.call(dataFilter) === '[object Function]') {
+    str = dataFilter(str) || str;
+  }
+
   return parse && str && (str.length || str instanceof Object)
     ? parse(str)
     : null;
@@ -499,7 +508,9 @@ function Request(method, url) {
     var res = null;
 
     try {
-      res = new Response(self);
+      res = new Response(self, {
+        dataFilter: this._dataFilterFn
+      });
     } catch(e) {
       err = new Error('Parser is unable to parse the response');
       err.parse = true;
@@ -925,6 +936,18 @@ Request.prototype.withCredentials = function(){
 };
 
 /**
+ * Allow transformation of response data before parsing
+ *
+ * @param {Function} fn
+ * @returns {Request} for chaining
+ * @api public
+ */
+Request.prototype.dataFilter = function(fn) {
+  this._dataFilterFn = fn;
+  return this;
+};
+
+/**
  * Initiate request, invoking callback `fn(res)`
  * with an instanceof `Response`.
  *
@@ -1039,7 +1062,7 @@ Request.prototype.then = function (fulfill, reject) {
   return this.end(function(err, res) {
     err ? reject(err) : fulfill(res);
   });
-}
+};
 
 /**
  * Expose `Request`.

--- a/test/client/request.js
+++ b/test/client/request.js
@@ -143,14 +143,14 @@ it('Request#parse overrides body parser no matter Content-Type', function(done){
 
 it('response with dataFilter applied', function(next){
   request
-      .get(uri + '/foo')
+      .get('/querystring', { search: 'Manny' })
       .dataFilter(function() {
         return JSON.stringify({
-          foo: 'not bar'
+          search: 'Billy'
         });
       })
       .on('response', function(res){
-        assert('not bar' == res.body.foo);
+        assert.deepEqual(res.body, { search: 'Billy' });
         next();
       })
       .end();

--- a/test/client/request.js
+++ b/test/client/request.js
@@ -141,6 +141,21 @@ it('Request#parse overrides body parser no matter Content-Type', function(done){
   });
 });
 
+it('response with dataFilter applied', function(next){
+  request
+      .get(uri + '/foo')
+      .dataFilter(function() {
+        return JSON.stringify({
+          foo: 'not bar'
+        });
+      })
+      .on('response', function(res){
+        assert('not bar' == res.body.foo);
+        next();
+      })
+      .end();
+});
+
 // Don't run on browsers without xhr2 support
 if ('FormData' in window) {
   it('xhr2 download file', function(next) {


### PR DESCRIPTION
This function allows you to transform the data prior to parsing of the body. It attempts not to be opinionated on the type of data or what you are trying to do to it. The basic application:
```
request
  .get('url.com/foo')
  .dataFilter((data) => {
    return data.replace(/text_to_strip/g, '');
  })
  .end((err, res) => {
    console.log(res.body); // will have text_to_strip removed globally from the data
  });
```
The original application I was striving for was stripping of XSS prefixes / postfixes, however I tried to make it more generalized so that it could be used for a multitude of purposes. This method is only applied in the parseBody function, and if nothing is returned from the callback passed then it falls back to the original str value passed to parseBody.

Apologies in advance for the lack of commit squashing.