### PR TITLE
use native xhr auth on client

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -682,13 +682,19 @@ Request.prototype.accept = function(type){
  *
  * @param {String} user
  * @param {String} pass
+ * @param {Boolean} useNative
  * @return {Request} for chaining
  * @api public
  */
 
-Request.prototype.auth = function(user, pass){
-  var str = btoa(user + ':' + pass);
-  this.set('Authorization', 'Basic ' + str);
+Request.prototype.auth = function(user, pass, useNative){
+  if (useNative) {
+    this.username = user;
+    this.password = pass;
+  } else {
+    var str = btoa(user + ':' + pass);
+    this.set('Authorization', 'Basic ' + str);
+  }
   return this;
 };
 
@@ -960,7 +966,11 @@ Request.prototype.end = function(fn){
   }
 
   // initiate request
-  xhr.open(this.method, this.url, true);
+  if (this.username && this.password) {
+    xhr.open(this.method, this.url, true, this.username, this.password);
+  } else {
+    xhr.open(this.method, this.url, true);
+  }
 
   // CORS
   if (this._withCredentials) xhr.withCredentials = true;

--- a/lib/client.js
+++ b/lib/client.js
@@ -682,19 +682,13 @@ Request.prototype.accept = function(type){
  *
  * @param {String} user
  * @param {String} pass
- * @param {Boolean} useNative
  * @return {Request} for chaining
  * @api public
  */
 
-Request.prototype.auth = function(user, pass, useNative){
-  if (useNative) {
-    this.username = user;
-    this.password = pass;
-  } else {
-    var str = btoa(user + ':' + pass);
-    this.set('Authorization', 'Basic ' + str);
-  }
+Request.prototype.auth = function(user, pass){
+  this.username = user;
+  this.password = pass;
   return this;
 };
 

--- a/lib/client.js
+++ b/lib/client.js
@@ -682,13 +682,29 @@ Request.prototype.accept = function(type){
  *
  * @param {String} user
  * @param {String} pass
+ * @param {Object} options with 'type' property 'auto' or 'basic' (default 'basic')
  * @return {Request} for chaining
  * @api public
  */
 
-Request.prototype.auth = function(user, pass){
-  this.username = user;
-  this.password = pass;
+Request.prototype.auth = function(user, pass, options){
+  if (!options) {
+    options = {
+      type: 'basic'
+    }
+  }
+
+  switch (options.type) {
+    case 'basic':
+      var str = btoa(user + ':' + pass);
+      this.set('Authorization', 'Basic ' + str);
+    break;
+
+    case 'auto':
+      this.username = user;
+      this.password = pass;
+    break;
+  }
   return this;
 };
 

--- a/test/client/request.js
+++ b/test/client/request.js
@@ -121,6 +121,32 @@ it('basic auth', function(next){
   });
 });
 
+it('auth type "basic"', function(next){
+  window.btoa = window.btoa || require('Base64').btoa;
+
+  request
+  .post('/auth')
+  .auth('foo', 'bar', {type: 'basic'})
+  .end(function(err, res){
+    assert('foo' == res.body.user);
+    assert('bar' == res.body.pass);
+    next();
+  });
+});
+
+it('auth type "auto"', function(next){
+  window.btoa = window.btoa || require('Base64').btoa;
+
+  request
+  .post('/auth')
+  .auth('foo', 'bar', {type: 'auto'})
+  .end(function(err, res){
+    assert('foo' == res.body.user);
+    assert('bar' == res.body.pass);
+    next();
+  });
+});
+
 it('progress event listener on xhr object registered when some on the request', function(){
   var req = request
   .get('/foo')

--- a/test/support/server.js
+++ b/test/support/server.js
@@ -1,6 +1,7 @@
 var express = require('express');
 var bodyParser = require('body-parser');
 var cookieParser = require('cookie-parser');
+var basicAuth = require('basic-auth-connect');
 
 var app = express();
 
@@ -160,7 +161,7 @@ app.get('/text', function(req, res){
   res.send("just some text");
 });
 
-app.post('/auth', function(req, res) {
+app.post('/auth', basicAuth('foo', 'bar'), function(req, res) {
   var auth = req.headers.authorization,
       parts = auth.split(' '),
       credentials = new Buffer(parts[1], 'base64').toString().split(':'),


### PR DESCRIPTION
Use native xhr auth on client because:

> Chrome supports four authentication schemes: Basic, Digest, NTLM, and Negotiate. 

I did check Digest auth on chrome it works

Why this lib did not use native authentication?