### PR TITLE
.abort() extracted to request-base

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -535,22 +535,6 @@ for (var key in requestBase) {
 }
 
 /**
- * Abort the request, and clear potential timeout.
- *
- * @return {Request}
- * @api public
- */
-
-Request.prototype.abort = function(){
-  if (this.aborted) return;
-  this.aborted = true;
-  this.xhr.abort();
-  this.clearTimeout();
-  this.emit('abort');
-  return this;
-};
-
-/**
  * Set Content-Type to `type`, mapping values from `request.types`.
  *
  * Examples:
@@ -578,7 +562,7 @@ Request.prototype.type = function(type){
 };
 
 /**
- * Set responseType to `val`. Presently valid responseTypes are 'blob' and 
+ * Set responseType to `val`. Presently valid responseTypes are 'blob' and
  * 'arraybuffer'.
  *
  * Examples:
@@ -855,7 +839,7 @@ Request.prototype.end = function(fn){
 
     if (0 == status) {
       if (self.timedout) return self.timeoutError();
-      if (self.aborted) return;
+      if (self._aborted) return;
       return self.crossDomainError();
     }
     self.emit('end');

--- a/lib/node/index.js
+++ b/lib/node/index.js
@@ -457,20 +457,6 @@ Request.prototype.buffer = function(val){
 };
 
 /**
- * Abort and clear timeout.
- *
- * @api public
- */
-
-Request.prototype.abort = function(){
-  debug('abort %s %s', this.method, this.url);
-  this._aborted = true;
-  this.clearTimeout();
-  this.req.abort();
-  this.emit('abort');
-};
-
-/**
  * Redirect to `url
  *
  * @param {IncomingMessage} res

--- a/lib/request-base.js
+++ b/lib/request-base.js
@@ -167,3 +167,19 @@ exports.field = function(name, val) {
   this._formData.append(name, val);
   return this;
 };
+
+/**
+ * Abort the request, and clear potential timeout.
+ *
+ * @return {Request}
+ * @api public
+ */
+
+exports.abort = function(){
+  this._aborted = true;
+  this.xhr && this.xhr.abort(); // browser
+  this.req && this.req.abort(); // node
+  this.clearTimeout();
+  this.emit('abort');
+  return this;
+};


### PR DESCRIPTION
- Client code did not return `this` when `.abort()` was called on an
already-aborted instance. This was probably an unreported bug. Now
consistently returns `this` for chaining.
- internal state is called `_aborted` consistently. Any third party
code directly accessing `req.aborted` in the browser will break. This
property was and is an internal property and not a public API.

(heads up @jpodwys)