### PR TITLE
test for multiple abort calls

### DIFF
--- a/lib/request-base.js
+++ b/lib/request-base.js
@@ -174,8 +174,10 @@ exports.field = function(name, val) {
  * @return {Request}
  * @api public
  */
-
 exports.abort = function(){
+  if (this._aborted) {
+    return this;
+  }
   this._aborted = true;
   this.xhr && this.xhr.abort(); // browser
   this.req && this.req.abort(); // node

--- a/test/basic.js
+++ b/test/basic.js
@@ -346,5 +346,20 @@ describe('request', function(){
         req.abort();
       }, 1000);
     })
+
+    it('should allow chaining .abort() several times', function(done){
+      var req = request
+      .get(uri + '/delay/3000')
+      .end(function(err, res){
+        assert(false, 'should not complete the request');
+      });
+
+      // This also verifies only a single 'done' event is emitted
+      req.on('abort', done);
+
+      setTimeout(function() {
+        req.abort().abort().abort();
+      }, 1000);
+    })
   })
 })


### PR DESCRIPTION
Turns out positioning of `this.clearTimeout()` matters in the browser.

Sorry for the churn on this one. I'm pretty confident it is finalized now.