### PR TITLE
saucelabs browser test tweaks

### DIFF
--- a/.zuul.yml
+++ b/.zuul.yml
@@ -1,5 +1,6 @@
 ui: mocha-bdd
 server: ./test/support/server.js
+tunnel_host: http://focusaurus.com
 browsers:
   - name: chrome
     version: latest

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ test-cov: lib-cov
 	SUPERAGENT_COV=1 $(MAKE) test REPORTER=html-cov > coverage.html
 
 test-browser:
-	./node_modules/.bin/zuul -- $(BROWSERTESTS)
+	SAUCE_APPIUM_VERSION=1.6 ./node_modules/.bin/zuul -- $(BROWSERTESTS)
 
 test-browser-local:
 	./node_modules/.bin/zuul --local 4000 -- $(BROWSERTESTS)

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "mocha": "^3.1.2",
     "should": "^11.1.1",
     "should-http": "^0.0.4",
-    "zuul": "^3.10.1"
+    "zuul": "^3.11.1"
   },
   "browser": {
     "./lib/node/index.js": "./lib/client.js",

--- a/test/basic.js
+++ b/test/basic.js
@@ -6,7 +6,7 @@ var assert = require('assert');
 var request = require('../');
 
 describe('request', function(){
-  this.timeout(10000);
+  this.timeout(20000);
 
   describe('res.statusCode', function(){
     it('should set statusCode', function(done){

--- a/test/client/request.js
+++ b/test/client/request.js
@@ -2,7 +2,7 @@ var assert = require('assert');
 var request = require('../../');
 
 describe('request', function() {
-  this.timeout(10000);
+  this.timeout(20000);
 
 it('request() error object', function(next) {
   request('GET', '/error').end(function(err, res) {

--- a/test/client/xdomain.js
+++ b/test/client/xdomain.js
@@ -2,7 +2,7 @@ var assert = require('assert');
 var request = require('../../');
 
 describe('xdomain', function(){
-  this.timeout(10000);
+  this.timeout(20000);
 
   // TODO (defunctzombie) I am not certain this actually forces xdomain request
   // use localtunnel.me and tunnel127.com alias instead

--- a/test/content-type.js
+++ b/test/content-type.js
@@ -5,7 +5,7 @@ var assert = require('assert');
 var request = require('../');
 
 describe('req.set("Content-Type", contentType)', function(){
-  this.timeout(10000);
+  this.timeout(20000);
 
   it('should work with just the contentType component', function(done){
     request

--- a/test/json.js
+++ b/test/json.js
@@ -6,7 +6,7 @@ var assert = require('assert');
 var request = require('../');
 
 describe('req.send(Object) as "json"', function(){
-  this.timeout(10000);
+  this.timeout(20000);
 
   it('should default to json', function(done){
     request
@@ -119,7 +119,7 @@ describe('req.send(Object) as "json"', function(){
 })
 
 describe('res.body', function(){
-  this.timeout(10000);
+  this.timeout(20000);
 
   describe('application/json', function(){
     it('should parse the body', function(done){

--- a/test/redirects.js
+++ b/test/redirects.js
@@ -49,6 +49,10 @@ describe('request', function(){
         res.headers.location.should.equal('/reply-method')
       })
       .end(function(err, res){
+        if (err) {
+          done(err);
+          return;
+        }
         res.text.should.equal('method=get');
         done();
       })
@@ -67,6 +71,10 @@ describe('request', function(){
         res.headers.location.should.equal('/reply-method')
       })
       .end(function(err, res){
+        if (err) {
+          done(err);
+          return;
+        }
         res.text.should.equal('method=put');
         done();
       })
@@ -85,6 +93,10 @@ describe('request', function(){
         res.headers.location.should.equal('/reply-method')
       })
       .end(function(err, res){
+        if (err) {
+          done(err);
+          return;
+        }
         res.text.should.equal('method=put');
         done();
       })

--- a/test/redirects.js
+++ b/test/redirects.js
@@ -6,7 +6,7 @@ var assert = require('assert');
 var request = require('../');
 
 describe('request', function(){
-  this.timeout(10000);
+  this.timeout(20000);
   describe('on redirect', function(){
     it('should retain header fields', function(done){
       request

--- a/test/request.js
+++ b/test/request.js
@@ -5,7 +5,7 @@ var assert = require('assert');
 var request = require('../');
 
 describe('request', function() {
-  this.timeout(10000);
+  this.timeout(20000);
 
 it('Request inheritance', function(){
   assert(request.get(uri + '/') instanceof request.Request);

--- a/test/use.js
+++ b/test/use.js
@@ -6,7 +6,7 @@ var assert = require('assert');
 var request = require('../');
 
 describe('request', function(){
-  this.timeout(10000);
+  this.timeout(20000);
   describe('use', function(){
     it('should use plugin success', function(done){
       var now = '' + Date.now();


### PR DESCRIPTION
- 20s timeouts
- latest zuul
- configure SAUCE_APPIUM 1.6

I was seeing our 10s timeouts exceeded a lot in sauce labs for slower browsers/OSes. Increasing to 20s seems empirically to help. :-/