### PR TITLE
bump extend dependency due to missing license information

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "cookiejar": "2.0.6",
     "debug": "2",
     "reduce-component": "1.0.1",
-    "extend": "1.2.1",
+    "extend": "3.0.0",
     "form-data": "0.2.0",
     "readable-stream": "1.0.27-1"
   },


### PR DESCRIPTION
For a project of mine it is necessary, that all dependencies have license information.

Unfortunately superagents `extend` dependency does not contain any license information.

Therefore I bumped this dependency.