### PR TITLE
added support for blob and arraybuffer responseType

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -578,6 +578,26 @@ Request.prototype.type = function(type){
 };
 
 /**
+ * Set responseType to `val`. Presently valid responseTypes are 'blob' and 
+ * 'arraybuffer'.
+ *
+ * Examples:
+ *
+ *      req.get('/')
+ *        .responseType('blob')
+ *        .end(callback);
+ *
+ * @param {String} val
+ * @return {Request} for chaining
+ * @api public
+ */
+
+Request.prototype.responseType = function(val){
+  this._responseType = val;
+  return this;
+};
+
+/**
  * Set Accept to `type`, mapping values from `request.types`.
  *
  * Examples:
@@ -881,6 +901,10 @@ Request.prototype.end = function(fn){
   for (var field in this.header) {
     if (null == this.header[field]) continue;
     xhr.setRequestHeader(field, this.header[field]);
+  }
+
+  if (this._responseType) {
+    xhr.responseType = this._responseType;
   }
 
   // send stuff

--- a/test/client/request.js
+++ b/test/client/request.js
@@ -107,6 +107,16 @@ it('GET querystring object .get(uri, obj, fn)', function(next){
   });
 });
 
+it('GET blob object', function(next){
+  request
+    .get('/blob', { foo: 'bar'})
+    .responseType('blob')
+    .end(function(err, res){
+      assert.deepEqual(res.xhr.response instanceof Blob, true);
+      next();
+    });
+});
+
 window.btoa = window.btoa || null;
 it('basic auth', function(next){
   window.btoa = window.btoa || require('Base64').btoa;


### PR DESCRIPTION
Allows the following request to be made
```javascript
request
  .get('http://d8d913s460fub.cloudfront.net/videoserver/cat-test-video-320x240.mp4')
  .set('Content-Type', 'blob')
  .end(function (err, res) {
    console.log(err, res);
  });
```