### PR TITLE
Update requestBase to remove implied global scope reference by 'this'

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -13,7 +13,7 @@ if (typeof window !== 'undefined') { // Browser window
 }
 
 var Emitter = require('emitter');
-var requestBase = require('./request-base');
+var requestBase = require('./request-base').methods;
 var isObject = require('./is-object');
 
 /**

--- a/lib/node/index.js
+++ b/lib/node/index.js
@@ -23,7 +23,7 @@ var qs = require('qs');
 var zlib = require('zlib');
 var util = require('util');
 var pkg = require('../../package.json');
-var requestBase = require('../request-base');
+var requestBase = require('../request-base').methods;
 var isObject = require('../is-object');
 
 /**

--- a/lib/request-base.js
+++ b/lib/request-base.js
@@ -4,13 +4,22 @@
 var isObject = require('./is-object');
 
 /**
+ * Attach the request-base mixin methods to
+ * a separate object from "exports" to accomodate
+ * ES6 module semantics where 'this' should never
+ * refer to the global scope (required for Rollup
+ * bundling)
+ */
+var methods = {}
+
+/**
  * Clear previous timeout.
  *
  * @return {Request} for chaining
  * @api public
  */
 
-exports.clearTimeout = function _clearTimeout(){
+methods.clearTimeout = function _clearTimeout(){
   this._timeout = 0;
   clearTimeout(this._timer);
   return this;
@@ -25,7 +34,7 @@ exports.clearTimeout = function _clearTimeout(){
  * @api public
  */
 
-exports.parse = function parse(fn){
+methods.parse = function parse(fn){
   this._parser = fn;
   return this;
 };
@@ -39,7 +48,7 @@ exports.parse = function parse(fn){
  * @api public
  */
 
-exports.serialize = function serialize(fn){
+methods.serialize = function serialize(fn){
   this._serializer = fn;
   return this;
 };
@@ -52,7 +61,7 @@ exports.serialize = function serialize(fn){
  * @api public
  */
 
-exports.timeout = function timeout(ms){
+methods.timeout = function timeout(ms){
   this._timeout = ms;
   return this;
 };
@@ -65,7 +74,7 @@ exports.timeout = function timeout(ms){
  * @return {Request}
  */
 
-exports.then = function then(resolve, reject) {
+methods.then = function then(resolve, reject) {
   if (!this._fullfilledPromise) {
     var self = this;
     this._fullfilledPromise = new Promise(function(innerResolve, innerReject){
@@ -77,7 +86,7 @@ exports.then = function then(resolve, reject) {
   return this._fullfilledPromise.then(resolve, reject);
 }
 
-exports.catch = function(cb) {
+methods.catch = function(cb) {
   return this.then(undefined, cb);
 };
 
@@ -85,7 +94,7 @@ exports.catch = function(cb) {
  * Allow for extension
  */
 
-exports.use = function use(fn) {
+methods.use = function use(fn) {
   fn(this);
   return this;
 }
@@ -100,7 +109,7 @@ exports.use = function use(fn) {
  * @api public
  */
 
-exports.get = function(field){
+methods.get = function(field){
   return this._header[field.toLowerCase()];
 };
 
@@ -116,7 +125,7 @@ exports.get = function(field){
  * @deprecated
  */
 
-exports.getHeader = exports.get;
+methods.getHeader = methods.get;
 
 /**
  * Set header `field` to `val`, or multiple fields with one object.
@@ -139,7 +148,7 @@ exports.getHeader = exports.get;
  * @api public
  */
 
-exports.set = function(field, val){
+methods.set = function(field, val){
   if (isObject(field)) {
     for (var key in field) {
       this.set(key, field[key]);
@@ -163,7 +172,7 @@ exports.set = function(field, val){
  *
  * @param {String} field
  */
-exports.unset = function(field){
+methods.unset = function(field){
   delete this._header[field.toLowerCase()];
   delete this.header[field];
   return this;
@@ -188,7 +197,7 @@ exports.unset = function(field){
  * @return {Request} for chaining
  * @api public
  */
-exports.field = function(name, val) {
+methods.field = function(name, val) {
 
   // name should be either a string or an object.
   if (null === name ||  undefined === name) {
@@ -216,7 +225,7 @@ exports.field = function(name, val) {
  * @return {Request}
  * @api public
  */
-exports.abort = function(){
+methods.abort = function(){
   if (this._aborted) {
     return this;
   }
@@ -239,7 +248,7 @@ exports.abort = function(){
  * @api public
  */
 
-exports.withCredentials = function(){
+methods.withCredentials = function(){
   // This is browser-only functionality. Node side is no-op.
   this._withCredentials = true;
   return this;
@@ -253,7 +262,7 @@ exports.withCredentials = function(){
  * @api public
  */
 
-exports.redirects = function(n){
+methods.redirects = function(n){
   this._maxRedirects = n;
   return this;
 };
@@ -267,7 +276,7 @@ exports.redirects = function(n){
  * @api public
  */
 
-exports.toJSON = function(){
+methods.toJSON = function(){
   return {
     method: this.method,
     url: this.url,
@@ -287,7 +296,7 @@ exports.toJSON = function(){
  * @api private
  */
 
-exports._isHost = function _isHost(obj) {
+methods._isHost = function _isHost(obj) {
   var str = {}.toString.call(obj);
 
   switch (str) {
@@ -340,7 +349,7 @@ exports._isHost = function _isHost(obj) {
  * @api public
  */
 
-exports.send = function(data){
+methods.send = function(data){
   var obj = isObject(data);
   var type = this._header['content-type'];
 
@@ -370,3 +379,5 @@ exports.send = function(data){
   if (!type) this.type('json');
   return this;
 };
+
+exports.methods = methods;


### PR DESCRIPTION
This PR is submitted for discussion and possible merge.  This PR updates `requestBase` so the `this` reference doe not imply the global scope which is aligned with ES6 module semantics and is required for proper bundling with rollup.  

Rollup, upon seeing a `this` reference in the code whose parent scope is global will redefine `this` to `undefined` since that is conformant with ES6 module semantics. (https://github.com/rollup/rollup/issues/759) In this case, since the methods in `requestBase` are mixed into other prototypes during run-time,  in practice `this` does not end up referring to the global scope, so the redefinition by rollup causes errors. By enclosing the methods in a parent object the `this` no longer seems to imply the global scope and rollup does not modify the `this` references and this module gets bundled without issue.