### PR TITLE
Adding statusCode to error response when JSON response is malformed

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -506,6 +506,8 @@ function Request(method, url) {
       err.original = e;
       // issue #675: return the raw response if the response parsing fails
       err.rawResponse = self.xhr && self.xhr.responseText ? self.xhr.responseText : null;
+      // issue #876: return the http status code if the response parsing fails
+      err.statusCode = self.xhr && self.xhr.status ? self.xhr.status : null;
       return self.callback(err);
     }
 

--- a/lib/node/parsers/json.js
+++ b/lib/node/parsers/json.js
@@ -10,6 +10,8 @@ module.exports = function parseJSON(res, fn){
       var err = e;
       // issue #675: return the raw response if the response parsing fails
       err.rawResponse = res.text || null;
+      // issue #876: return the http status code if the response parsing fails
+      err.statusCode = res.statusCode;
     } finally {
       fn(err, body);
     }

--- a/test/client/request.js
+++ b/test/client/request.js
@@ -90,7 +90,6 @@ it('GET querystring empty objects', function(next){
   });
 });
 
-
 it('GET querystring object .get(uri, obj)', function(next){
   request
   .get('/querystring', { search: 'Manny' })

--- a/test/json.js
+++ b/test/json.js
@@ -148,6 +148,15 @@ describe('res.body', function(){
         done();
       });
     });
+
+    it('should return the http status code', function(done){
+      request
+      .get(uri + '/invalid-json-forbidden')
+      .end(function(err, res){
+        assert.equal(err.statusCode, 403);
+        done();
+      });
+    });
   });
 
   if (doesntWorkInBrowserYet) describe('No content', function(){

--- a/test/support/server.js
+++ b/test/support/server.js
@@ -151,6 +151,11 @@ app.get('/invalid-json', function(req, res) {
   res.send(")]}', {'header':{'code':200,'text':'OK','version':'1.0'},'data':'some data'}");
 });
 
+app.get('/invalid-json-forbidden', function(req, res) {
+  res.set('content-type', 'application/json');
+  res.status(403).send("Forbidden");
+});
+
 app.get('/text', function(req, res){
   res.send("just some text");
 });


### PR DESCRIPTION
In reference to issue #876, these changes will allow the client to access the http status code even when the JSON response body is malformed.

This is the same pull request as https://github.com/visionmedia/superagent/pull/877 but has been squashed into one commit instead of 6 as suggested by @pornel.