### PR TITLE
change .on to .once, prevent possible memory leaks

### DIFF
--- a/lib/node/index.js
+++ b/lib/node/index.js
@@ -137,7 +137,7 @@ function Request(method, url) {
   this.qsRaw = [];
   this._redirectList = [];
   this._streamRequest = false;
-  this.on('end', this.clearTimeout.bind(this));
+  this.once('end', this.clearTimeout.bind(this));
 }
 
 /**
@@ -189,7 +189,7 @@ Request.prototype.attach = function(field, file, filename){
 Request.prototype._getFormData = function() {
   if (!this._formData) {
     this._formData = new FormData();
-    this._formData.on('error', function(err) {
+    this._formData.once('error', function(err) {
       this.emit('error', err);
       this.abort();
     }.bind(this));
@@ -342,7 +342,7 @@ Request.prototype.pipe = function(stream, options){
   this.piped = true; // HACK...
   this.buffer(false);
   var self = this;
-  this.end().req.on('response', function(res){
+  this.end().req.once('response', function(res){
     // redirect
     var redirect = isRedirect(res.statusCode);
     if (redirect && self._redirects++ != self._maxRedirects) {
@@ -358,7 +358,7 @@ Request.prototype.pipe = function(stream, options){
     } else {
       res.pipe(stream, options);
     }
-    res.on('end', function(){
+    res.once('end', function(){
       self.emit('end');
     });
   });
@@ -535,7 +535,7 @@ Request.prototype.request = function(){
   if (/^https?\+unix:/.test(url.protocol) === true) {
     // get the protocol
     url.protocol = url.protocol.split('+')[0] + ':';
-    
+
     // get the socket, path
     var unixParts = url.path.match(/^([^/]+)(.+)$/);
     options.socketPath = unixParts[1].replace(/%2F/g, '/');
@@ -562,9 +562,9 @@ Request.prototype.request = function(){
   this.host = url.host;
 
   // expose events
-  req.on('drain', function(){ self.emit('drain'); });
+  req.once('drain', function(){ self.emit('drain'); });
 
-  req.on('error', function(err){
+  req.once('error', function(err){
     // flag abortion here for out timeouts
     // because node will emit a faux-error "socket hang up"
     // when request is aborted before a connection is made
@@ -722,7 +722,7 @@ Request.prototype.end = function(fn){
   }
 
   // response
-  req.on('response', function(res){
+  req.once('response', function(res){
     debug('%s %s -> %s', self.method, self.url, res.statusCode);
 
     if (self.piped) {
@@ -812,7 +812,7 @@ Request.prototype.end = function(fn){
       debug('unbuffered %s %s', self.method, self.url);
       self.callback(null, self._emitResponse());
       if (multipart) return // allow multipart to handle end event
-      res.on('end', function(){
+      res.once('end', function(){
         debug('end %s %s', self.method, self.url);
         self.emit('end');
       })
@@ -820,10 +820,10 @@ Request.prototype.end = function(fn){
     }
 
     // terminating events
-    res.on('error', function(err){
+    res.once('error', function(err){
       self.callback(err, null);
     });
-    if (!parserHandlesEnd) res.on('end', function(){
+    if (!parserHandlesEnd) res.once('end', function(){
       debug('end %s %s', self.method, self.url);
       // TODO: unless buffering emit earlier to stream
       self.emit('end');

--- a/package.json
+++ b/package.json
@@ -24,19 +24,19 @@
     "url": "git://github.com/visionmedia/superagent.git"
   },
   "dependencies": {
-    "qs": "^6.1.0",
-    "formidable": "^1.0.17",
-    "mime": "^1.3.4",
     "component-emitter": "^1.2.0",
-    "methods": "^1.1.1",
     "cookiejar": "^2.0.6",
     "debug": "^2.2.0",
     "extend": "^3.0.0",
-    "form-data": "1.0.0-rc4",
+    "form-data": "^2.1.1",
+    "formidable": "^1.0.17",
+    "methods": "^1.1.1",
+    "mime": "^1.3.4",
+    "qs": "^6.1.0",
     "readable-stream": "^2.0.5"
   },
   "devDependencies": {
-    "Base64": "^0.3.0",
+    "Base64": "^1.0.0",
     "basic-auth-connect": "^1.0.0",
     "better-assert": "^1.0.1",
     "body-parser": "^1.15.0",
@@ -45,8 +45,8 @@
     "express": "^4.13.4",
     "express-session": "^1.13.0",
     "marked": "^0.3.5",
-    "mocha": "^2.4.5",
-    "should": "^8.2.2",
+    "mocha": "^3.1.2",
+    "should": "^11.1.1",
     "should-http": "^0.0.4",
     "zuul": "^3.10.1"
   },


### PR DESCRIPTION
 recorded multiple memory leaks from superagent. This was from a 1.1 version, but the underlying problem was still the same. 

```
(node) warning: possible EventEmitter memory leak detected. 11 end listeners added. Use emitter.setMaxListeners() to increase limit.
Trace
    at IncomingMessage.addListener (events.js:239:17)
    at IncomingMessage.Readable.on (_stream_readable.js:680:33)
    at ClientRequest.<anonymous> (.../node_modules/superagent/lib/node/index.js:915:9)
```
```
at IncomingMessage.Readable.on (_stream_readable.js:680:33)
    at IncomingMessage.once (events.js:265:8)
    at IncomingMessage.Readable.pipe (_stream_readable.js:486:9)
    at Object.exports.unzip (.../node_modules/superagent/lib/node/utils.js:90:7)
    at ClientRequest.<anonymous> (.../node_modules/superagent/lib/node/index.js:825:13)
```
```
at IncomingMessage.addListener (events.js:239:17)
    at IncomingMessage.Readable.on (_stream_readable.js:680:33)
    at parseJSON (.../node_modules/superagent/lib/node/parsers/json.js:6:7)
    at ClientRequest.<anonymous> (.../node_modules/superagent/lib/node/index.js:883:9)
    at emitOne (events.js:82:20)
    at ClientRequest.emit (events.js:169:7)
    at HTTPParser.parserOnIncomingClient [as onIncoming] (_http_client.js:433:21)
```