### PR TITLE
Fixed conflict with express (and possibly other libraries) when using npm 3.x

### DIFF
--- a/lib/node/agent.js
+++ b/lib/node/agent.js
@@ -55,7 +55,13 @@ Agent.prototype.attachCookies = function(req){
 };
 
 // generate HTTP verb methods
-methods.indexOf('del') == -1 && methods.push('del');
+if (methods.indexOf('del') == -1) {
+  // create a copy so we don't cause conflicts with
+  // other packages using the methods package and
+  // npm 3.x
+  methods = methods.slice(0);
+  methods.push('del');
+}
 methods.forEach(function(method){
   var name = method;
   method = 'del' == method ? 'delete' : method;

--- a/lib/node/index.js
+++ b/lib/node/index.js
@@ -1162,7 +1162,13 @@ function request(method, url) {
 }
 
 // generate HTTP verb methods
-methods.indexOf('del') == -1 && methods.push('del');
+if (methods.indexOf('del') == -1) {
+  // create a copy so we don't cause conflicts with
+  // other packages using the methods package and
+  // npm 3.x
+  methods = methods.slice(0);
+  methods.push('del');
+}
 methods.forEach(function(method){
   var name = method;
   method = 'del' == method ? 'delete' : method;


### PR DESCRIPTION
This is caused by superagent modifying the list of http methods coming from the 'methods' package. In npm 2.x this isn't usually a problem as superagent uses its own copy of the methods package, however in npm 3.x all packages are deduped, so express, superagent, and other libraries all share the same package. 

The fix is to create a shallow copy before modifying the list for superagents use so that other libraries are not affected.