### PR TITLE
Add the response to an error inside a promise

### DIFF
--- a/lib/request-base.js
+++ b/lib/request-base.js
@@ -70,7 +70,10 @@ exports.then = function then(resolve, reject) {
     var self = this;
     this._fullfilledPromise = new Promise(function(innerResolve, innerReject){
       self.end(function(err, res){
-        if (err) innerReject(err); else innerResolve(res);
+        if (err) {
+          err.res = res;
+          innerReject(err);
+        } else innerResolve(res);
       });
     });
   }


### PR DESCRIPTION
Sometimes the res object contains critical data as to why a request failed.  When a promise errors out, it would be nice to have that information as part of the error object.