### PR TITLE
Initialize request data

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -474,6 +474,7 @@ function Request(method, url) {
   this._query = this._query || [];
   this.method = method;
   this.url = url;
+  this._data = {};
   this.header = {}; // preserves header name case
   this._header = {}; // coerces header names to lowercase
   this.on('end', function(){

--- a/lib/client.js
+++ b/lib/client.js
@@ -474,7 +474,6 @@ function Request(method, url) {
   this._query = this._query || [];
   this.method = method;
   this.url = url;
-  this._data = {};
   this.header = {}; // preserves header name case
   this._header = {}; // coerces header names to lowercase
   this.on('end', function(){

--- a/lib/request-base.js
+++ b/lib/request-base.js
@@ -374,10 +374,11 @@ RequestBase.prototype._isHost = function _isHost(obj) {
 RequestBase.prototype.send = function(data){
   var obj = isObject(data);
   var type = this._header['content-type'];
+  var objectType = {}.toString.call(data);
 
   if (obj && Array.isArray(data)) {
     this._data = this._data || [];
-  } else if (obj && 'object' == typeof data) {
+  } else if (obj && objectType == '[object Object]') {
     this._data = this._data || {};
   }
 

--- a/lib/request-base.js
+++ b/lib/request-base.js
@@ -375,6 +375,12 @@ RequestBase.prototype.send = function(data){
   var obj = isObject(data);
   var type = this._header['content-type'];
 
+  if (obj && Array.isArray(data)) {
+    this._data = this._data || [];
+  } else if (obj && 'object' == typeof data) {
+    this._data = this._data || {};
+  }
+
   // merge
   if (obj && isObject(this._data)) {
     for (var key in data) {

--- a/lib/request-base.js
+++ b/lib/request-base.js
@@ -375,10 +375,11 @@ RequestBase.prototype.send = function(data){
   var obj = isObject(data);
   var type = this._header['content-type'];
   var objectType = {}.toString.call(data);
+  var isBuffer = data instanceof Buffer;
 
   if (obj && Array.isArray(data)) {
     this._data = this._data || [];
-  } else if (obj && objectType == '[object Object]') {
+  } else if (obj && objectType === '[object Object]' && !isBuffer) {
     this._data = this._data || {};
   }
 


### PR DESCRIPTION
I recently had an issue where I would be making two consecutive POST request. Both received an object as `data` and both used a second `csrf` object. Something like:

```javascript
var csrf = extractCSRF();

request1 = (data) => {
  return new Promise((resolve, reject) => {
    request
      .post(ENDPOINT_1)
      .set(HEADERS)
      .send(csrf)
      .send(data)
      .end((err, res) => err ? reject(err) : resolve(res.body));
  });
}

request2 = (data) => {
  return new Promise((resolve, reject) => {
    request
      .post(ENDPOINT_2)
      .set(HEADERS)
      .send(csrf)
      .send(data)
      .end((err, res) => err ? reject(err) : resolve(res.body));
  });
}
```

The second request would fail because of conflicting parameters. The `csrf` object was being mutated due after the first request causing a merge conflict and a malformed request.

I was able to track this down to [this line](https://github.com/visionmedia/superagent/blob/master/lib/request-base.js#L379). This check would fail because `this._data` was uninitialized, meaning that the object cloning wouldn't occur. Instead, it was falling down to the `else` branch which contains the line `this._data = data`. As a consequence, `send` was mutating the `csrf` object which is unwanted behavior.

I fixed this issue by initializing `this._data`.