### PR TITLE
Remove superagent-promise-plugin from plugin list

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -71,7 +71,6 @@ Existing plugins:
  * [superagent-cache](https://github.com/jpodwys/superagent-cache) - superagent with built-in, flexible caching (compatible with superagent `1.x`)
  * [superagent-jsonapify](https://github.com/alex94puchades/superagent-jsonapify) - A lightweight [json-api](http://jsonapi.org/format/) client addon for superagent
  * [superagent-serializer](https://github.com/zzarcon/superagent-serializer) - Converts server payload into different cases
- * [superagent-promise-plugin](https://github.com/jomaxx/superagent-promise-plugin) - Shims req.end to return a promise when executed with no callback.
  * [superagent-use](https://github.com/koenpunt/superagent-use) - A client addon to apply plugins to all requests.
  * [superagent-httpbackend](https://www.npmjs.com/package/superagent-httpbackend) - stub out requests using AngularJS' $httpBackend syntax
  * [superagent-throttle](https://github.com/leviwheatcroft/superagent-throttle) - queues and intelligently throttles requests


### PR DESCRIPTION
Support added in 2.0.0 negates any utility and it's presence in this list implies that Promises are _not_ supported. This was pretty confusing to me, even though the docs on the site clearly communicate that Promises are now supported. I look at READMEs first and docs elsewhere a distant second.

I also somehow missed that news earlier this year and caught myself using thenables after forgetting to install the plugin in a project. Retracing my steps wondering why it was actually working, I discovered the good news!