### PR TITLE
Redirect after a multipart/form-data POST

### DIFF
--- a/lib/node/index.js
+++ b/lib/node/index.js
@@ -637,7 +637,8 @@ Request.prototype.redirect = function(res){
   delete headers.host;
 
   delete this.req;
-
+  delete this._formData;
+  
   // remove all add header except User-Agent
   for (var key in this.header) {
     if (key !== 'User-Agent') {

--- a/test/node/redirects.js
+++ b/test/node/redirects.js
@@ -265,6 +265,28 @@ describe('request', function(){
       });
     })
   })
+  
+  describe('on POST using multipart/form-data', function(){
+    it('should redirect as GET', function(done){
+      var redirects = [];
+
+      request
+      .post('http://localhost:3003/movie')
+      .type('form')
+      .field('name', 'Tobi')
+      .redirects(2)
+      .on('redirect', function(res){
+        redirects.push(res.headers.location);
+      })
+      .end(function(err, res){
+        var arr = [];
+        arr.push('/movies/all/0');
+        redirects.should.eql(arr);
+        res.text.should.equal('first movie page');
+        done();
+      });
+    })
+  })
 
   describe('on 303', function(){
     it('should redirect with same method', function(done){


### PR DESCRIPTION
This might be related to other multipart/form-data issues.

It occurs when the "Content-Type" header is set to "multipart/form-data" during the request, followed by a redirect response from the server. In the code, a FormData instance is created during the POST request, but it's not cleared within the redirect function. This prevents the callback ( req.end(data) ) at around line 1070 from running and the script hangs.
```
      formData.pipe(getProgressMonitor()).pipe(req);
    });
  } else {
    req.end(data);
  }

```
This is probably a temporary fix. I suppose there are cases where keeping the FormData around during the redirect might be desirable. 

Here's some standalone test code I was using.
```
var http = require('http');
var server = http.createServer(listener);
var superagent = require('superagent');
var assert = require('assert');

server.on('error', onError);
server.on('listening', onListening);

server.listen(8888);

var successBody = 'Redirected!';
var url = 'http://localhost:8888';
var url_redirect = '/redirect';

function onListening() {
	
	console.log('Listening');
	
	console.log('Attempting text/html request');
	superagent
	.get(url)
	.set('Content-Type', 'text/html')
	.end(function(err, res) {
		
		assert.equal(res.text, successBody, 'Did not redirect from text/html request.');
		
		console.log('Attempting multipart/form-data request...');
		
		var redirects = [];
		superagent
		.post(url)
		.type('multipart/form-data')
		.field('testfield','test value')
		.end(function(err, res) {
			assert.equal(res.text, successBody);
			console.log('Success!');
			server.close();
		});
		
	});
}

function listener(req, res) {
	
	if(req.url == url_redirect){
		res.end(successBody);
	}
	else{
		res.writeHead(303, 
				{
					'Content-Type':'text/html',
					'Location':url_redirect
				}
			);
		res.end('Redirecting...');
	}
	
}

function onError(error) {
	throw error;
}
```