### PR TITLE
XMLHttpRequest for firefox extensions

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -62,6 +62,9 @@ request.getXHR = function () {
     try { return new ActiveXObject('Msxml2.XMLHTTP.6.0'); } catch(e) {}
     try { return new ActiveXObject('Msxml2.XMLHTTP.3.0'); } catch(e) {}
     try { return new ActiveXObject('Msxml2.XMLHTTP'); } catch(e) {}
+    try { var { Cc, Ci } = require('chrome');
+          return Cc["@mozilla.org/xmlextras/xmlhttprequest;1"].createInstance(Ci.nsIXMLHttpRequest);
+    } catch(e) {}
   }
   return false;
 };

--- a/lib/client.js
+++ b/lib/client.js
@@ -62,7 +62,8 @@ request.getXHR = function () {
     try { return new ActiveXObject('Msxml2.XMLHTTP.6.0'); } catch(e) {}
     try { return new ActiveXObject('Msxml2.XMLHTTP.3.0'); } catch(e) {}
     try { return new ActiveXObject('Msxml2.XMLHTTP'); } catch(e) {}
-    try { var { Cc, Ci } = require('chrome');
+    try { var Cc = require('chrome').Cc;
+          var Ci = require('chrome').Ci;
           return Cc["@mozilla.org/xmlextras/xmlhttprequest;1"].createInstance(Ci.nsIXMLHttpRequest);
     } catch(e) {}
   }


### PR DESCRIPTION
for firefox extensions - there is no way for import XMLHttpRequest into globals. Components.utils.importGlobalProperties (see https://developer.mozilla.org/en-US/docs/Mozilla/Tech/XPCOM/Language_Bindings/Components.utils.importGlobalProperties) does not work properly.