### PR TITLE
Added random User Agent method to utils

### DIFF
--- a/lib/node/utils.js
+++ b/lib/node/utils.js
@@ -134,7 +134,6 @@ exports.unzip = function(req, res){
  * @return {Object} header
  * @api private
  */
-
 exports.cleanHeader = function(header, shouldStripCookie){
   delete header['content-type'];
   delete header['content-length'];
@@ -144,4 +143,20 @@ exports.cleanHeader = function(header, shouldStripCookie){
     delete header['cookie'];
   }
   return header;
+};
+
+/**
+ * Generates a random User Agent
+ * http://www.useragentstring.com/pages/useragentstring.php
+ * @api private
+ */
+exports.randomUa = function(){
+  // little array, it's just a PoC
+  var uas = [
+              'Mozilla/5.0 (Windows NT 6.1; WOW64; rv:40.0) Gecko/20100101 Firefox/40.1',
+              'Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.1; WOW64; Trident/6.0)',
+              'Mozilla/5.0 (Windows NT 6.3; rv:36.0) Gecko/20100101 Firefox/36.0',
+              'Mozilla/5.0 (Windows NT 6.1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2228.0 Safari/537.36'
+            ];
+  return uas[Math.round(Math.random() * (uas.length-1))];
 };


### PR DESCRIPTION
I added this simple function for me. Maybe somebody finds it useful.
Applies a random User Agent instead of a fixed one or the default _node-superagent_.

Example of use:

```
request.get(url)
        .set('User-Agent', utils.randomUa())
        .end(function(err, res){
            if (err) throw err;
            console.log(res.text);
        });
```
