### PR TITLE
Added superagent-suffix to existing plugins documentation

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -67,6 +67,7 @@ request
 Existing plugins:
  * [superagent-no-cache](https://github.com/johntron/superagent-no-cache) - prevents caching by including Cache-Control header
  * [superagent-prefix](https://github.com/johntron/superagent-prefix) - prefixes absolute URLs (useful in test environment)
+ * [superagent-suffix](https://github.com/timneutkens1/superagent-suffix) - suffix URLs with a given path
  * [superagent-mock](https://github.com/M6Web/superagent-mock) - simulate HTTP calls by returning data fixtures based on the requested URL
  * [superagent-mocker](https://github.com/shuvalov-anton/superagent-mocker) — simulate REST API
  * [superagent-cache](https://github.com/jpodwys/superagent-cache) - superagent with built-in, flexible caching


### PR DESCRIPTION
Hi, I created a url suffix plugin. Surprisingly it did not exist. I have added it to the Readme.md after superagent-prefix.