### PR TITLE
Set xhr.response instead of xhr.responseText to err.rawResponse

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -487,9 +487,16 @@ function Request(method, url) {
       err.parse = true;
       err.original = e;
       // issue #675: return the raw response if the response parsing fails
-      err.rawResponse = self.xhr && self.xhr.response ? self.xhr.response : null;
-      // issue #876: return the http status code if the response parsing fails
-      err.statusCode = self.xhr && self.xhr.status ? self.xhr.status : null;
+      if (self.xhr) {
+        // ie9 doesn't have 'response' property
+        err.rawResponse = typeof self.xhr.responseType == 'undefined' ? self.xhr.responseText : self.xhr.response;
+        // issue #876: return the http status code if the response parsing fails
+        err.statusCode = self.xhr.status ? self.xhr.status : null;
+      } else {
+        err.rawResponse = null;
+        err.statusCode = null;
+      }
+      
       return self.callback(err);
     }
 

--- a/lib/client.js
+++ b/lib/client.js
@@ -487,7 +487,7 @@ function Request(method, url) {
       err.parse = true;
       err.original = e;
       // issue #675: return the raw response if the response parsing fails
-      err.rawResponse = self.xhr && self.xhr.responseText ? self.xhr.responseText : null;
+      err.rawResponse = self.xhr && self.xhr.response ? self.xhr.response : null;
       // issue #876: return the http status code if the response parsing fails
       err.statusCode = self.xhr && self.xhr.status ? self.xhr.status : null;
       return self.callback(err);

--- a/test/client/request.js
+++ b/test/client/request.js
@@ -229,6 +229,18 @@ if ('FormData' in window) {
     })
     .end();
   });
+  it('get error status code and rawResponse on file download', function(next) {
+    request
+    .get('/arraybuffer-unauthorized')
+    .responseType('arraybuffer') 
+    .end(function(err, res) {
+      assert(err.statusCode, 401);
+      assert(err.rawResponse instanceof ArrayBuffer);
+      var decodedString = String.fromCharCode.apply(null, new Uint8Array(err.rawResponse));
+      assert(decodedString, '{"message":"Authorization has been denied for this request."}');
+      next();
+    });
+  });
 }
 
 });

--- a/test/support/server.js
+++ b/test/support/server.js
@@ -230,6 +230,11 @@ app.get('/arraybuffer', function(req, res) {
   res.send(content);
 });
 
+app.get('/arraybuffer-unauthorized', function(req, res) {
+  res.set('Content-Type', 'application/json');
+  res.status(401).send('{"message":"Authorization has been denied for this request."}');
+});
+
 app.post('/empty-body', bodyParser.text(), function(req, res) {
   if (typeof req.body === 'object' && Object.keys(req.body).length === 0) {
     res.sendStatus(204);


### PR DESCRIPTION
responseText throws InvalidStateError when responseType is not 'text' or ''
