### PR TITLE
Deduplicate Response creation, order of events

### DIFF
--- a/lib/node/index.js
+++ b/lib/node/index.js
@@ -352,10 +352,7 @@ Request.prototype.pipe = function(stream, options){
     }
 
     self.res = res;
-    var response = new Response(self);
-    self.response = response;
-    self.emit('response', response);
-    response.redirects = self._redirectList;
+    self._emitResponse();
     if (self._aborted) return;
 
     if (self._shouldUnzip(res)) {
@@ -632,6 +629,18 @@ Request.prototype._appendQueryString = function(req){
  * @api public
  */
 
+Request.prototype._emitResponse = function(body, files){
+    var response = new Response(this);
+    this.response = response;
+    response.redirects = this._redirectList;
+    if (undefined !== body) {
+      response.body = body;
+    }
+    response.files = files;
+    this.emit('response', response);
+    return response;
+};
+
 Request.prototype.end = function(fn){
   var self = this;
   var data = this._data;
@@ -707,12 +716,8 @@ Request.prototype.end = function(fn){
     }
 
     if ('HEAD' == self.method) {
-      var response = new Response(self);
-      self.response = response;
-      response.redirects = self._redirectList;
-      self.emit('response', response);
-      self.callback(null, response);
       self.emit('end');
+      self.callback(null, self._emitResponse());
       return;
     }
 
@@ -727,17 +732,12 @@ Request.prototype.end = function(fn){
 
     // TODO: make all parsers take callbacks
     if (!parser && multipart) {
-      var form = new formidable.IncomingForm;
+      var form = new formidable.IncomingForm();
 
       form.parse(res, function(err, fields, files){
         if (err) return self.callback(err);
-        var response = new Response(self);
-        self.response = response;
-        response.body = fields;
-        response.files = files;
-        response.redirects = self._redirectList;
         self.emit('end');
-        self.callback(null, response);
+        self.callback(null, self._emitResponse(fields, files));
       });
       return;
     }
@@ -746,12 +746,8 @@ Request.prototype.end = function(fn){
     if (!parser && isImage(mime)) {
       exports.parse.image(res, function(err, obj){
         if (err) return self.callback(err);
-        var response = new Response(self);
-        self.response = response;
-        response.body = obj;
-        response.redirects = self._redirectList;
         self.emit('end');
-        self.callback(null, response);
+        self.callback(null, self._emitResponse(obj));
       });
       return;
     }
@@ -791,11 +787,7 @@ Request.prototype.end = function(fn){
     // unbuffered
     if (!buffer) {
       debug('unbuffered %s %s', self.method, self.url);
-      var response = new Response(self);
-      self.response = response;
-      response.redirects = self._redirectList;
-      self.emit('response', response);
-      self.callback(null, response);
+      self.callback(null, self._emitResponse());
       if (multipart) return // allow multipart to handle end event
       res.on('end', function(){
         debug('end %s %s', self.method, self.url);
@@ -811,12 +803,8 @@ Request.prototype.end = function(fn){
     res.on('end', function(){
       debug('end %s %s', self.method, self.url);
       // TODO: unless buffering emit earlier to stream
-      var response = new Response(self);
-      self.response = response;
-      response.redirects = self._redirectList;
-      self.emit('response', response);
-      self.callback(null, response);
       self.emit('end');
+      self.callback(null, self._emitResponse());
     });
   });
 

--- a/lib/node/index.js
+++ b/lib/node/index.js
@@ -786,10 +786,11 @@ Request.prototype.end = function(fn){
       }
     }
 
+    self.res = res;
+
     // unbuffered
     if (!buffer) {
       debug('unbuffered %s %s', self.method, self.url);
-      self.res = res;
       var response = new Response(self);
       self.response = response;
       response.redirects = self._redirectList;
@@ -804,7 +805,6 @@ Request.prototype.end = function(fn){
     }
 
     // terminating events
-    self.res = res;
     res.on('error', function(err){
       self.callback(err, null);
     });


### PR DESCRIPTION
Now response is always created in the same way. 

Order of events is now more consistent:

* `end`, `response`, and callback — for *buffered* responses. Same in Node and browser
* `response`, `end`, and callback for unbuffered responses (pipe)

