### PR TITLE
The returned object is not compatible with Promises.

### DIFF
--- a/test/basic.js
+++ b/test/basic.js
@@ -384,6 +384,22 @@ describe('request', function(){
     })
   })
 
+  describe('.catch(reject)', function() {
+    it('should reject an error with .catch(reject)', function(done) {
+      if ('undefined' === typeof Promise) {
+        return done();
+      }
+
+      request
+      .get(uri + '/error')
+      .catch(function(err) {
+        assert(err.status == 500);
+        assert(err.response.text == 'boom');
+        done();
+      })
+    })
+  })
+
   describe('.abort()', function(){
     it('should abort the request', function(done){
       var req = request


### PR DESCRIPTION
We can't only catch errors for request
```js
const superagent = require('superagent')

superagent
  .get('https://ya.ru')
  .catch(err => console.log(err))
```

Output:
```
  .catch(err => console.log(err))
        ^

TypeError: superagent.get(...).catch is not a function
```

But in promises we can:

```js
Promise.reject('Error!')
  .catch(err => {
    console.log(err) // Error!
  })

Promise.resolve(123)
  .catch(err => {
    // no errors
    console.log(err)
  })
```

---

Added test to reproduce error. I can try to fix it if you are ok with it.