### PR TITLE
extract .toJSON() to request-base

### DIFF
--- a/lib/node/index.js
+++ b/lib/node/index.js
@@ -939,21 +939,6 @@ Request.prototype.end = function(fn){
 };
 
 /**
- * To json.
- *
- * @return {Object}
- * @api public
- */
-
-Request.prototype.toJSON = function(){
-  return {
-    method: this.method,
-    url: this.url,
-    data: this._data
-  };
-};
-
-/**
  * Expose `Request`.
  */
 

--- a/lib/request-base.js
+++ b/lib/request-base.js
@@ -202,3 +202,21 @@ exports.withCredentials = function(){
   this._withCredentials = true;
   return this;
 };
+
+
+/**
+ * Convert to a plain javascript object (not JSON string) of scalar properties.
+ * Note as this method is designed to return a useful non-this value,
+ * it cannot be chained.
+ *
+ * @return {Object} describing method, url, and data of this request
+ * @api public
+ */
+
+exports.toJSON = function(){
+  return {
+    method: this.method,
+    url: this.url,
+    data: this._data
+  };
+};

--- a/test/basic.js
+++ b/test/basic.js
@@ -362,4 +362,19 @@ describe('request', function(){
       }, 1000);
     })
   })
+
+  describe('req.toJSON()', function(){
+    it('should describe the request', function(done){
+      var req = request
+      .post(uri + '/echo')
+      .send({ foo: 'baz' })
+      .end(function(err, res){
+        var json = req.toJSON();
+        assert('POST' == json.method);
+        assert(/\/echo$/.test(json.url));
+        assert('baz' == json.data.foo);
+        done();
+      });
+    })
+  })
 })

--- a/test/node/basic.js
+++ b/test/node/basic.js
@@ -41,21 +41,6 @@ describe('[node] request', function(){
     })
   })
 
-  describe('req.toJSON()', function(){
-    it('should describe the request', function(done){
-      request
-      .post(':5000/echo')
-      .send({ foo: 'baz' })
-      .end(function(err, res){
-        var obj = res.request.toJSON();
-        assert('POST' == obj.method);
-        assert(':5000/echo' == obj.url);
-        assert('baz' == obj.data.foo);
-        done();
-      });
-    })
-  })
-
   describe('res.toJSON()', function(){
     it('should describe the response', function(done){
       request


### PR DESCRIPTION
This API is now present in both node and the browser.
It was node-only prior to this.
Docs improved and unit tests moved so it runs in node and browser.

Part of #830