### PR TITLE
Add component-emitter to bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,4 +1,7 @@
 {
   "name": "superagent",
-  "main": "lib/client.js"
+  "main": "lib/client.js",
+  "dependencies": {
+    "emitter": "component-emitter#^1.1.2"
+  }
 }


### PR DESCRIPTION
The library relies on component-emitter but is not listed in the bower.json.

There are a few others too, just haven't run into issues yet.