### PR TITLE
avoid TCP port conflicts in all tests

### DIFF
--- a/test/node/agency.js
+++ b/test/node/agency.js
@@ -51,7 +51,14 @@ app.get('/simple', function(req, res) {
   res.status(200).send('simple');
 });
 
-app.listen(4000);
+var base = 'http://localhost'
+var server;
+before(function listen(done) {
+  server = app.listen(0, function listening() {
+    base += ':' + server.address().port;
+    done();
+  });
+});
 
 describe('request', function() {
   describe('persistent agent', function() {
@@ -62,7 +69,7 @@ describe('request', function() {
 
     it('should gain a session on POST', function(done) {
       agent3
-        .post('http://localhost:4000/signin')
+        .post(base + '/signin')
         .end(function(err, res) {
           should.not.exist(err);
           res.should.have.status(200);
@@ -74,7 +81,7 @@ describe('request', function() {
 
     it('should start with empty session (set cookies)', function(done) {
       agent1
-        .get('http://localhost:4000/dashboard')
+        .get(base + '/dashboard')
         .end(function(err, res) {
           should.exist(err);
           res.should.have.status(401);
@@ -85,7 +92,7 @@ describe('request', function() {
 
     it('should gain a session (cookies already set)', function(done) {
       agent1
-        .post('http://localhost:4000/signin')
+        .post(base + '/signin')
         .end(function(err, res) {
           should.not.exist(err);
           res.should.have.status(200);
@@ -97,7 +104,7 @@ describe('request', function() {
 
     it('should persist cookies across requests', function(done) {
       agent1
-        .get('http://localhost:4000/dashboard')
+        .get(base + '/dashboard')
         .end(function(err, res) {
           should.not.exist(err);
           res.should.have.status(200);
@@ -107,10 +114,10 @@ describe('request', function() {
 
     it('should have the cookie set in the end callback', function(done) {
       agent4
-        .post('http://localhost:4000/setcookie')
+        .post(base + '/setcookie')
         .end(function(err, res) {
           agent4
-            .get('http://localhost:4000/getcookie')
+            .get(base + '/getcookie')
             .end(function(err, res) {
               should.not.exist(err);
               res.should.have.status(200);
@@ -122,7 +129,7 @@ describe('request', function() {
 
     it('should not share cookies', function(done) {
       agent2
-        .get('http://localhost:4000/dashboard')
+        .get(base + '/dashboard')
         .end(function(err, res) {
           should.exist(err);
           res.should.have.status(401);
@@ -132,7 +139,7 @@ describe('request', function() {
 
     it('should not lose cookies between agents', function(done) {
       agent1
-        .get('http://localhost:4000/dashboard')
+        .get(base + '/dashboard')
         .end(function(err, res) {
           should.not.exist(err);
           res.should.have.status(200);
@@ -142,7 +149,7 @@ describe('request', function() {
 
     it('should be able to follow redirects', function(done) {
       agent1
-        .get('http://localhost:4000/')
+        .get(base)
         .end(function(err, res) {
           should.not.exist(err);
           res.should.have.status(200);
@@ -153,20 +160,20 @@ describe('request', function() {
 
     it('should be able to post redirects', function(done) {
       agent1
-        .post('http://localhost:4000/redirect')
+        .post(base + '/redirect')
         .send({ foo: 'bar', baz: 'blaaah' })
         .end(function(err, res) {
           should.not.exist(err);
           res.should.have.status(200);
           res.text.should.include('simple');
-          res.redirects.should.eql(['http://localhost:4000/simple']);
+          res.redirects.should.eql([base + '/simple']);
           done();
         });
     });
 
     it('should be able to limit redirects', function(done) {
       agent1
-        .get('http://localhost:4000/')
+        .get(base)
         .redirects(0)
         .end(function(err, res) {
           should.exist(err);
@@ -179,7 +186,7 @@ describe('request', function() {
 
     it('should be able to create a new session (clear cookie)', function(done) {
       agent1
-        .post('http://localhost:4000/signout')
+        .post(base + '/signout')
         .end(function(err, res) {
           should.not.exist(err);
           res.should.have.status(200);
@@ -190,7 +197,7 @@ describe('request', function() {
 
     it('should regenerate with an empty session', function(done) {
       agent1
-        .get('http://localhost:4000/dashboard')
+        .get(base + '/dashboard')
         .end(function(err, res) {
           should.exist(err);
           res.should.have.status(401);

--- a/test/node/basic-auth.js
+++ b/test/node/basic-auth.js
@@ -14,13 +14,20 @@ app.get('/basic-auth/again', basicAuth('tobi', ''), function(req, res){
   res.end('you win again!');
 });
 
-app.listen(3010);
+var base = 'http://localhost'
+var server;
+before(function listen(done) {
+  server = app.listen(0, function listening() {
+    base += ':' + server.address().port;
+    done();
+  });
+});
 
 describe('Basic auth', function(){
   describe('when credentials are present in url', function(){
     it('should set Authorization', function(done){
       request
-      .get('http://tobi:learnboost@localhost:3010/basic-auth')
+      .get('http://tobi:learnboost@localhost:' + server.address().port + '/basic-auth')
       .end(function(err, res){
         res.status.should.equal(200);
         done();
@@ -31,7 +38,7 @@ describe('Basic auth', function(){
   describe('req.auth(user, pass)', function(){
     it('should set Authorization', function(done){
       request
-      .get('http://localhost:3010/basic-auth')
+      .get(base + '/basic-auth')
       .auth('tobi', 'learnboost')
       .end(function(err, res){
         res.status.should.equal(200);
@@ -43,7 +50,7 @@ describe('Basic auth', function(){
   describe('req.auth(user + ":" + pass)', function(){
     it('should set authorization', function(done){
       request
-      .get('http://localhost:3010/basic-auth/again')
+      .get(base + '/basic-auth/again')
       .auth('tobi')
       .end(function(err, res){
         res.status.should.eql(200);

--- a/test/node/flags.js
+++ b/test/node/flags.js
@@ -29,14 +29,21 @@ app.get('/no-content', function(req, res){
   res.status(204).end();
 });
 
-app.listen(3004);
+var base = 'http://localhost'
+var server;
+before(function listen(done) {
+  server = app.listen(0, function listening() {
+    base += ':' + server.address().port;
+    done();
+  });
+});
 
 describe('flags', function(){
 
   describe('with 4xx response', function(){
     it('should set res.error and res.clientError', function(done){
       request
-      .get('http://localhost:3004/notfound')
+      .get(base + '/notfound')
       .end(function(err, res){
         assert(err);
         assert(!res.ok, 'response should not be ok');
@@ -51,7 +58,7 @@ describe('flags', function(){
   describe('with 5xx response', function(){
     it('should set res.error and res.serverError', function(done){
       request
-      .get('http://localhost:3004/error')
+      .get(base + '/error')
       .end(function(err, res){
         assert(err);
         assert(!res.ok, 'response should not be ok');
@@ -67,7 +74,7 @@ describe('flags', function(){
   describe('with 404 Not Found', function(){
     it('should res.notFound', function(done){
       request
-      .get('http://localhost:3004/notfound')
+      .get(base + '/notfound')
       .end(function(err, res){
         assert(err);
         assert(res.notFound, 'response should be .notFound');
@@ -79,7 +86,7 @@ describe('flags', function(){
   describe('with 400 Bad Request', function(){
     it('should set req.badRequest', function(done){
       request
-      .get('http://localhost:3004/bad-request')
+      .get(base + '/bad-request')
       .end(function(err, res){
         assert(err);
         assert(res.badRequest, 'response should be .badRequest');
@@ -91,7 +98,7 @@ describe('flags', function(){
   describe('with 401 Bad Request', function(){
     it('should set res.unauthorized', function(done){
       request
-      .get('http://localhost:3004/unauthorized')
+      .get(base + '/unauthorized')
       .end(function(err, res){
         assert(err);
         assert(res.unauthorized, 'response should be .unauthorized');
@@ -103,7 +110,7 @@ describe('flags', function(){
   describe('with 406 Not Acceptable', function(){
     it('should set res.notAcceptable', function(done){
       request
-      .get('http://localhost:3004/not-acceptable')
+      .get(base + '/not-acceptable')
       .end(function(err, res){
         assert(err);
         assert(res.notAcceptable, 'response should be .notAcceptable');
@@ -115,7 +122,7 @@ describe('flags', function(){
   describe('with 204 No Content', function(){
     it('should set res.noContent', function(done){
       request
-      .get('http://localhost:3004/no-content')
+      .get(base + '/no-content')
       .end(function(err, res){
         assert(!err);
         assert(res.noContent, 'response should be .noContent');

--- a/test/node/form.js
+++ b/test/node/form.js
@@ -14,13 +14,20 @@ app.get('/form-data', function(req, res){
   res.send('pet[name]=manny');
 });
 
-app.listen(3002);
+var base = 'http://localhost'
+var server;
+before(function listen(done) {
+  server = app.listen(0, function listening() {
+    base += ':' + server.address().port;
+    done();
+  });
+});
 
 describe('req.send(Object) as "form"', function(){
   describe('with req.type() set to form', function(){
     it('should send x-www-form-urlencoded data', function(done){
       request
-      .post('http://localhost:3002/echo')
+      .post(base + '/echo')
       .type('form')
       .send({ name: 'tobi' })
       .end(function(err, res){
@@ -34,7 +41,7 @@ describe('req.send(Object) as "form"', function(){
   describe('when called several times', function(){
     it('should merge the objects', function(done){
       request
-      .post('http://localhost:3002/echo')
+      .post(base + '/echo')
       .type('form')
       .send({ name: { first: 'tobi', last: 'holowaychuk' } })
       .send({ age: '1' })
@@ -50,7 +57,7 @@ describe('req.send(Object) as "form"', function(){
 describe('req.send(String)', function(){
   it('should default to "form"', function(done){
     request
-    .post('http://localhost:3002/echo')
+    .post(base + '/echo')
     .send('user[name]=tj')
     .send('user[email]=tj@vision-media.ca')
     .end(function(err, res){
@@ -65,7 +72,7 @@ describe('res.body', function(){
   describe('application/x-www-form-urlencoded', function(){
     it('should parse the body', function(done){
       request
-      .get('http://localhost:3002/form-data')
+      .get(base + '/form-data')
       .end(function(err, res){
         res.text.should.equal('pet[name]=manny');
         res.body.should.eql({ pet: { name: 'manny' }});

--- a/test/node/https.js
+++ b/test/node/https.js
@@ -20,14 +20,22 @@ server = https.createServer({
   cert: cert
 }, app);
 
-server.listen(8443);
+// WARNING: this .listen() boilerplate is slightly different from most tests
+// due to HTTPS. Do not copy/paste without examination.
+var base = 'https://localhost'
+before(function listen(done) {
+  server.listen(0, function listening() {
+    base += ':' + server.address().port;
+    done();
+  });
+});
 
 describe('https', function(){
 
   describe('request', function(){
     it('should give a good response', function(done){
       request
-      .get('https://localhost:8443/')
+      .get(base)
       .ca(cert)
       .end(function(err, res){
         assert(res.ok);
@@ -41,12 +49,12 @@ describe('https', function(){
     it('should be able to make multiple requests without redefining the certificate', function(done){
       var agent = request.agent({ca: cert});
       agent
-      .get('https://localhost:8443/')
+      .get(base)
       .end(function(err, res){
         assert(res.ok);
         assert('Safe and secure!' === res.text);
         agent
-        .get(url.parse('https://localhost:8443/'))
+        .get(url.parse(base))
         .end(function(err, res){
           assert(res.ok);
           assert('Safe and secure!' === res.text);

--- a/test/node/image.js
+++ b/test/node/image.js
@@ -19,12 +19,19 @@ describe('res.body', function(){
     res.end(img, 'binary');
   });
 
-  app.listen(3011);
+var base = 'http://localhost'
+var server;
+before(function listen(done) {
+  server = app.listen(0, function listening() {
+    base += ':' + server.address().port;
+    done();
+  });
+});
 
   describe('image/png', function(){
     it('should parse the body', function(done){
       request
-      .get('http://localhost:3011/image')
+      .get(base + '/image')
       .end(function(err, res){
         (res.body.length - img.length).should.equal(0);
         done();

--- a/test/node/incoming-multipart.js
+++ b/test/node/incoming-multipart.js
@@ -24,12 +24,19 @@
 //   }, 1000);
 // });
 
-// app.listen(3007);
+// var base = 'http://localhost'
+// var server;
+// before(function listen(done) {
+//   server = app.listen(0, function listening() {
+//     base += ':' + server.address().port;
+//     done();
+//   });
+// });
 
 // describe('request multipart/form-data', function(){
 //   describe('req.body', function(){
 //     it('should be populated with fields', function(done){
-//       request.get('http://localhost:3007/', function(err, res){
+//       request.get(base, function(err, res){
 //         if (err) return done(err);
 //         res.status.should.equal(200);
 //         res.body.should.eql({ name: 'tobi' });

--- a/test/node/inflate.js
+++ b/test/node/inflate.js
@@ -16,8 +16,14 @@ if (zlib) {
   var app = express()
     , subject = 'some long long long long string';
 
-  app.listen(3080);
-
+  var base = 'http://localhost'
+  var server;
+  before(function listen(done) {
+    server = app.listen(0, function listening() {
+      base += ':' + server.address().port;
+      done();
+    });
+  });
   app.get('/binary', function(req, res){
     zlib.deflate(subject, function (err, buf){
       res.set('Content-Encoding', 'gzip');
@@ -40,7 +46,7 @@ if (zlib) {
   describe('zlib', function(){
     it('should deflate the content', function(done){
       request
-        .get('http://localhost:3080')
+        .get(base)
         .end(function(err, res){
           res.should.have.status(200);
           res.text.should.equal(subject);
@@ -51,7 +57,7 @@ if (zlib) {
 
     it('should handle corrupted responses', function(done){
       request
-        .get('http://localhost:3080/corrupt')
+        .get(base + '/corrupt')
         .end(function(err, res){
           assert(err, 'missing error');
           assert(!res, 'response should not be defined');
@@ -62,7 +68,7 @@ if (zlib) {
     describe('without encoding set', function(){
       it('should emit buffers', function(done){
         request
-          .get('http://localhost:3080/binary')
+          .get(base + '/binary')
           .end(function(err, res){
             res.should.have.status(200);
             res.headers['content-length'].should.be.below(subject.length);

--- a/test/node/multipart.js
+++ b/test/node/multipart.js
@@ -14,8 +14,14 @@ app.post('/echo', function(req, res){
   req.pipe(res);
 });
 
-var server = app.listen();
-
+var base = 'http://localhost'
+var server;
+before(function listen(done) {
+  server = app.listen(0, function listening() {
+    base += ':' + server.address().port;
+    done();
+  });
+});
 // function boundary(ct) {
 //   return ct.match(/boundary="(.*)"/)[1];
 // }
@@ -23,7 +29,7 @@ var server = app.listen();
 describe('Request', function(){
 //   describe('#part()', function(){
 //     it('should return a new Part', function(){
-//       var req = request.post('http://localhost:' + server.address().port + '');
+//       var req = request.post(base + '');
 //       req.part().constructor.name.should.equal('Part');
 //       req.part().constructor.name.should.equal('Part');
 //       req.part().should.not.equal(req.part());
@@ -31,7 +37,7 @@ describe('Request', function(){
 //   })
 
 //   it('should default res.files to {}', function(done){
-//     var req = request.post('http://localhost:' + server.address().port + '/echo');
+//     var req = request.post(base + '/echo');
 
 //     req.end(function(err, res){
 //       if (err) return done(err);
@@ -43,7 +49,7 @@ describe('Request', function(){
 
 //   describe('#field(name, value)', function(){
 //     it('should set a multipart field value', function(done){
-//       var req = request.post('http://localhost:' + server.address().port + '/echo');
+//       var req = request.post(base + '/echo');
 
 //       req.field('user[name]', 'tobi');
 //       req.field('user[age]', '2');
@@ -59,7 +65,7 @@ describe('Request', function(){
 //     })
 
 //     it('should work with file attachments', function(done){
-//       var req = request.post('http://localhost:' + server.address().port + '/echo');
+//       var req = request.post(base + '/echo');
 
 //       req.field('name', 'Tobi');
 //       req.attach('document', 'test/node/fixtures/user.html');
@@ -81,7 +87,7 @@ describe('Request', function(){
 
 //   describe('#attach(name, path)', function(){
 //     it('should attach a file', function(done){
-//       var req = request.post('http://localhost:' + server.address().port + '/echo');
+//       var req = request.post(base + '/echo');
 
 //       req.attach('one', 'test/node/fixtures/user.html');
 //       req.attach('two', 'test/node/fixtures/user.json');
@@ -111,7 +117,7 @@ describe('Request', function(){
 
 //     describe('when a file does not exist', function(){
 //       it('should emit an error', function(done){
-//         var req = request.post('http://localhost:' + server.address().port + '/echo');
+//         var req = request.post(base + '/echo');
 
 //         req.attach('name', 'foo');
 //         req.attach('name2', 'bar');
@@ -134,7 +140,7 @@ describe('Request', function(){
   describe('#attach(name, path, filename)', function(){
     it('should use the custom filename', function(done){
       request
-      .post('http://localhost:' + server.address().port + '/echo')
+      .post(base + '/echo')
       .attach('document', 'test/node/fixtures/user.html', 'doc.html')
       .end(function(err, res){
         if (err) return done(err);
@@ -150,7 +156,7 @@ describe('Request', function(){
       var total = 0;
       var uploadEventWasFired = false;
       request
-      .post('http://localhost:' + server.address().port + '/echo')
+      .post(base + '/echo')
       .attach('document', 'test/node/fixtures/user.html')
       .on('progress', function (event) {
         total = event.total;
@@ -177,7 +183,7 @@ describe('Request', function(){
 // describe('Part', function(){
 //   describe('with a single part', function(){
 //     it('should construct a multipart request', function(done){
-//       var req = request.post('http://localhost:' + server.address().port + '/echo');
+//       var req = request.post(base + '/echo');
 
 //       req
 //         .part()
@@ -200,7 +206,7 @@ describe('Request', function(){
 //   describe('with several parts', function(){
 //     it('should construct a multipart request', function(done){
 
-//       var req = request.post('http://localhost:' + server.address().port + '/echo');
+//       var req = request.post(base + '/echo');
 
 //       req.part()
 //         .set('Content-Type', 'image/png')
@@ -232,7 +238,7 @@ describe('Request', function(){
 //   describe('with a Content-Type specified', function(){
 //     it('should append the boundary', function(done){
 //       var req = request
-//         .post('http://localhost:' + server.address().port + '/echo')
+//         .post(base + '/echo')
 //         .type('multipart/form-data');
 
 //       req
@@ -253,7 +259,7 @@ describe('Request', function(){
 //   describe('#name(str)', function(){
 //     it('should set Content-Disposition to form-data and name param', function(done){
 //       var req = request
-//         .post('http://localhost:' + server.address().port + '/echo');
+//         .post(base + '/echo');
 
 //       req
 //         .part()
@@ -271,7 +277,7 @@ describe('Request', function(){
 //   describe('#attachment(name, path)', function(){
 //     it('should set Content-Disposition and Content-Type', function(done){
 //       var req = request
-//         .post('http://localhost:' + server.address().port + '/echo')
+//         .post(base + '/echo')
 //         .type('multipart/form-data');
 
 //       req

--- a/test/node/not-modified.js
+++ b/test/node/not-modified.js
@@ -12,14 +12,21 @@ app.get('/', function(req, res){
   }
 });
 
-app.listen(3008);
+var base = 'http://localhost'
+var server;
+before(function listen(done) {
+  server = app.listen(0, function listening() {
+    base += ':' + server.address().port;
+    done();
+  });
+});
 
 describe('request', function(){
   describe('not modified', function(){
     var ts;
     it('should start with 200', function(done){
       request
-      .get('http://localhost:3008/')
+      .get(base)
       .end(function(err, res){
         res.should.have.status(200)
         res.text.should.match(/^\d+$/);
@@ -30,7 +37,7 @@ describe('request', function(){
 
     it('should then be 304', function(done){
       request
-      .get('http://localhost:3008/')
+      .get(base)
       .set('If-Modified-Since', new Date(ts).toUTCString())
       .end(function(err, res){
         res.should.have.status(304)

--- a/test/node/parsers.js
+++ b/test/node/parsers.js
@@ -34,12 +34,19 @@ app.get('/chunked-json', function(req, res){
   },10);
 });
 
-app.listen(3033);
+var base = 'http://localhost'
+var server;
+before(function listen(done) {
+  server = app.listen(0, function listening() {
+    base += ':' + server.address().port;
+    done();
+  });
+});
 
 describe('req.parse(fn)', function(){
   it('should take precedence over default parsers', function(done){
     request
-    .get('http://localhost:3033/manny')
+    .get(base + '/manny')
     .parse(request.parse['application/json'])
     .end(function(err, res){
       assert(res.ok);
@@ -51,7 +58,7 @@ describe('req.parse(fn)', function(){
 
   it('should be the only parser', function(done){
     request
-    .get('http://localhost:3033/image')
+    .get(base + '/image')
     .parse(function(res, fn) {
       res.on('data', function() {});
     })
@@ -65,7 +72,7 @@ describe('req.parse(fn)', function(){
 
   it('should emit error if parser throws', function(done){
     request
-    .get('http://localhost:3033/manny')
+    .get(base + '/manny')
     .parse(function() {
       throw new Error('I am broken');
     })
@@ -78,7 +85,7 @@ describe('req.parse(fn)', function(){
 
   it('should emit error if parser returns an error', function(done){
     request
-    .get('http://localhost:3033/manny')
+    .get(base + '/manny')
     .parse(function(res, fn) {
       fn(new Error('I am broken'));
     })
@@ -91,7 +98,7 @@ describe('req.parse(fn)', function(){
 
   it('should not emit error on chunked json', function(done){
     request
-    .get('http://localhost:3033/chunked-json')
+    .get(base + '/chunked-json')
     .end(function(err){
       assert(!err);
       done();
@@ -100,7 +107,7 @@ describe('req.parse(fn)', function(){
 
   it('should not emit error on aborted chunked json', function(done){
     var req = request
-    .get('http://localhost:3033/chunked-json')
+    .get(base + '/chunked-json')
     .end(function(err){
       assert(!err);
       done();

--- a/test/node/pipe-redirect.js
+++ b/test/node/pipe-redirect.js
@@ -21,7 +21,14 @@ app.get('/movies/all/0', function (req, res) {
   res.send('first movie page');
 });
 
-app.listen(3012);
+var base = 'http://localhost'
+var server;
+before(function listen(done) {
+  server = app.listen(0, function listening() {
+    base += ':' + server.address().port;
+    done();
+  });
+});
 
 describe('pipe on redirect', function () {
   afterEach(removeTmpfile);
@@ -29,7 +36,7 @@ describe('pipe on redirect', function () {
     var stream = fs.createWriteStream('test/node/fixtures/pipe.txt');
     var redirects = [];
     var req = request
-      .get('http://localhost:3012/')
+      .get(base)
       .on('redirect', function (res) {
         redirects.push(res.headers.location);
       })

--- a/test/node/pipe.js
+++ b/test/node/pipe.js
@@ -7,17 +7,28 @@ var request = require('../../')
 
 app.use(bodyParser.json());
 
+app.get('/', function(req, res){
+  fs.createReadStream('test/node/fixtures/user.json').pipe(res);
+});
+
 app.post('/', function(req, res){
   res.send(req.body);
 });
 
-app.listen(3020);
+var base = 'http://localhost'
+var server;
+before(function listen(done) {
+  server = app.listen(0, function listening() {
+    base += ':' + server.address().port;
+    done();
+  });
+});
 
 describe('request pipe', function(){
   afterEach(removeTmpfile);
 
   it('should act as a writable stream', function(done){
-    var req = request.post('http://localhost:3020');
+    var req = request.post(base);
     var stream = fs.createReadStream('test/node/fixtures/user.json');
 
     req.type('json');
@@ -33,7 +44,7 @@ describe('request pipe', function(){
   it('should act as a readable stream', function(done){
     var stream = fs.createWriteStream('test/node/fixtures/tmp.json');
 
-    var req = request.get('http://localhost:3025');
+    var req = request.get(base);
     req.type('json');
 
     req.on('end', function(){

--- a/test/node/query.js
+++ b/test/node/query.js
@@ -17,14 +17,19 @@ app.put('/', function(req, res){
   res.status(200).send(req.query);
 });
 
-before(function(done) {
-  app.listen(3006, done);
+var base = 'http://localhost'
+var server;
+before(function listen(done) {
+  server = app.listen(0, function listening() {
+    base += ':' + server.address().port;
+    done();
+  });
 });
 
 describe('req.query(String)', function(){
   it('should supply uri malformed error to the callback', function(done){
     request
-    .get('http://localhost:3006')
+    .get(base)
     .query('name=toby')
     .query('a=\uD800')
     .query({ b: '\uD800' })
@@ -37,7 +42,7 @@ describe('req.query(String)', function(){
 
   it('should support passing in a string', function(done){
     request
-    .del('http://localhost:3006')
+    .del(base)
     .query('name=t%F6bi')
     .end(function(err, res){
       res.body.should.eql({ name: 't%F6bi' });
@@ -47,7 +52,7 @@ describe('req.query(String)', function(){
 
   it('should work with url query-string and string for query', function(done){
     request
-    .del('http://localhost:3006/?name=tobi')
+    .del(base + '/?name=tobi')
     .query('age=2%20')
     .end(function(err, res){
       res.body.should.eql({ name: 'tobi', age: '2 ' });
@@ -57,7 +62,7 @@ describe('req.query(String)', function(){
 
   it('should support compound elements in a string', function(done){
     request
-      .del('http://localhost:3006/')
+      .del(base)
       .query('name=t%F6bi&age=2')
       .end(function(err, res){
         res.body.should.eql({ name: 't%F6bi', age: '2' });
@@ -67,7 +72,7 @@ describe('req.query(String)', function(){
 
   it('should work when called multiple times with a string', function(done){
     request
-    .del('http://localhost:3006/')
+    .del(base)
     .query('name=t%F6bi')
     .query('age=2%F6')
     .end(function(err, res){
@@ -78,7 +83,7 @@ describe('req.query(String)', function(){
 
   it('should work with normal `query` object and query string', function(done){
     request
-    .del('http://localhost:3006/')
+    .del(base)
     .query('name=t%F6bi')
     .query({ age: '2' })
     .end(function(err, res){
@@ -91,7 +96,7 @@ describe('req.query(String)', function(){
 describe('req.query(Object)', function(){
   it('should construct the query-string', function(done){
     request
-    .del('http://localhost:3006/')
+    .del(base)
     .query({ name: 'tobi' })
     .query({ order: 'asc' })
     .query({ limit: ['1', '2'] })
@@ -105,7 +110,7 @@ describe('req.query(Object)', function(){
     var date = new Date(0);
 
     request
-    .del('http://localhost:3006/')
+    .del(base)
     .query({ at: date })
     .end(function(err, res){
       assert(date.toISOString() == res.body.at);
@@ -115,7 +120,7 @@ describe('req.query(Object)', function(){
 
   it('should work after setting header fields', function(done){
     request
-    .del('http://localhost:3006/')
+    .del(base)
     .set('Foo', 'bar')
     .set('Bar', 'baz')
     .query({ name: 'tobi' })
@@ -129,7 +134,7 @@ describe('req.query(Object)', function(){
 
   it('should append to the original query-string', function(done){
     request
-    .del('http://localhost:3006/?name=tobi')
+    .del(base + '/?name=tobi')
     .query({ order: 'asc' })
     .end(function(err, res) {
       res.body.should.eql({ name: 'tobi', order: 'asc' });
@@ -139,7 +144,7 @@ describe('req.query(Object)', function(){
 
   it('should retain the original query-string', function(done){
     request
-    .del('http://localhost:3006/?name=tobi')
+    .del(base + '/?name=tobi')
     .end(function(err, res) {
       res.body.should.eql({ name: 'tobi' });
       done();
@@ -147,7 +152,7 @@ describe('req.query(Object)', function(){
   });
 
   it('query-string should be sent on pipe', function(done){
-    var req = request.put('http://localhost:3006/?name=tobi');
+    var req = request.put(base + '/?name=tobi');
     var stream = fs.createReadStream('test/node/fixtures/user.json');
 
     req.on('response', function(res){

--- a/test/node/redirects-other-host.js
+++ b/test/node/redirects-other-host.js
@@ -6,39 +6,53 @@ var request = require('../../')
   , app2 = express()
   , should = require('should');
 
-app.all('/test-301', function(req, res){
-  res.redirect(301, 'http://localhost:3211/');
-});
-app.all('/test-302', function(req, res){
-  res.redirect(302, 'http://localhost:3211/');
-});
-app.all('/test-303', function(req, res){
-  res.redirect(303, 'http://localhost:3211/');
-});
-app.all('/test-307', function(req, res){
-  res.redirect(307, 'http://localhost:3211/');
-});
-app.all('/test-308', function(req, res){
-  res.redirect(308, 'http://localhost:3211/');
+var base = 'http://localhost'
+var server;
+before(function listen(done) {
+  server = app.listen(0, function listening() {
+    base += ':' + server.address().port;
+    done();
+  });
 });
 
-app.listen(3210);
+var base2 = 'http://localhost'
+var server2;
+before(function listen(done) {
+  server2 = app2.listen(0, function listening() {
+    base2 += ':' + server2.address().port;
+    done();
+  });
+});
+
+app.all('/test-301', function(req, res){
+  res.redirect(301, base2 + '/');
+});
+app.all('/test-302', function(req, res){
+  res.redirect(302, base2 + '/');
+});
+app.all('/test-303', function(req, res){
+  res.redirect(303, base2 + '/');
+});
+app.all('/test-307', function(req, res){
+  res.redirect(307, base2 + '/');
+});
+app.all('/test-308', function(req, res){
+  res.redirect(308, base2 + '/');
+});
 
 
 app2.all('/', function(req, res) {
   res.send(req.method);
 });
 
-app2.listen(3211);
-
 describe('request.get', function(){
   describe('on 301 redirect', function(){
     it('should follow Location with a GET request', function(done){
       var req = request
-        .get('http://localhost:3210/test-301')
+        .get(base + '/test-301')
         .redirects(1)
         .end(function(err, res){
-          req.req._headers.host.should.eql('localhost:3211');
+          req.req._headers.host.should.eql('localhost:' + server2.address().port);
           res.status.should.eql(200);
           res.text.should.eql('GET');
           done();
@@ -48,10 +62,10 @@ describe('request.get', function(){
   describe('on 302 redirect', function(){
     it('should follow Location with a GET request', function(done){
       var req = request
-        .get('http://localhost:3210/test-302')
+        .get(base + '/test-302')
         .redirects(1)
         .end(function(err, res){
-          req.req._headers.host.should.eql('localhost:3211');
+          req.req._headers.host.should.eql('localhost:' + server2.address().port + '');
           res.status.should.eql(200);
           res.text.should.eql('GET');
           done();
@@ -61,10 +75,10 @@ describe('request.get', function(){
   describe('on 303 redirect', function(){
     it('should follow Location with a GET request', function(done){
       var req = request
-        .get('http://localhost:3210/test-303')
+        .get(base + '/test-303')
         .redirects(1)
         .end(function(err, res){
-          req.req._headers.host.should.eql('localhost:3211');
+          req.req._headers.host.should.eql('localhost:' + server2.address().port + '');
           res.status.should.eql(200);
           res.text.should.eql('GET');
           done();
@@ -74,10 +88,10 @@ describe('request.get', function(){
   describe('on 307 redirect', function(){
     it('should follow Location with a GET request', function(done){
       var req = request
-        .get('http://localhost:3210/test-307')
+        .get(base + '/test-307')
         .redirects(1)
         .end(function(err, res){
-          req.req._headers.host.should.eql('localhost:3211');
+          req.req._headers.host.should.eql('localhost:' + server2.address().port + '');
           res.status.should.eql(200);
           res.text.should.eql('GET');
           done();
@@ -87,10 +101,10 @@ describe('request.get', function(){
   describe('on 308 redirect', function(){
     it('should follow Location with a GET request', function(done){
       var req = request
-        .get('http://localhost:3210/test-308')
+        .get(base + '/test-308')
         .redirects(1)
         .end(function(err, res){
-          req.req._headers.host.should.eql('localhost:3211');
+          req.req._headers.host.should.eql('localhost:' + server2.address().port + '');
           res.status.should.eql(200);
           res.text.should.eql('GET');
           done();
@@ -103,10 +117,10 @@ describe('request.post', function(){
   describe('on 301 redirect', function(){
     it('should follow Location with a GET request', function(done){
       var req = request
-        .post('http://localhost:3210/test-301')
+        .post(base + '/test-301')
         .redirects(1)
         .end(function(err, res){
-          req.req._headers.host.should.eql('localhost:3211');
+          req.req._headers.host.should.eql('localhost:' + server2.address().port + '');
           res.status.should.eql(200);
           res.text.should.eql('GET');
           done();
@@ -116,10 +130,10 @@ describe('request.post', function(){
   describe('on 302 redirect', function(){
     it('should follow Location with a GET request', function(done){
       var req = request
-        .post('http://localhost:3210/test-302')
+        .post(base + '/test-302')
         .redirects(1)
         .end(function(err, res){
-          req.req._headers.host.should.eql('localhost:3211');
+          req.req._headers.host.should.eql('localhost:' + server2.address().port + '');
           res.status.should.eql(200);
           res.text.should.eql('GET');
           done();
@@ -129,10 +143,10 @@ describe('request.post', function(){
   describe('on 303 redirect', function(){
     it('should follow Location with a GET request', function(done){
       var req = request
-        .post('http://localhost:3210/test-303')
+        .post(base + '/test-303')
         .redirects(1)
         .end(function(err, res){
-          req.req._headers.host.should.eql('localhost:3211');
+          req.req._headers.host.should.eql('localhost:' + server2.address().port + '');
           res.status.should.eql(200);
           res.text.should.eql('GET');
           done();
@@ -142,10 +156,10 @@ describe('request.post', function(){
   describe('on 307 redirect', function(){
     it('should follow Location with a POST request', function(done){
       var req = request
-        .post('http://localhost:3210/test-307')
+        .post(base + '/test-307')
         .redirects(1)
         .end(function(err, res){
-          req.req._headers.host.should.eql('localhost:3211');
+          req.req._headers.host.should.eql('localhost:' + server2.address().port + '');
           res.status.should.eql(200);
           res.text.should.eql('POST');
           done();
@@ -155,10 +169,10 @@ describe('request.post', function(){
   describe('on 308 redirect', function(){
     it('should follow Location with a POST request', function(done){
       var req = request
-        .post('http://localhost:3210/test-308')
+        .post(base + '/test-308')
         .redirects(1)
         .end(function(err, res){
-          req.req._headers.host.should.eql('localhost:3211');
+          req.req._headers.host.should.eql('localhost:' + server2.address().port + '');
           res.status.should.eql(200);
           res.text.should.eql('POST');
           done();

--- a/test/node/redirects.js
+++ b/test/node/redirects.js
@@ -84,7 +84,14 @@ app.get('/bad-redirect', function(req, res){
   res.status(307).end();
 });
 
-app.listen(3003);
+var base = 'http://localhost'
+var server;
+before(function listen(done) {
+  server = app.listen(0, function listening() {
+    base += ':' + server.address().port;
+    done();
+  });
+});
 
 describe('request', function(){
   describe('on redirect', function(){
@@ -92,7 +99,7 @@ describe('request', function(){
       var redirects = [];
 
       request
-      .get('http://localhost:3003/')
+      .get(base)
       .on('redirect', function(res){
         redirects.push(res.headers.location);
       })
@@ -109,7 +116,7 @@ describe('request', function(){
 
     it('should retain header fields', function(done){
       request
-      .get('http://localhost:3003/header')
+      .get(base + '/header')
       .set('X-Foo', 'bar')
       .end(function(err, res){
         res.body.should.have.property('x-foo', 'bar');
@@ -119,7 +126,7 @@ describe('request', function(){
 
     it('should remove Content-* fields', function(done){
       request
-      .post('http://localhost:3003/header')
+      .post(base + '/header')
       .type('txt')
       .set('X-Foo', 'bar')
       .set('X-Bar', 'baz')
@@ -136,7 +143,7 @@ describe('request', function(){
 
     it('should retain cookies', function(done){
       request
-      .get('http://localhost:3003/header')
+      .get(base + '/header')
       .set('Cookie', 'foo=bar;')
       .end(function(err, res){
         res.body.should.have.property('cookie', 'foo=bar;');
@@ -146,7 +153,7 @@ describe('request', function(){
 
     it('should preserve timeout across redirects', function(done){
       request
-      .get('http://localhost:3003/movies/random')
+      .get(base + '/movies/random')
       .timeout(250)
       .end(function(err, res){
         assert(err instanceof Error, 'expected an error');
@@ -160,7 +167,7 @@ describe('request', function(){
       var query = [];
 
       request
-      .get('http://localhost:3003/?foo=bar')
+      .get(base + '/?foo=bar')
       .on('redirect', function(res){
         query.push(res.headers.query);
         redirects.push(res.headers.location);
@@ -181,7 +188,7 @@ describe('request', function(){
 
     it('should handle no location header', function(done){
       request
-      .get('http://localhost:3003/bad-redirect')
+      .get(base + '/bad-redirect')
       .end(function(err, res){
         err.message.should.equal('No location header for redirect');
         done();
@@ -193,7 +200,7 @@ describe('request', function(){
         var redirects = [];
 
         request
-        .get('http://localhost:3003/relative')
+        .get(base + '/relative')
         .on('redirect', function(res){
           redirects.push(res.headers.location);
         })
@@ -209,7 +216,7 @@ describe('request', function(){
         var redirects = [];
 
         request
-        .get('http://localhost:3003/relative/sub')
+        .get(base + '/relative/sub')
         .on('redirect', function(res){
           redirects.push(res.headers.location);
         })
@@ -228,7 +235,7 @@ describe('request', function(){
       var redirects = [];
 
       request
-      .get('http://localhost:3003/')
+      .get(base)
       .redirects(2)
       .on('redirect', function(res){
         redirects.push(res.headers.location);
@@ -250,7 +257,7 @@ describe('request', function(){
       var redirects = [];
 
       request
-      .post('http://localhost:3003/movie')
+      .post(base + '/movie')
       .send({ name: 'Tobi' })
       .redirects(2)
       .on('redirect', function(res){
@@ -265,13 +272,13 @@ describe('request', function(){
       });
     })
   })
-  
+
   describe('on POST using multipart/form-data', function(){
     it('should redirect as GET', function(done){
       var redirects = [];
 
       request
-      .post('http://localhost:3003/movie')
+      .post(base + '/movie')
       .type('form')
       .field('name', 'Tobi')
       .redirects(2)
@@ -291,7 +298,7 @@ describe('request', function(){
   describe('on 303', function(){
     it('should redirect with same method', function(done){
       request
-      .put('http://localhost:3003/redirect-303')
+      .put(base + '/redirect-303')
       .send({msg: "hello"})
       .redirects(1)
       .on('redirect', function(res) {
@@ -307,7 +314,7 @@ describe('request', function(){
   describe('on 307', function(){
     it('should redirect with same method', function(done){
       request
-      .put('http://localhost:3003/redirect-307')
+      .put(base + '/redirect-307')
       .send({msg: "hello"})
       .redirects(1)
       .on('redirect', function(res) {
@@ -323,7 +330,7 @@ describe('request', function(){
   describe('on 308', function(){
     it('should redirect with same method', function(done){
       request
-      .put('http://localhost:3003/redirect-308')
+      .put(base + '/redirect-308')
       .send({msg: "hello"})
       .redirects(1)
       .on('redirect', function(res) {

--- a/test/node/response-readable-stream.js
+++ b/test/node/response-readable-stream.js
@@ -8,12 +8,19 @@ app.get('/', function(req, res){
   fs.createReadStream('test/node/fixtures/user.json').pipe(res);
 });
 
-app.listen(3025);
+var base = 'http://localhost'
+var server;
+before(function listen(done) {
+  server = app.listen(0, function listening() {
+    base += ':' + server.address().port;
+    done();
+  });
+});
 
 describe('response', function(){
     it('should act as a readable stream', function(done){
       var req = request
-        .get('http://localhost:3025')
+        .get(base)
         .buffer(false);
 
       req.end(function(err,res){

--- a/test/node/timeout.js
+++ b/test/node/timeout.js
@@ -11,13 +11,19 @@ app.get('/:ms', function(req, res){
   }, ms);
 });
 
-app.listen(3009);
-
+var base = 'http://localhost'
+var server;
+before(function listen(done) {
+  server = app.listen(0, function listening() {
+    base += ':' + server.address().port;
+    done();
+  });
+});
 describe('.timeout(ms)', function(){
   describe('when timeout is exceeded', function(done){
     it('should error', function(done){
       request
-      .get('http://localhost:3009/500')
+      .get(base + '/500')
       .timeout(150)
       .end(function(err, res){
         assert(err, 'expected an error');

--- a/test/node/toError.js
+++ b/test/node/toError.js
@@ -9,12 +9,19 @@ app.get('/', function(req, res){
   res.status(400).send('invalid json');
 });
 
-var server = app.listen();
+var base = 'http://localhost'
+var server;
+before(function listen(done) {
+  server = app.listen(0, function listening() {
+    base += ':' + server.address().port;
+    done();
+  });
+});
 
 describe('res.toError()', function(){
   it('should return an Error', function(done){
     request
-    .get('http://localhost:' + server.address().port)
+    .get(base)
     .end(function(err, res){
       var err = res.toError();
       assert(err.status == 400);

--- a/test/node/user-agent.js
+++ b/test/node/user-agent.js
@@ -10,12 +10,19 @@ app.all('/ua', function(req, res){
   req.pipe(res);
 });
 
-app.listen(3345);
+var base = 'http://localhost'
+var server;
+before(function listen(done) {
+  server = app.listen(0, function listening() {
+    base += ':' + server.address().port;
+    done();
+  });
+});
 
 describe('req.get()', function(){
   it('should set a default user-agent', function(done){
     request
-    .get('http://localhost:3345/ua')
+    .get(base + '/ua')
     .end(function(err, res){
       assert(res.headers);
       assert(res.headers['user-agent']);
@@ -26,7 +33,7 @@ describe('req.get()', function(){
 
   it('should be able to override user-agent', function(done){
     request
-    .get('http://localhost:3345/ua')
+    .get(base + '/ua')
     .set('User-Agent', 'foo/bar')
     .end(function(err, res){
       assert(res.headers);
@@ -37,7 +44,7 @@ describe('req.get()', function(){
 
   it('should be able to wipe user-agent', function(done){
     request
-    .get('http://localhost:3345/ua')
+    .get(base + '/ua')
     .unset('User-Agent')
     .end(function(err, res){
       assert(res.headers);


### PR DESCRIPTION
When starting express servers in unit tests, always listen on a free
port.

This should solve port conflicts entirely, which were still plaguing me (I use a **lot** of ports, especially in 3xxx 4xxx ranges!).

It should also avoid theoretical race condition where server.listen()
takes a long time due to how we use `before`, although in practice
I don't believe this was ever occurring.

There's some boilerplate to do it right with mocha before, etc, but
it's OK.

One implicit interdependency between distinct tests was refactored.