### PR TITLE
Return this when overwriting the response object's on() method

### DIFF
--- a/lib/node/utils.js
+++ b/lib/node/utils.js
@@ -119,6 +119,7 @@ exports.unzip = function(req, res){
     } else {
       _on.call(res, type, fn);
     }
+    return this;
   };
 };
 


### PR DESCRIPTION
Superagent is overriding Node's `res.on` function, but forgetting to return `this` to maintain the original behavior.