### PR TITLE
guard for in when setting headers

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -825,8 +825,9 @@ Request.prototype.end = function(fn){
 
   // set header fields
   for (var field in this.header) {
-    if (null == this.header[field]) continue;
-    xhr.setRequestHeader(field, this.header[field]);
+    if ({}.hasOwnProperty.call(this.header, field)) {
+        xhr.setRequestHeader(field, this.header[field]);
+    }
   }
 
   if (this._responseType) {


### PR DESCRIPTION
We're having an issue with IE11 that is trying to set a `Symbol(Symbol.iterator)` as a header. Guarding the `for .. in` loop fixes this issue. Do you think it makes sense implementing this?
Thanks!