### PR TITLE
refactor: add _appendQueryString to client request

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -636,6 +636,9 @@ Request.prototype.auth = function(user, pass, options){
 */
 
 Request.prototype.query = function(val){
+  if (arguments.length === 0) {
+    return this._query.join('&');
+  }
   if ('string' != typeof val) val = serialize(val);
   if (val) this._query.push(val);
   return this;
@@ -715,6 +718,20 @@ Request.prototype._timeoutError = function(){
   this.callback(err);
 };
 
+/**
+ * Compose querystring to append to req.url
+ *
+ * @api private
+ */
+
+Request.prototype._appendQueryString = function(){
+  var query = this._query.join('&');
+  if (query) {
+    this.url += ~this.url.indexOf('?')
+      ? '&' + query
+      : '?' + query;
+  }
+};
 
 /**
  * Initiate request, invoking callback `fn(res)`
@@ -728,7 +745,6 @@ Request.prototype._timeoutError = function(){
 Request.prototype.end = function(fn){
   var self = this;
   var xhr = this.xhr = request.getXHR();
-  var query = this._query.join('&');
   var timeout = this._timeout;
   var data = this._formData || this._data;
 
@@ -782,12 +798,7 @@ Request.prototype.end = function(fn){
   }
 
   // querystring
-  if (query) {
-    query = request.serializeObject(query);
-    this.url += ~this.url.indexOf('?')
-      ? '&' + query
-      : '?' + query;
-  }
+  this._appendQueryString();
 
   // initiate request
   if (this.username && this.password) {

--- a/lib/client.js
+++ b/lib/client.js
@@ -636,9 +636,6 @@ Request.prototype.auth = function(user, pass, options){
 */
 
 Request.prototype.query = function(val){
-  if (arguments.length === 0) {
-    return this._query.join('&');
-  }
   if ('string' != typeof val) val = serialize(val);
   if (val) this._query.push(val);
   return this;


### PR DESCRIPTION
Heya,

Server-side requests have this `_appendQueryString()` function, but client-side requests don't, so there's no consistent way for plugins to apply the query string. Makes things a little annoying for plugins that overwrite `Request.prototype.end()` like https://github.com/vkarpov15/superagent-httpbackend.

Thanks,
Val