### PR TITLE
Set https.servername from Host header

### DIFF
--- a/lib/node/index.js
+++ b/lib/node/index.js
@@ -518,6 +518,11 @@ Request.prototype.request = function(){
   options.ca = this._ca;
   options.agent = this._agent;
 
+  // Allows request.get('https://1.2.3.4/').set('Host', 'example.com')
+  if (this._header['host']) {
+    options.servername = this._header['host'].replace(/:[0-9]+$/,'');
+  }
+
   // initiate request
   var mod = exports.protocols[url.protocol];
 


### PR DESCRIPTION
I need to make requests to a specific IP address. With HTTP that's easy:

```
request.get('http://1.2.3.4').set('Host', 'example.com')
```

but for HTTPS it currently fails, because TLS will be validated against `1.2.3.4` rather than `example.com`.

This change makes Host header (if set) take precedence over the URL.

Open questions:
- Is it secure?
- How to test it?
