### PR TITLE
enable field() to handle an object

### DIFF
--- a/lib/request-base.js
+++ b/lib/request-base.js
@@ -166,21 +166,31 @@ exports.unset = function(field){
 };
 
 /**
- * Write the field `name` and `val` for "multipart/form-data"
- * request bodies.
+ * Write the field `name` and `val`, or multiple fields with one object
+ * for "multipart/form-data" request bodies.
  *
  * ``` js
  * request.post('/upload')
  *   .field('foo', 'bar')
  *   .end(callback);
+ *
+ * request.post('/upload')
+ *   .field({ foo: 'bar', baz: 'qux' })
+ *   .end(callback);
  * ```
  *
- * @param {String} name
+ * @param {String|Object} name
  * @param {String|Blob|File|Buffer|fs.ReadStream} val
  * @return {Request} for chaining
  * @api public
  */
 exports.field = function(name, val) {
+  if (isObject(name)) {
+    for (var key in name) {
+      this.field(key, name[key]);
+    }
+    return this;
+  }
   this._getFormData().append(name, val);
   return this;
 };

--- a/test/node/multipart.js
+++ b/test/node/multipart.js
@@ -191,6 +191,35 @@ describe('Request', function(){
           })
     })
   })
+
+  describe('#field(name, val)', function() {
+    it('should set a multipart field value', function(done) {
+      request.post(base + '/echo')
+      .field('first-name', 'foo')
+      .field('last-name', 'bar')
+      .end(function(err, res) {
+        if(err) done(err);
+        res.should.be.ok;
+        res.body['first-name'].should.equal('foo');
+        res.body['last-name'].should.equal('bar');
+        done();
+      });
+    });
+  });
+
+  describe('#field(object)', function() {
+    it('should set multiple multipart fields', function(done) {
+      request.post(base + '/echo')
+      .field({ 'first-name': 'foo', 'last-name': 'bar' })
+      .end(function(err, res) {
+        if(err) done(err);
+        res.should.be.ok;
+        res.body['first-name'].should.equal('foo');
+        res.body['last-name'].should.equal('bar');
+        done();
+      });
+    });
+  });
 })
 
 // describe('Part', function(){


### PR DESCRIPTION
Allows `.field()` to behave similar to `.set()` and handle an object to set multiple key-values. Would it also be desirable to have it handle arrays? i.e
The following:
```
req.field({ array: [1, 2, 3]  });
```
would translate to something like:
```
req.field('array', 1);
req.field('array', 2);
req.field('array', 3);
```

The underlying `form-data`'s `append()` does not support this and errors out as it feels this sort of call is ambiguous (multiple interpretations). Would this be inline with superagent or is it indeed too ambiguous? 

Also I could not find browser-side tests for `.field()`, is this intended? 