### PR TITLE
Add link to superagent-use

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -74,6 +74,7 @@ Existing plugins:
  * [superagent-jsonapify](https://github.com/alex94puchades/superagent-jsonapify) - A lightweight [json-api](http://jsonapi.org/format/) client addon for superagent
  * [superagent-serializer](https://github.com/zzarcon/superagent-serializer) - Converts server payload into different cases
  * [superagent-promise-plugin](https://github.com/jomaxx/superagent-promise-plugin) - Shims req.end to return a promise when executed with no callback.
+ * [superagent-use](https://github.com/koenpunt/superagent-use) - A client addon to apply plugins to all requests.
 
 Please prefix your plugin with `superagent-*` so that it can easily be found by others.
 


### PR DESCRIPTION
`superagent-use` makes is possible to apply plugins to all requests, instead of just a single request.

My usecase is that I use SuperAgent to request data from an API, which resides on another domain than the application itself. 

With this plugin I no longer have to set the hostname for every request, I simply add a global plugin.

Before:

```js
var superagent = require('superagent');
var prefix = require('superagent-prefix')('https://api.example.com');

superagent
  .get('/')
  .use(prefix)
  .end(function(){});

superagent
  .post('/auth')
  .use(prefix)
  .send({user: 'foo', pass: 'bar'})
  .end(function(){});

// etc..
```

After:

```js
var superagent = require('superagent-use');
var prefix = require('superagent-prefix')('https://api.example.com');
superagent.use(prefix);

superagent
  .get('/')
  .end(function(){});

superagent
  .post('/auth')
  .send({user: 'foo', pass: 'bar'})
  .end(function(){});

// etc..
```