### PR TITLE
Fix calling abort before XHR setup

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -547,7 +547,7 @@ for (var key in requestBase) {
 Request.prototype.abort = function(){
   if (this.aborted) return;
   this.aborted = true;
-  this.xhr.abort();
+  this.xhr && this.xhr.abort();
   this.clearTimeout();
   this.emit('abort');
   return this;


### PR DESCRIPTION
Fix runtime issue in 1.8.x branch when calling `abort` before the XHR have been created.