### PR TITLE
Mixin RequestBase functions from a prototype

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -13,7 +13,7 @@ if (typeof window !== 'undefined') { // Browser window
 }
 
 var Emitter = require('emitter');
-var requestBase = require('./request-base');
+var RequestBase = require('./request-base');
 var isObject = require('./is-object');
 
 /**
@@ -517,13 +517,11 @@ function Request(method, url) {
 }
 
 /**
- * Mixin `Emitter` and `requestBase`.
+ * Mixin `Emitter` and `RequestBase`.
  */
 
 Emitter(Request.prototype);
-for (var key in requestBase) {
-  Request.prototype[key] = requestBase[key];
-}
+RequestBase(Request.prototype);
 
 /**
  * Set Content-Type to `type`, mapping values from `request.types`.

--- a/lib/node/index.js
+++ b/lib/node/index.js
@@ -23,7 +23,7 @@ var qs = require('qs');
 var zlib = require('zlib');
 var util = require('util');
 var pkg = require('../../package.json');
-var requestBase = require('../request-base');
+var RequestBase = require('../request-base');
 
 /**
  * Expose the request function.
@@ -142,12 +142,10 @@ function Request(method, url) {
 
 /**
  * Inherit from `Stream` (which inherits from `EventEmitter`).
- * Mixin `requestBase`.
+ * Mixin `RequestBase`.
  */
 util.inherits(Request, Stream);
-for (var key in requestBase) {
-  Request.prototype[key] = requestBase[key];
-}
+RequestBase(Request.prototype);
 
 /**
  * Queue the given `file` as an attachment to the specified `field`,

--- a/lib/request-base.js
+++ b/lib/request-base.js
@@ -4,13 +4,44 @@
 var isObject = require('./is-object');
 
 /**
+ * Expose `RequestBase`.
+ */
+
+module.exports = RequestBase;
+
+/**
+ * Initialize a new `RequestBase`.
+ *
+ * @api public
+ */
+
+function RequestBase(obj) {
+  if (obj) return mixin(obj);
+}
+
+/**
+ * Mixin the prototype properties.
+ *
+ * @param {Object} obj
+ * @return {Object}
+ * @api private
+ */
+
+function mixin(obj) {
+  for (var key in RequestBase.prototype) {
+    obj[key] = RequestBase.prototype[key];
+  }
+  return obj;
+}
+
+/**
  * Clear previous timeout.
  *
  * @return {Request} for chaining
  * @api public
  */
 
-exports.clearTimeout = function _clearTimeout(){
+RequestBase.prototype.clearTimeout = function _clearTimeout(){
   this._timeout = 0;
   clearTimeout(this._timer);
   return this;
@@ -25,7 +56,7 @@ exports.clearTimeout = function _clearTimeout(){
  * @api public
  */
 
-exports.parse = function parse(fn){
+RequestBase.prototype.parse = function parse(fn){
   this._parser = fn;
   return this;
 };
@@ -39,7 +70,7 @@ exports.parse = function parse(fn){
  * @api public
  */
 
-exports.serialize = function serialize(fn){
+RequestBase.prototype.serialize = function serialize(fn){
   this._serializer = fn;
   return this;
 };
@@ -52,7 +83,7 @@ exports.serialize = function serialize(fn){
  * @api public
  */
 
-exports.timeout = function timeout(ms){
+RequestBase.prototype.timeout = function timeout(ms){
   this._timeout = ms;
   return this;
 };
@@ -65,7 +96,7 @@ exports.timeout = function timeout(ms){
  * @return {Request}
  */
 
-exports.then = function then(resolve, reject) {
+RequestBase.prototype.then = function then(resolve, reject) {
   if (!this._fullfilledPromise) {
     var self = this;
     this._fullfilledPromise = new Promise(function(innerResolve, innerReject){
@@ -77,7 +108,7 @@ exports.then = function then(resolve, reject) {
   return this._fullfilledPromise.then(resolve, reject);
 }
 
-exports.catch = function(cb) {
+RequestBase.prototype.catch = function(cb) {
   return this.then(undefined, cb);
 };
 
@@ -85,7 +116,7 @@ exports.catch = function(cb) {
  * Allow for extension
  */
 
-exports.use = function use(fn) {
+RequestBase.prototype.use = function use(fn) {
   fn(this);
   return this;
 }
@@ -100,7 +131,7 @@ exports.use = function use(fn) {
  * @api public
  */
 
-exports.get = function(field){
+RequestBase.prototype.get = function(field){
   return this._header[field.toLowerCase()];
 };
 
@@ -116,7 +147,7 @@ exports.get = function(field){
  * @deprecated
  */
 
-exports.getHeader = exports.get;
+RequestBase.prototype.getHeader = RequestBase.prototype.get;
 
 /**
  * Set header `field` to `val`, or multiple fields with one object.
@@ -139,7 +170,7 @@ exports.getHeader = exports.get;
  * @api public
  */
 
-exports.set = function(field, val){
+RequestBase.prototype.set = function(field, val){
   if (isObject(field)) {
     for (var key in field) {
       this.set(key, field[key]);
@@ -163,7 +194,7 @@ exports.set = function(field, val){
  *
  * @param {String} field
  */
-exports.unset = function(field){
+RequestBase.prototype.unset = function(field){
   delete this._header[field.toLowerCase()];
   delete this.header[field];
   return this;
@@ -188,7 +219,7 @@ exports.unset = function(field){
  * @return {Request} for chaining
  * @api public
  */
-exports.field = function(name, val) {
+RequestBase.prototype.field = function(name, val) {
 
   // name should be either a string or an object.
   if (null === name ||  undefined === name) {
@@ -216,7 +247,7 @@ exports.field = function(name, val) {
  * @return {Request}
  * @api public
  */
-exports.abort = function(){
+RequestBase.prototype.abort = function(){
   if (this._aborted) {
     return this;
   }
@@ -239,7 +270,7 @@ exports.abort = function(){
  * @api public
  */
 
-exports.withCredentials = function(){
+RequestBase.prototype.withCredentials = function(){
   // This is browser-only functionality. Node side is no-op.
   this._withCredentials = true;
   return this;
@@ -253,7 +284,7 @@ exports.withCredentials = function(){
  * @api public
  */
 
-exports.redirects = function(n){
+RequestBase.prototype.redirects = function(n){
   this._maxRedirects = n;
   return this;
 };
@@ -267,7 +298,7 @@ exports.redirects = function(n){
  * @api public
  */
 
-exports.toJSON = function(){
+RequestBase.prototype.toJSON = function(){
   return {
     method: this.method,
     url: this.url,
@@ -287,7 +318,7 @@ exports.toJSON = function(){
  * @api private
  */
 
-exports._isHost = function _isHost(obj) {
+RequestBase.prototype._isHost = function _isHost(obj) {
   var str = {}.toString.call(obj);
 
   switch (str) {
@@ -340,7 +371,7 @@ exports._isHost = function _isHost(obj) {
  * @api public
  */
 
-exports.send = function(data){
+RequestBase.prototype.send = function(data){
   var obj = isObject(data);
   var type = this._header['content-type'];
 


### PR DESCRIPTION
This PR is an alternative solution to #1076

* Make RequestBase a constructor function
* Make it mixin its prototype functions when called as a function
* Unifies mixin approach with Emitter
* Fixes global scope issues in module bundlers like rollup.js

References #1076

See also:
https://github.com/rollup/rollup/issues/1007
https://github.com/rollup/rollup/pull/1023
https://github.com/rollup/rollup-plugin-commonjs/issues/127
