### PR TITLE
Require form-data on-demand, so that it doesn’t throw when not in use

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,3 +1,7 @@
+# 1.8.1 (2016-03-14)
+
+  * Fixed form-data incompatibility with IE9
+
 # 1.8.0 (2016-03-09)
 
  * Extracted common code into request-base class (Peter Lyons)

--- a/bower.json
+++ b/bower.json
@@ -1,4 +1,7 @@
 {
   "name": "superagent",
-  "main": "lib/client.js"
+  "main": "lib/client.js",
+  "dependencies": {
+    "form-data": "form-data-superagent#^1.0.0"
+  }
 }

--- a/lib/request-base.js
+++ b/lib/request-base.js
@@ -3,8 +3,6 @@
  */
 var isObject = require('./is-object');
 
-var FormData = require('form-data'); // browserify compatible
-
 /**
  * Clear previous timeout.
  *
@@ -163,7 +161,10 @@ exports.unset = function(field){
  * @api public
  */
 exports.field = function(name, val) {
-  if (!this._formData) this._formData = new FormData();
+  if (!this._formData) {
+    var FormData = require('form-data'); // browserify compatible. May throw if FormData is not supported natively.
+    this._formData = new FormData();
+  }
   this._formData.append(name, val);
   return this;
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "superagent",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "description": "elegant & feature rich browser / node HTTP with a fluent API",
   "scripts": {
     "prepublish": "make all",

--- a/test/client/request.js
+++ b/test/client/request.js
@@ -108,6 +108,9 @@ it('GET querystring object .get(uri, obj, fn)', function(next){
 });
 
 it('GET blob object', function(next){
+  if ('undefined' === typeof Blob) {
+    return next();
+  }
   request
     .get('/blob', { foo: 'bar'})
     .responseType('blob')


### PR DESCRIPTION
Fixes #933