### PR TITLE
extract common code into request-base object

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -4,7 +4,7 @@
 
 var Emitter = require('emitter');
 var reduce = require('reduce');
-var RequestBase = require('./request-base');
+var requestBase = require('./request-base');
 
 /**
  * Root reference for iframes.
@@ -495,7 +495,6 @@ request.Response = Response;
 
 function Request(method, url) {
   var self = this;
-  RequestBase.call(this);
   this._query = this._query || [];
   this.method = method;
   this.url = url;
@@ -538,12 +537,12 @@ function Request(method, url) {
 }
 
 /**
- * Mixin `Emitter` and `RequestBase`.
+ * Mixin `Emitter` and `requestBase`.
  */
 
 Emitter(Request.prototype);
-for (var key in RequestBase.prototype) {
-  Request.prototype[key] = RequestBase.prototype[key];
+for (var key in requestBase) {
+  Request.prototype[key] = requestBase[key];
 }
 
 /**

--- a/lib/client.js
+++ b/lib/client.js
@@ -4,6 +4,7 @@
 
 var Emitter = require('emitter');
 var reduce = require('reduce');
+var RequestBase = require('./request-base');
 
 /**
  * Root reference for iframes.
@@ -47,6 +48,12 @@ function isHost(obj) {
       return false;
   }
 }
+
+/**
+ * Expose `request`.
+ */
+
+var request = module.exports = require('./request').bind(null, Request);
 
 /**
  * Determine XHR.
@@ -488,7 +495,7 @@ request.Response = Response;
 
 function Request(method, url) {
   var self = this;
-  Emitter.call(this);
+  RequestBase.call(this);
   this._query = this._query || [];
   this.method = method;
   this.url = url;
@@ -531,45 +538,13 @@ function Request(method, url) {
 }
 
 /**
- * Mixin `Emitter`.
+ * Mixin `Emitter` and `RequestBase`.
  */
 
 Emitter(Request.prototype);
-
-/**
- * Allow for extension
- */
-
-Request.prototype.use = function(fn) {
-  fn(this);
-  return this;
+for (var key in RequestBase.prototype) {
+  Request.prototype[key] = RequestBase.prototype[key];
 }
-
-/**
- * Set timeout to `ms`.
- *
- * @param {Number} ms
- * @return {Request} for chaining
- * @api public
- */
-
-Request.prototype.timeout = function(ms){
-  this._timeout = ms;
-  return this;
-};
-
-/**
- * Clear previous timeout.
- *
- * @return {Request} for chaining
- * @api public
- */
-
-Request.prototype.clearTimeout = function(){
-  this._timeout = 0;
-  clearTimeout(this._timer);
-  return this;
-};
 
 /**
  * Abort the request, and clear potential timeout.
@@ -675,20 +650,6 @@ Request.prototype.getHeader = function(field){
 
 Request.prototype.type = function(type){
   this.set('Content-Type', request.types[type] || type);
-  return this;
-};
-
-/**
- * Force given parser
- *
- * Sets the body parser no matter type.
- *
- * @param {Function}
- * @api public
- */
-
-Request.prototype.parse = function(fn){
-  this._parser = fn;
   return this;
 };
 
@@ -1029,54 +990,12 @@ Request.prototype.end = function(fn){
   return this;
 };
 
-/**
- * Faux promise support
- *
- * @param {Function} fulfill
- * @param {Function} reject
- * @return {Request}
- */
-
-Request.prototype.then = function (fulfill, reject) {
-  return this.end(function(err, res) {
-    err ? reject(err) : fulfill(res);
-  });
-}
 
 /**
  * Expose `Request`.
  */
 
 request.Request = Request;
-
-/**
- * Issue a request:
- *
- * Examples:
- *
- *    request('GET', '/users').end(callback)
- *    request('/users').end(callback)
- *    request('/users', callback)
- *
- * @param {String} method
- * @param {String|Function} url or callback
- * @return {Request}
- * @api public
- */
-
-function request(method, url) {
-  // callback
-  if ('function' == typeof url) {
-    return new Request('GET', method).end(url);
-  }
-
-  // url first
-  if (1 == arguments.length) {
-    return new Request('GET', method);
-  }
-
-  return new Request(method, url);
-}
 
 /**
  * GET `url` with optional callback `fn(res)`.
@@ -1185,9 +1104,3 @@ request.put = function(url, data, fn){
   if (fn) req.end(fn);
   return req;
 };
-
-/**
- * Expose `request`.
- */
-
-module.exports = request;

--- a/lib/node/index.js
+++ b/lib/node/index.js
@@ -23,7 +23,7 @@ var qs = require('qs');
 var zlib = require('zlib');
 var util = require('util');
 var pkg = require('../../package.json');
-var RequestBase = require('../request-base');
+var requestBase = require('../request-base');
 
 /**
  * Expose the request function.
@@ -119,7 +119,6 @@ exports.parse = require('./parsers');
 
 function Request(method, url) {
   Stream.call(this);
-  RequestBase.call(this);
   var self = this;
   if ('string' != typeof url) url = format(url);
   this._agent = false;
@@ -142,11 +141,11 @@ function Request(method, url) {
 
 /**
  * Inherit from `Stream` (which inherits from `EventEmitter`).
- * Mixin `RequestBase`.
+ * Mixin `requestBase`.
  */
 util.inherits(Request, Stream);
-for (var key in RequestBase.prototype) {
-  Request.prototype[key] = RequestBase.prototype[key];
+for (var key in requestBase) {
+  Request.prototype[key] = requestBase[key];
 }
 
 /**

--- a/lib/node/index.js
+++ b/lib/node/index.js
@@ -23,12 +23,13 @@ var qs = require('qs');
 var zlib = require('zlib');
 var util = require('util');
 var pkg = require('../../package.json');
+var RequestBase = require('../request-base');
 
 /**
  * Expose the request function.
  */
 
-exports = module.exports = request;
+var request = exports = module.exports = require('../request').bind(null, Request);
 
 /**
  * Expose the agent function
@@ -118,6 +119,7 @@ exports.parse = require('./parsers');
 
 function Request(method, url) {
   Stream.call(this);
+  RequestBase.call(this);
   var self = this;
   if ('string' != typeof url) url = format(url);
   this._agent = false;
@@ -139,10 +141,13 @@ function Request(method, url) {
 }
 
 /**
- * Inherit from `Stream`.
+ * Inherit from `Stream` (which inherits from `EventEmitter`).
+ * Mixin `RequestBase`.
  */
-
 util.inherits(Request, Stream);
+for (var key in RequestBase.prototype) {
+  Request.prototype[key] = RequestBase.prototype[key];
+}
 
 /**
  * Write the field `name` and `val` for "multipart/form-data"
@@ -542,33 +547,6 @@ Request.prototype.buffer = function(val){
 };
 
 /**
- * Set timeout to `ms`.
- *
- * @param {Number} ms
- * @return {Request} for chaining
- * @api public
- */
-
-Request.prototype.timeout = function(ms){
-  this._timeout = ms;
-  return this;
-};
-
-/**
- * Clear previous timeout.
- *
- * @return {Request} for chaining
- * @api public
- */
-
-Request.prototype.clearTimeout = function(){
-  debug('clear timeout %s %s', this.method, this.url);
-  this._timeout = 0;
-  clearTimeout(this._timer);
-  return this;
-};
-
-/**
  * Abort and clear timeout.
  *
  * @api public
@@ -580,19 +558,6 @@ Request.prototype.abort = function(){
   this.clearTimeout();
   this.req.abort();
   this.emit('abort');
-};
-
-/**
- * Define the parser to be used for this response.
- *
- * @param {Function} fn
- * @return {Request} for chaining
- * @api public
- */
-
-Request.prototype.parse = function(fn){
-  this._parser = fn;
-  return this;
 };
 
 /**
@@ -705,15 +670,6 @@ Request.prototype.auth = function(user, pass){
 
 Request.prototype.ca = function(cert){
   this._ca = cert;
-  return this;
-};
-
-/**
- * Allow for extension
- */
-
-Request.prototype.use = function(fn) {
-  fn(this);
   return this;
 };
 
@@ -1101,20 +1057,6 @@ Request.prototype.end = function(fn){
 };
 
 /**
- * Faux promise support
- *
- * @param {Function} fulfill
- * @param {Function} reject
- * @return {Request}
- */
-
-Request.prototype.then = function (fulfill, reject) {
-  return this.end(function(err, res) {
-    err ? reject(err) : fulfill(res);
-  });
-}
-
-/**
  * To json.
  *
  * @return {Object}
@@ -1134,35 +1076,6 @@ Request.prototype.toJSON = function(){
  */
 
 exports.Request = Request;
-
-/**
- * Issue a request:
- *
- * Examples:
- *
- *    request('GET', '/users').end(callback)
- *    request('/users').end(callback)
- *    request('/users', callback)
- *
- * @param {String} method
- * @param {String|Function} url or callback
- * @return {Request}
- * @api public
- */
-
-function request(method, url) {
-  // callback
-  if ('function' == typeof url) {
-    return new Request('GET', method).end(url);
-  }
-
-  // url first
-  if (1 == arguments.length) {
-    return new Request('GET', method);
-  }
-
-  return new Request(method, url);
-}
 
 // generate HTTP verb methods
 if (methods.indexOf('del') == -1) {

--- a/lib/request-base.js
+++ b/lib/request-base.js
@@ -1,0 +1,68 @@
+/**
+ * Base class for HTTP requests in both node and browser
+ */
+function RequestBase() {}
+
+/**
+ * Clear previous timeout.
+ *
+ * @return {Request} for chaining
+ * @api public
+ */
+
+RequestBase.prototype.clearTimeout = function(){
+  this._timeout = 0;
+  clearTimeout(this._timer);
+  return this;
+};
+
+/**
+ * Force given parser
+ *
+ * Sets the body parser no matter type.
+ *
+ * @param {Function}
+ * @api public
+ */
+
+RequestBase.prototype.parse = function(fn){
+  this._parser = fn;
+  return this;
+};
+
+/**
+ * Set timeout to `ms`.
+ *
+ * @param {Number} ms
+ * @return {Request} for chaining
+ * @api public
+ */
+
+RequestBase.prototype.timeout = function(ms){
+  this._timeout = ms;
+  return this;
+};
+
+/**
+ * Faux promise support
+ *
+ * @param {Function} fulfill
+ * @param {Function} reject
+ * @return {Request}
+ */
+
+RequestBase.prototype.then = function (fulfill, reject) {
+  return this.end(function(err, res) {
+    err ? reject(err) : fulfill(res);
+  });
+}
+
+/**
+ * Allow for extension
+ */
+
+RequestBase.prototype.use = function(fn) {
+  fn(this);
+  return this;
+}
+module.exports = RequestBase;

--- a/lib/request-base.js
+++ b/lib/request-base.js
@@ -1,7 +1,6 @@
 /**
- * Base class for HTTP requests in both node and browser
+ * Module of mixed-in functions shared between node and client code
  */
-function RequestBase() {}
 
 /**
  * Clear previous timeout.
@@ -10,7 +9,7 @@ function RequestBase() {}
  * @api public
  */
 
-RequestBase.prototype.clearTimeout = function(){
+exports.clearTimeout = function _clearTimeout(){
   this._timeout = 0;
   clearTimeout(this._timer);
   return this;
@@ -25,7 +24,7 @@ RequestBase.prototype.clearTimeout = function(){
  * @api public
  */
 
-RequestBase.prototype.parse = function(fn){
+exports.parse = function parse(fn){
   this._parser = fn;
   return this;
 };
@@ -38,7 +37,7 @@ RequestBase.prototype.parse = function(fn){
  * @api public
  */
 
-RequestBase.prototype.timeout = function(ms){
+exports.timeout = function timeout(ms){
   this._timeout = ms;
   return this;
 };
@@ -51,7 +50,7 @@ RequestBase.prototype.timeout = function(ms){
  * @return {Request}
  */
 
-RequestBase.prototype.then = function (fulfill, reject) {
+exports.then = function then(fulfill, reject) {
   return this.end(function(err, res) {
     err ? reject(err) : fulfill(res);
   });
@@ -61,8 +60,7 @@ RequestBase.prototype.then = function (fulfill, reject) {
  * Allow for extension
  */
 
-RequestBase.prototype.use = function(fn) {
+exports.use = function use(fn) {
   fn(this);
   return this;
 }
-module.exports = RequestBase;

--- a/lib/request.js
+++ b/lib/request.js
@@ -1,0 +1,32 @@
+// The node and browser modules expose versions of this with the
+// appropriate constructor function bound as first argument
+/**
+ * Issue a request:
+ *
+ * Examples:
+ *
+ *    request('GET', '/users').end(callback)
+ *    request('/users').end(callback)
+ *    request('/users', callback)
+ *
+ * @param {String} method
+ * @param {String|Function} url or callback
+ * @return {Request}
+ * @api public
+ */
+
+function request(RequestConstructor, method, url) {
+  // callback
+  if ('function' == typeof url) {
+    return new RequestConstructor('GET', method).end(url);
+  }
+
+  // url first
+  if (2 == arguments.length) {
+    return new RequestConstructor('GET', method);
+  }
+
+  return new RequestConstructor(method, url);
+}
+
+module.exports = request;


### PR DESCRIPTION
This takes any identical copy/paste code between
client code and node code and puts it in a common
superclass.

This handles the identical/easy cases.

Plan to handle the slightly different cases next.

Part of #830