### PR TITLE
Dep semver updates

### DIFF
--- a/docs/test.html
+++ b/docs/test.html
@@ -338,7 +338,7 @@ setTimeout(function() {
     should.not.exist(err);
     res.should.have.status(200);
     should.not.exist(res.headers['set-cookie']);
-    res.text.should.include('dashboard');
+    res.text.should.containEql('dashboard');
     done();
   });</code></pre></dd>
             <dt>should start with empty session (set cookies)</dt>
@@ -357,7 +357,7 @@ setTimeout(function() {
     should.not.exist(err);
     res.should.have.status(200);
     should.not.exist(res.headers['set-cookie']);
-    res.text.should.include('dashboard');
+    res.text.should.containEql('dashboard');
     done();
   });</code></pre></dd>
             <dt>should persist cookies across requests</dt>
@@ -403,7 +403,7 @@ setTimeout(function() {
   .end(function(err, res) {
     should.not.exist(err);
     res.should.have.status(200);
-    res.text.should.include('dashboard');
+    res.text.should.containEql('dashboard');
     done();
   });</code></pre></dd>
             <dt>should be able to post redirects</dt>
@@ -413,7 +413,7 @@ setTimeout(function() {
   .end(function(err, res) {
     should.not.exist(err);
     res.should.have.status(200);
-    res.text.should.include('simple');
+    res.text.should.containEql('simple');
     res.redirects.should.eql(['http://localhost:4000/simple']);
     done();
   });</code></pre></dd>

--- a/package.json
+++ b/package.json
@@ -45,7 +45,8 @@
     "express-session": "^1.13.0",
     "marked": "^0.3.5",
     "mocha": "^2.4.5",
-    "should": "~3.1.3",
+    "should": "^8.2.2",
+    "should-http": "^0.0.4",
     "zuul": "^3.10.1"
   },
   "browser": {

--- a/package.json
+++ b/package.json
@@ -23,30 +23,30 @@
   },
   "dependencies": {
     "qs": "2.3.3",
-    "formidable": "~1.0.14",
-    "mime": "1.3.4",
-    "component-emitter": "~1.2.0",
-    "methods": "~1.1.1",
-    "cookiejar": "2.0.6",
-    "debug": "2",
-    "reduce-component": "1.0.1",
-    "extend": "3.0.0",
+    "formidable": "^1.0.17",
+    "mime": "^1.3.4",
+    "component-emitter": "^1.2.0",
+    "methods": "^1.1.1",
+    "cookiejar": "^2.0.6",
+    "debug": "^2.2.0",
+    "reduce-component": "^1.0.1",
+    "extend": "^3.0.0",
     "form-data": "1.0.0-rc3",
-    "readable-stream": "1.0.27-1"
+    "readable-stream": "^2.0.5"
   },
   "devDependencies": {
-    "Base64": "~0.3.0",
-    "basic-auth-connect": "~1.0.0",
-    "better-assert": "~1.0.1",
-    "body-parser": "~1.9.2",
-    "browserify": "~6.3.2",
-    "cookie-parser": "~1.3.3",
-    "express": "~4.9.8",
-    "express-session": "~1.9.1",
-    "marked": "0.3.5",
-    "mocha": "~2.0.1",
+    "Base64": "^0.3.0",
+    "basic-auth-connect": "^1.0.0",
+    "better-assert": "^1.0.1",
+    "body-parser": "^1.15.0",
+    "browserify": "^13.0.0",
+    "cookie-parser": "^1.4.1",
+    "express": "^4.13.4",
+    "express-session": "^1.13.0",
+    "marked": "^0.3.5",
+    "mocha": "^2.4.5",
     "should": "~3.1.3",
-    "zuul": "~1.19.0"
+    "zuul": "^3.10.1"
   },
   "browser": {
     "./lib/node/index.js": "./lib/client.js",
@@ -61,6 +61,6 @@
   },
   "main": "./lib/node/index.js",
   "engines": {
-    "node": ">= 0.8"
+    "node": ">= 0.10"
   }
 }

--- a/test/node/agency.js
+++ b/test/node/agency.js
@@ -1,3 +1,5 @@
+require('should-http');
+
 var express = require('express')
   , app = express()
   , request = require('../../')
@@ -74,7 +76,7 @@ describe('request', function() {
           should.not.exist(err);
           res.should.have.status(200);
           should.not.exist(res.headers['set-cookie']);
-          res.text.should.include('dashboard');
+          res.text.should.containEql('dashboard');
           done();
         });
     });
@@ -97,7 +99,7 @@ describe('request', function() {
           should.not.exist(err);
           res.should.have.status(200);
           should.not.exist(res.headers['set-cookie']);
-          res.text.should.include('dashboard');
+          res.text.should.containEql('dashboard');
           done();
         });
     });
@@ -153,7 +155,7 @@ describe('request', function() {
         .end(function(err, res) {
           should.not.exist(err);
           res.should.have.status(200);
-          res.text.should.include('dashboard');
+          res.text.should.containEql('dashboard');
           done();
         });
     });
@@ -165,7 +167,7 @@ describe('request', function() {
         .end(function(err, res) {
           should.not.exist(err);
           res.should.have.status(200);
-          res.text.should.include('simple');
+          res.text.should.containEql('simple');
           res.redirects.should.eql([base + '/simple']);
           done();
         });

--- a/test/node/inflate.js
+++ b/test/node/inflate.js
@@ -1,3 +1,5 @@
+require('should');
+require('should-http');
 
 var request = require('../../')
   , assert = require('assert')

--- a/test/node/multipart.js
+++ b/test/node/multipart.js
@@ -124,7 +124,7 @@ describe('Request', function(){
 //         req.attach('name3', 'baz');
 
 //         req.on('error', function(err){
-//           err.message.should.include('ENOENT');
+//           err.message.should.containEql('ENOENT');
 //           err.path.should.equal('foo');
 //           done();
 //         });
@@ -194,7 +194,7 @@ describe('Request', function(){
 //       req.end(function(err, res){
 //         if (err) return done(err);
 //         var ct = res.header['content-type'];
-//         ct.should.include('multipart/form-data; boundary=');
+//         ct.should.containEql('multipart/form-data; boundary=');
 //         res.body.should.eql({});
 //         res.files.image.name.should.equal('image.png');
 //         res.files.image.type.should.equal('image/png');
@@ -249,7 +249,7 @@ describe('Request', function(){
 
 //       req.end(function(err, res){
 //         if (err) return done(err);
-//         res.header['content-type'].should.include('boundary=');
+//         res.header['content-type'].should.containEql('boundary=');
 //         res.body.name.should.equal('Tobi');
 //         done();
 //       });

--- a/test/node/not-modified.js
+++ b/test/node/not-modified.js
@@ -1,3 +1,5 @@
+require('should');
+require('should-http');
 
 var request = require('../../')
   , express = require('express')


### PR DESCRIPTION
Update to current latest version of all deps.

Consistently use semver major number only.

Code updates for removed should.js APIs.

Didn't update `qs` as that is trickier and being dealt with in a separate issue.