### PR TITLE
request-base: add header for inspect

### DIFF
--- a/lib/request-base.js
+++ b/lib/request-base.js
@@ -247,7 +247,7 @@ exports.toJSON = function(){
     method: this.method,
     url: this.url,
     data: this._data,
-    header: this._header
+    headers: this._header
   };
 };
 

--- a/lib/request-base.js
+++ b/lib/request-base.js
@@ -246,7 +246,8 @@ exports.toJSON = function(){
   return {
     method: this.method,
     url: this.url,
-    data: this._data
+    data: this._data,
+    header: this._header
   };
 };
 

--- a/test/request.js
+++ b/test/request.js
@@ -622,7 +622,7 @@ it('req.toJSON()', function(next){
   request
   .get(uri + '/ok')
   .end(function(err, res){
-    var j = res.request.toJSON();
+    var j = (res.request || res.req).toJSON();
     ['url', 'method', 'data', 'headers'].forEach(function(prop){
       assert(j.hasOwnProperty(prop));
     });

--- a/test/request.js
+++ b/test/request.js
@@ -618,4 +618,16 @@ it('response should set statusCode', function(next){
     })
 });
 
+it('req.toJSON()', function(next){
+  request
+  .get(uri + '/ok')
+  .end(function(err, res){
+    var j = res.request.toJSON();
+    ['url', 'method', 'data', 'headers'].forEach(function(prop){
+      assert(j.hasOwnProperty(prop));
+    });
+    next();
+  });
+});
+
 });


### PR DESCRIPTION
header is also important for inspect a request. as I'm using the `Authentication` header for auth. and I'm using this

```js
request
  .get(url)
  .set('foo', 'bar')
  .then((err, res) => {
    if(err) return next(err);
  });
```

`next` is the `next` in express. I'd like to inspect the header too.