### PR TITLE
Fix case-sensitivity in node header introduced by a4ddd6a

### DIFF
--- a/lib/node/index.js
+++ b/lib/node/index.js
@@ -125,7 +125,7 @@ function Request(method, url) {
   this.method = method;
   this.url = url;
   this.header = {
-    'User-Agent': 'node-superagent/' + pkg.version
+    'user-agent': 'node-superagent/' + pkg.version
   };
   this.writable = true;
   this._redirects = 0;
@@ -249,6 +249,7 @@ Request.prototype.agent = function(agent){
 
 /**
  * Set header `field` to `val`, or multiple fields with one object.
+ * Case-insensitive.
  *
  * Examples:
  *
@@ -276,12 +277,13 @@ Request.prototype.set = function(field, val){
   }
 
   debug('set %s "%s"', field, val);
-  this.header[field] = val;
+  this.header[field.toLowerCase()] = val;
   return this;
 };
 
 /**
  * Remove header `field`.
+ * Case-insensitive.
  *
  * Example:
  *
@@ -297,12 +299,13 @@ Request.prototype.set = function(field, val){
 Request.prototype.unset = function(field){
   debug('unset %s', field);
 
-  delete this.header[field];
+  delete this.header[field.toLowerCase()];
   return this;
 };
 
 /**
  * Get request header `field`.
+ * Case-insensitive.
  *
  * @param {String} field
  * @return {String}
@@ -310,7 +313,7 @@ Request.prototype.unset = function(field){
  */
 
 Request.prototype.get = function(field){
-  return this.header[field];
+  return this.header[field.toLowerCase()];
 };
 
 /**
@@ -651,7 +654,7 @@ Request.prototype.redirect = function(res){
 
   delete this.req;
   delete this._formData;
-  
+
   // remove all add header except User-Agent
   for (var key in this.header) {
     if (key !== 'User-Agent') {

--- a/test/node/basic.js
+++ b/test/node/basic.js
@@ -104,6 +104,21 @@ describe('[node] request', function(){
     })
   })
 
+  describe('case-insensitive', function(){
+    it('should set/get header fields case-insensitively', function(){
+      var r = request.post('http://localhost:5000/echo');
+      r.set('MiXeD', 'helloes');
+      assert(r.get('mixed') === 'helloes');
+    });
+
+    it('should unset header fields case-insensitively', function () {
+      var r = request.post('http://localhost:5000/echo');
+      r.set('MiXeD', 'helloes');
+      r.unset('MIXED');
+      assert(r.get('mixed') === undefined);
+    });
+  });
+
   describe('req.write(str)', function(){
     it('should write the given data', function(done){
       var req = request.post('http://localhost:5000/echo');


### PR DESCRIPTION
a4ddd6a introduces case-sensitivity in header set(), get(), and unset(), which is inconsistent with Node HTTP module and the HTTP spec itself. It also borks some superagent addons such as [superagent-hawk](https://github.com/CrowdProcess/superagent-hawk/blob/master/index.js#L31).