### PR TITLE
add superagent-throttle to plugins list

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -76,6 +76,7 @@ Existing plugins:
  * [superagent-promise-plugin](https://github.com/jomaxx/superagent-promise-plugin) - Shims req.end to return a promise when executed with no callback.
  * [superagent-use](https://github.com/koenpunt/superagent-use) - A client addon to apply plugins to all requests.
  * [superagent-httpbackend](https://www.npmjs.com/package/superagent-httpbackend) - stub out requests using AngularJS' $httpBackend syntax
+ * [superagent-throttle](https://github.com/leviwheatcroft/superagent-throttle) - queues and intelligently throttles requests
 
 Please prefix your plugin with `superagent-*` so that it can easily be found by others.
 


### PR DESCRIPTION
that's for maintaining superagent, it's a great module. I wrote a plugin to throttle requests, was hoping for a mention in your readme.. thanks!