### PR TITLE
Make .then() return a real Promise

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -34,6 +34,10 @@
 
     request('GET', '/search').end(callback);
 
+ES6 promises are supported. Instead of `.end()` you can call `.then()`:
+
+    request('GET', '/search').then(success, failure);
+
  The __node__ client may also provide absolute urls:
 
      request
@@ -437,12 +441,14 @@ Your callback function will always be passed two arguments: error and response. 
       // all other error types we handle generically
     }
 
-## Generator support
+## Promise and Generator support
 
-Superagent now supports easier control flow using generators. By using a generator control flow
-like [co](https://github.com/tj/co) or a web framework like [koa](https://github.com/koajs/koa),
-you can `yield` on any superagent method:
+Superagent's request is a "thenable" object that's compatible with JavaScript promises.
+
+Libraries like [co](https://github.com/tj/co) or a web framework like [koa](https://github.com/koajs/koa) can `yield` on any superagent method:
 
     var res = yield request
       .get('http://local')
       .auth('tobi', 'learnboost')
+
+Note that superagent expects the global `Promise` object to be present. You'll need a polyfill to use promises in Internet Explorer or Node.js 0.10.

--- a/lib/request-base.js
+++ b/lib/request-base.js
@@ -46,17 +46,23 @@ exports.timeout = function timeout(ms){
 };
 
 /**
- * Faux promise support
+ * Promise support
  *
- * @param {Function} fulfill
+ * @param {Function} resolve
  * @param {Function} reject
  * @return {Request}
  */
 
-exports.then = function then(fulfill, reject) {
-  return this.end(function(err, res) {
-    err ? reject(err) : fulfill(res);
-  });
+exports.then = function then(resolve, reject) {
+  if (!this._fullfilledPromise) {
+    var self = this;
+    this._fullfilledPromise = new Promise(function(innerResolve, innerReject){
+      self.end(function(err, res){
+        if (err) innerReject(err); else innerResolve(res);
+      });
+    });
+  }
+  return this._fullfilledPromise.then(resolve, reject);
 }
 
 /**

--- a/test/basic.js
+++ b/test/basic.js
@@ -64,6 +64,36 @@ describe('request', function(){
         done();
       });
     })
+
+    it('is optional with a promise', function() {
+      if ('undefined' === typeof Promise) {
+        return;
+      }
+
+      return request.get(uri + '/login')
+      .then(function(res) {
+          return res.status;
+      })
+      .then()
+      .then(function(status) {
+          assert.equal(200, status, "Real promises pass results through");
+      });
+    });
+
+    it('called only once with a promise', function() {
+      if ('undefined' === typeof Promise) {
+        return;
+      }
+
+      var req = request.get(uri + '/unique');
+
+      return Promise.all([req, req, req])
+      .then(function(results){
+        results.forEach(function(item){
+          assert.equal(item.body, results[0].body, "It should keep returning the same result after being called once");
+        });
+      });
+    });
   })
 
   describe('res.error', function(){
@@ -81,6 +111,20 @@ describe('request', function(){
         assert(err, 'should have an error for 500');
         assert.equal(err.message, 'Internal Server Error');
         done();
+      });
+    })
+
+    it('with .then() promise', function(){
+      if ('undefined' === typeof Promise) {
+        return;
+      }
+
+      return request
+      .get(uri + '/error')
+      .then(function(){
+        assert.fail();
+      }, function(err){
+        assert.equal(err.message, 'Internal Server Error');
       });
     })
   })
@@ -312,6 +356,10 @@ describe('request', function(){
 
   describe('.then(fulfill, reject)', function() {
     it('should support successful fulfills with .then(fulfill)', function(done) {
+      if ('undefined' === typeof Promise) {
+        return done();
+      }
+
       request
       .post(uri + '/echo')
       .send({ name: 'tobi' })
@@ -322,6 +370,10 @@ describe('request', function(){
     })
 
     it('should reject an error with .then(null, reject)', function(done) {
+      if ('undefined' === typeof Promise) {
+        return done();
+      }
+
       request
       .get(uri + '/error')
       .then(null, function(err) {

--- a/test/support/server.js
+++ b/test/support/server.js
@@ -19,6 +19,11 @@ app.all('/echo', function(req, res){
   req.pipe(res);
 });
 
+var uniq = 0;
+app.all('/unique', function(req, res){
+  res.send('never the same ' + (uniq++));
+});
+
 app.use(bodyParser.urlencoded({ extended: true }));
 app.use(bodyParser.json());
 app.use(cookieParser());


### PR DESCRIPTION
Another take on Promises. 

* Uses global `Promise`. ES6 is final now, so I think it's OK to expect it for interoperability. 
   Node 0.10—the IE6 of Nodes—can easily polyfill it.
* Re-returns the same result, so that usage of the request as thenable in multiple places won't make multiple calls. That's consistent with how real promises behave.


Fixes #722 Closes #852
 
#854 #726