### PR TITLE
add 'timedout' property to Node Request instance

### DIFF
--- a/lib/node/index.js
+++ b/lib/node/index.js
@@ -665,6 +665,7 @@ Request.prototype.end = function(fn){
       var err = new Error('timeout of ' + timeout + 'ms exceeded');
       err.timeout = timeout;
       err.code = 'ECONNABORTED';
+      self.timedout = true;
       self.abort();
       self.callback(err);
     }, timeout);

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@yr/superagent",
+  "name": "superagent",
   "version": "2.1.0",
   "description": "elegant & feature rich browser / node HTTP with a fluent API",
   "scripts": {
@@ -21,7 +21,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git://github.com/YR/superagent.git"
+    "url": "git://github.com/visionmedia/superagent.git"
   },
   "dependencies": {
     "qs": "^6.1.0",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "superagent",
+  "name": "@yr/superagent",
   "version": "2.1.0",
   "description": "elegant & feature rich browser / node HTTP with a fluent API",
   "scripts": {
@@ -21,7 +21,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git://github.com/visionmedia/superagent.git"
+    "url": "git://github.com/YR/superagent.git"
   },
   "dependencies": {
     "qs": "^6.1.0",

--- a/test/request.js
+++ b/test/request.js
@@ -564,7 +564,7 @@ it('request(url, fn)', function(next){
 });
 
 it('req.timeout(ms)', function(next){
-  request
+  var req = request
   .get(uri + '/delay/3000')
   .timeout(1000)
   .end(function(err, res){
@@ -572,12 +572,13 @@ it('req.timeout(ms)', function(next){
     assert(1000 == err.timeout, 'err.timeout missing');
     assert('timeout of 1000ms exceeded' == err.message, 'err.message incorrect');
     assert(null == res);
+    assert(req.timedout, true);
     next();
   })
 })
 
 it('req.timeout(ms) with redirect', function(next) {
-  request
+  var req = request
   .get(uri + '/delay/const')
   .timeout(1000)
   .end(function(err, res) {
@@ -585,6 +586,7 @@ it('req.timeout(ms) with redirect', function(next) {
     assert(1000 == err.timeout, 'err.timeout missing');
     assert('timeout of 1000ms exceeded' == err.message, 'err.message incorrect');
     assert(null == res);
+    assert(req.timedout, true);
     next();
   });
 });


### PR DESCRIPTION
Normalises behaviour between Node and Client so it's easier to distinguish between aborted and timed out requests.