### PR TITLE
DRY Up Response in Node and Browser

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -16,7 +16,6 @@ var Emitter = require('emitter');
 var RequestBase = require('./request-base');
 var isObject = require('./is-object');
 var isFunction = require('./is-function');
-var utils = require('./utils');
 var ResponseBase = require('./response-base');
 
 /**

--- a/lib/client.js
+++ b/lib/client.js
@@ -17,6 +17,7 @@ var RequestBase = require('./request-base');
 var isObject = require('./is-object');
 var isFunction = require('./is-function');
 var utils = require('./utils');
+var ResponseBase = require('./response-base');
 
 /**
  * Noop.
@@ -313,18 +314,6 @@ function Response(req, options) {
 }
 
 /**
- * Get case-insensitive `field` value.
- *
- * @param {String} field
- * @return {String}
- * @api public
- */
-
-Response.prototype.get = function(field){
-  return this.header[field.toLowerCase()];
-};
-
-/**
  * Set header related properties:
  *
  *   - `.type` the content type without params
@@ -345,6 +334,7 @@ Response.prototype._setHeaderProperties = function(header){
   var obj = utils.params(ct);
   for (var key in obj) this[key] = obj[key];
 };
+ResponseBase(Response.prototype);
 
 /**
  * Parse the given body `str`.

--- a/lib/client.js
+++ b/lib/client.js
@@ -16,6 +16,7 @@ var Emitter = require('emitter');
 var RequestBase = require('./request-base');
 var isObject = require('./is-object');
 var isFunction = require('./is-function');
+var utils = require('./utils');
 
 /**
  * Noop.
@@ -245,37 +246,6 @@ function isJSON(mime) {
 }
 
 /**
- * Return the mime type for the given `str`.
- *
- * @param {String} str
- * @return {String}
- * @api private
- */
-
-function type(str){
-  return str.split(/ *; */).shift();
-};
-
-/**
- * Return header field parameters.
- *
- * @param {String} str
- * @return {Object}
- * @api private
- */
-
-function params(str){
-  return str.split(/ *; */).reduce(function(obj, str){
-    var parts = str.split(/ *= */),
-        key = parts.shift(),
-        val = parts.shift();
-
-    if (key && val) obj[key] = val;
-    return obj;
-  }, {});
-};
-
-/**
  * Initialize a new `Response` with the given `xhr`.
  *
  *  - set flags (.ok, .error, etc)
@@ -368,11 +338,11 @@ Response.prototype.get = function(field){
 
 Response.prototype._setHeaderProperties = function(header){
   // content-type
-  var ct = this.header['content-type'] || '';
-  this.type = type(ct);
+  var ct = header['content-type'] || '';
+  this.type = utils.type(ct);
 
   // params
-  var obj = params(ct);
+  var obj = utils.params(ct);
   for (var key in obj) this[key] = obj[key];
 };
 

--- a/lib/client.js
+++ b/lib/client.js
@@ -313,27 +313,6 @@ function Response(req, options) {
     : null;
 }
 
-/**
- * Set header related properties:
- *
- *   - `.type` the content type without params
- *
- * A response of "Content-Type: text/plain; charset=utf-8"
- * will provide you with a `.type` of "text/plain".
- *
- * @param {Object} header
- * @api private
- */
-
-Response.prototype._setHeaderProperties = function(header){
-  // content-type
-  var ct = header['content-type'] || '';
-  this.type = utils.type(ct);
-
-  // params
-  var obj = utils.params(ct);
-  for (var key in obj) this[key] = obj[key];
-};
 ResponseBase(Response.prototype);
 
 /**

--- a/lib/client.js
+++ b/lib/client.js
@@ -342,53 +342,6 @@ Response.prototype._parseBody = function(str){
 };
 
 /**
- * Set flags such as `.ok` based on `status`.
- *
- * For example a 2xx response will give you a `.ok` of __true__
- * whereas 5xx will be __false__ and `.error` will be __true__. The
- * `.clientError` and `.serverError` are also available to be more
- * specific, and `.statusType` is the class of error ranging from 1..5
- * sometimes useful for mapping respond colors etc.
- *
- * "sugar" properties are also defined for common cases. Currently providing:
- *
- *   - .noContent
- *   - .badRequest
- *   - .unauthorized
- *   - .notAcceptable
- *   - .notFound
- *
- * @param {Number} status
- * @api private
- */
-
-Response.prototype._setStatusProperties = function(status){
-  var type = status / 100 | 0;
-
-  // status / class
-  this.status = this.statusCode = status;
-  this.statusType = type;
-
-  // basics
-  this.info = 1 == type;
-  this.ok = 2 == type;
-  this.clientError = 4 == type;
-  this.serverError = 5 == type;
-  this.error = (4 == type || 5 == type)
-    ? this.toError()
-    : false;
-
-  // sugar
-  this.accepted = 202 == status;
-  this.noContent = 204 == status;
-  this.badRequest = 400 == status;
-  this.unauthorized = 401 == status;
-  this.notAcceptable = 406 == status;
-  this.notFound = 404 == status;
-  this.forbidden = 403 == status;
-};
-
-/**
  * Return an `Error` representative of this response.
  *
  * @return {Error}

--- a/lib/client.js
+++ b/lib/client.js
@@ -301,7 +301,12 @@ function Response(req, options) {
      ? this.xhr.responseText
      : null;
   this.statusText = this.req.xhr.statusText;
-  this._setStatusProperties(this.xhr.status);
+  var status = this.xhr.status;
+  // handle IE9 bug: http://stackoverflow.com/questions/10046972/msie-returns-status-code-of-1223-for-ajax-request
+  if (status === 1223) {
+      status = 204;
+  }
+  this._setStatusProperties(status);
   this.header = this.headers = parseHeader(this.xhr.getAllResponseHeaders());
   // getAllResponseHeaders sometimes falsely returns "" for CORS requests, but
   // getResponseHeader still works. so we get content-type even if getting
@@ -358,11 +363,6 @@ Response.prototype._parseBody = function(str){
  */
 
 Response.prototype._setStatusProperties = function(status){
-  // handle IE9 bug: http://stackoverflow.com/questions/10046972/msie-returns-status-code-of-1223-for-ajax-request
-  if (status === 1223) {
-    status = 204;
-  }
-
   var type = status / 100 | 0;
 
   // status / class

--- a/lib/node/index.js
+++ b/lib/node/index.js
@@ -12,7 +12,8 @@ var format = require('url').format;
 var resolve = require('url').resolve;
 var methods = require('methods');
 var Stream = require('stream');
-var utils = require('./utils');
+var utils = require('../utils');
+var unzip = require('./unzip').unzip;
 var extend = require('extend');
 var mime = require('mime');
 var https = require('https');
@@ -787,7 +788,7 @@ Request.prototype.end = function(fn){
 
     // zlib support
     if (self._shouldUnzip(res)) {
-      utils.unzip(req, res);
+      unzip(req, res);
     }
 
     if (!parser) {

--- a/lib/node/response.js
+++ b/lib/node/response.js
@@ -129,7 +129,7 @@ Response.prototype._setHeaderProperties = function(header){
   // TODO: make this a util
 
   // content-type
-  var ct = this.header['content-type'] || '';
+  var ct = header['content-type'] || '';
 
   // params
   var params = utils.params(ct);

--- a/lib/node/response.js
+++ b/lib/node/response.js
@@ -4,7 +4,7 @@
  */
 
 var util = require('util');
-var utils = require('./utils');
+var utils = require('../utils');
 var Stream = require('stream');
 
 /**

--- a/lib/node/response.js
+++ b/lib/node/response.js
@@ -33,7 +33,6 @@ function Response(req, options) {
   var res = this.res = req.res;
   this.request = req;
   this.req = req.req;
-  this.links = {};
   this.text = res.text;
   this.body = res.body !== undefined ? res.body : {};
   this.files = res.files || {};

--- a/lib/node/response.js
+++ b/lib/node/response.js
@@ -4,7 +4,6 @@
  */
 
 var util = require('util');
-var utils = require('../utils');
 var Stream = require('stream');
 var ResponseBase = require('../response-base');
 

--- a/lib/node/response.js
+++ b/lib/node/response.js
@@ -6,6 +6,7 @@
 var util = require('util');
 var utils = require('../utils');
 var Stream = require('stream');
+var ResponseBase = require('../response-base');
 
 /**
  * Expose `Response`.
@@ -53,18 +54,8 @@ function Response(req, options) {
  */
 
 util.inherits(Response, Stream);
+ResponseBase(Response.prototype);
 
-/**
- * Get case-insensitive `field` value.
- *
- * @param {String} field
- * @return {String}
- * @api public
- */
-
-Response.prototype.get = function(field){
-  return this.header[field.toLowerCase()];
-};
 
 /**
  * Implements methods of a `ReadableStream`

--- a/lib/node/response.js
+++ b/lib/node/response.js
@@ -104,39 +104,6 @@ Response.prototype.toError = function(){
 };
 
 /**
- * Set header related properties:
- *
- *   - `.type` the content type without params
- *
- * A response of "Content-Type: text/plain; charset=utf-8"
- * will provide you with a `.type` of "text/plain".
- *
- * @param {Object} header
- * @api private
- */
-
-Response.prototype._setHeaderProperties = function(header){
-  // TODO: moar!
-  // TODO: make this a util
-
-  // content-type
-  var ct = header['content-type'] || '';
-
-  // params
-  var params = utils.params(ct);
-  for (var key in params) this[key] = params[key];
-
-  this.type = utils.type(ct);
-
-  // links
-  try {
-    if (header.link) this.links = utils.parseLinks(header.link);
-  } catch (err) {
-    // ignore
-  }
-};
-
-/**
  * Set flags such as `.ok` based on `status`.
  *
  * For example a 2xx response will give you a `.ok` of __true__

--- a/lib/node/response.js
+++ b/lib/node/response.js
@@ -103,53 +103,6 @@ Response.prototype.toError = function(){
   return err;
 };
 
-/**
- * Set flags such as `.ok` based on `status`.
- *
- * For example a 2xx response will give you a `.ok` of __true__
- * whereas 5xx will be __false__ and `.error` will be __true__. The
- * `.clientError` and `.serverError` are also available to be more
- * specific, and `.statusType` is the class of error ranging from 1..5
- * sometimes useful for mapping respond colors etc.
- *
- * "sugar" properties are also defined for common cases. Currently providing:
- *
- *   - .noContent
- *   - .badRequest
- *   - .unauthorized
- *   - .notAcceptable
- *   - .notFound
- *
- * @param {Number} status
- * @api private
- */
-
-Response.prototype._setStatusProperties = function(status){
-  var type = status / 100 | 0;
-
-  // status / class
-  this.status = this.statusCode = status;
-  this.statusType = type;
-
-  // basics
-  this.info = 1 == type;
-  this.ok = 2 == type;
-  this.redirect = 3 == type;
-  this.clientError = 4 == type;
-  this.serverError = 5 == type;
-  this.error = (4 == type || 5 == type)
-    ? this.toError()
-    : false;
-
-  // sugar
-  this.accepted = 202 == status;
-  this.noContent = 204 == status;
-  this.badRequest = 400 == status;
-  this.unauthorized = 401 == status;
-  this.notAcceptable = 406 == status;
-  this.forbidden = 403 == status;
-  this.notFound = 404 == status;
-};
 
 Response.prototype.setStatusProperties = function(status){
   console.warn("In superagent 2.x setStatusProperties is a private method");

--- a/lib/node/unzip.js
+++ b/lib/node/unzip.js
@@ -16,55 +16,6 @@ try {
 } catch (e) { }
 
 /**
- * Return the mime type for the given `str`.
- *
- * @param {String} str
- * @return {String}
- * @api private
- */
-
-exports.type = function(str){
-  return str.split(/ *; */).shift();
-};
-
-/**
- * Return header field parameters.
- *
- * @param {String} str
- * @return {Object}
- * @api private
- */
-
-exports.params = function(str){
-  return str.split(/ *; */).reduce(function(obj, str){
-    var parts = str.split(/ *= */);
-    var key = parts.shift();
-    var val = parts.shift();
-
-    if (key && val) obj[key] = val;
-    return obj;
-  }, {});
-};
-
-/**
- * Parse Link header fields.
- *
- * @param {String} str
- * @return {Object}
- * @api private
- */
-
-exports.parseLinks = function(str){
-  return str.split(/ *, */).reduce(function(obj, str){
-    var parts = str.split(/ *; */);
-    var url = parts[0].slice(1, -1);
-    var rel = parts[1].split(/ *= */)[1].slice(1, -1);
-    obj[rel] = url;
-    return obj;
-  }, {});
-};
-
-/**
  * Buffers response data events and re-emits when they're unzipped.
  *
  * @param {Request} req
@@ -125,23 +76,4 @@ exports.unzip = function(req, res){
     }
     return this;
   };
-};
-
-/**
- * Strip content related fields from `header`.
- *
- * @param {Object} header
- * @return {Object} header
- * @api private
- */
-
-exports.cleanHeader = function(header, shouldStripCookie){
-  delete header['content-type'];
-  delete header['content-length'];
-  delete header['transfer-encoding'];
-  delete header['host'];
-  if (shouldStripCookie) {
-    delete header['cookie'];
-  }
-  return header;
 };

--- a/lib/response-base.js
+++ b/lib/response-base.js
@@ -1,5 +1,11 @@
 
 /**
+ * Module dependencies.
+ */
+
+var utils = require('./utils');
+
+/**
  * Expose `ResponseBase`.
  */
 
@@ -41,3 +47,36 @@ function mixin(obj) {
 ResponseBase.prototype.get = function(field){
     return this.header[field.toLowerCase()];
 };
+
+/**
+ * Set header related properties:
+ *
+ *   - `.type` the content type without params
+ *
+ * A response of "Content-Type: text/plain; charset=utf-8"
+ * will provide you with a `.type` of "text/plain".
+ *
+ * @param {Object} header
+ * @api private
+ */
+
+ResponseBase.prototype._setHeaderProperties = function(header){
+    // TODO: moar!
+    // TODO: make this a util
+
+    // content-type
+    var ct = header['content-type'] || '';
+    this.type = utils.type(ct);
+
+    // params
+    var params = utils.params(ct);
+    for (var key in params) this[key] = params[key];
+
+    // links
+    try {
+        if (header.link) this.links = utils.parseLinks(header.link);
+    } catch (err) {
+        // ignore
+    }
+};
+

--- a/lib/response-base.js
+++ b/lib/response-base.js
@@ -1,0 +1,43 @@
+
+/**
+ * Expose `ResponseBase`.
+ */
+
+module.exports = ResponseBase;
+
+/**
+ * Initialize a new `ResponseBase`.
+ *
+ * @api public
+ */
+
+function ResponseBase(obj) {
+  if (obj) return mixin(obj);
+}
+
+/**
+ * Mixin the prototype properties.
+ *
+ * @param {Object} obj
+ * @return {Object}
+ * @api private
+ */
+
+function mixin(obj) {
+  for (var key in ResponseBase.prototype) {
+    obj[key] = ResponseBase.prototype[key];
+  }
+  return obj;
+}
+
+/**
+ * Get case-insensitive `field` value.
+ *
+ * @param {String} field
+ * @return {String}
+ * @api public
+ */
+
+ResponseBase.prototype.get = function(field){
+    return this.header[field.toLowerCase()];
+};

--- a/lib/response-base.js
+++ b/lib/response-base.js
@@ -72,6 +72,8 @@ ResponseBase.prototype._setHeaderProperties = function(header){
     var params = utils.params(ct);
     for (var key in params) this[key] = params[key];
 
+    this.links = {};
+
     // links
     try {
         if (header.link) this.links = utils.parseLinks(header.link);

--- a/lib/response-base.js
+++ b/lib/response-base.js
@@ -80,3 +80,50 @@ ResponseBase.prototype._setHeaderProperties = function(header){
     }
 };
 
+/**
+ * Set flags such as `.ok` based on `status`.
+ *
+ * For example a 2xx response will give you a `.ok` of __true__
+ * whereas 5xx will be __false__ and `.error` will be __true__. The
+ * `.clientError` and `.serverError` are also available to be more
+ * specific, and `.statusType` is the class of error ranging from 1..5
+ * sometimes useful for mapping respond colors etc.
+ *
+ * "sugar" properties are also defined for common cases. Currently providing:
+ *
+ *   - .noContent
+ *   - .badRequest
+ *   - .unauthorized
+ *   - .notAcceptable
+ *   - .notFound
+ *
+ * @param {Number} status
+ * @api private
+ */
+
+ResponseBase.prototype._setStatusProperties = function(status){
+    var type = status / 100 | 0;
+
+    // status / class
+    this.status = this.statusCode = status;
+    this.statusType = type;
+
+    // basics
+    this.info = 1 == type;
+    this.ok = 2 == type;
+    this.redirect = 3 == type;
+    this.clientError = 4 == type;
+    this.serverError = 5 == type;
+    this.error = (4 == type || 5 == type)
+        ? this.toError()
+        : false;
+
+    // sugar
+    this.accepted = 202 == status;
+    this.noContent = 204 == status;
+    this.badRequest = 400 == status;
+    this.unauthorized = 401 == status;
+    this.notAcceptable = 406 == status;
+    this.forbidden = 403 == status;
+    this.notFound = 404 == status;
+};

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,0 +1,68 @@
+
+/**
+ * Return the mime type for the given `str`.
+ *
+ * @param {String} str
+ * @return {String}
+ * @api private
+ */
+
+exports.type = function(str){
+  return str.split(/ *; */).shift();
+};
+
+/**
+ * Return header field parameters.
+ *
+ * @param {String} str
+ * @return {Object}
+ * @api private
+ */
+
+exports.params = function(str){
+  return str.split(/ *; */).reduce(function(obj, str){
+    var parts = str.split(/ *= */);
+    var key = parts.shift();
+    var val = parts.shift();
+
+    if (key && val) obj[key] = val;
+    return obj;
+  }, {});
+};
+
+/**
+ * Parse Link header fields.
+ *
+ * @param {String} str
+ * @return {Object}
+ * @api private
+ */
+
+exports.parseLinks = function(str){
+  return str.split(/ *, */).reduce(function(obj, str){
+    var parts = str.split(/ *; */);
+    var url = parts[0].slice(1, -1);
+    var rel = parts[1].split(/ *= */)[1].slice(1, -1);
+    obj[rel] = url;
+    return obj;
+  }, {});
+};
+
+/**
+ * Strip content related fields from `header`.
+ *
+ * @param {Object} header
+ * @return {Object} header
+ * @api private
+ */
+
+exports.cleanHeader = function(header, shouldStripCookie){
+  delete header['content-type'];
+  delete header['content-length'];
+  delete header['transfer-encoding'];
+  delete header['host'];
+  if (shouldStripCookie) {
+    delete header['cookie'];
+  }
+  return header;
+};

--- a/test/node/utils.js
+++ b/test/node/utils.js
@@ -1,5 +1,5 @@
 var assert = require('assert');
-var utils = require('../../lib/node/utils');
+var utils = require('../../lib/utils');
 
 describe('utils.type(str)', function(){
   it('should return the mime type', function(){


### PR DESCRIPTION
Recently we were wondering why parsed `response.links` can be found in the node version of superagent, while not being there in the browser version, after a quick debugging session we found the reason why. In this PR we did the following things to get more parity between node and browser versions:

1.  split `lib/node/utils` into `lib/utils` and `lib/node/unzip`, so that `lib/utils` can be used in the browser code and does not bring unwanted dependencies (namely `unzip`) into the browser.

    Maybe `lib/node/unzip` should be renamed to `lib/node/node-utils` or extend `lib/utils`, but this seemed to be the cleanest solution at the moment.

2.  After that we realized, that the client and node implementation of `Response` share a lot features and therefore moved the following shared functions of `Response` to a `response-base` similar to the `request-base`:

     - `get`
     - `_setHeaderProperties` (Finally we are getting our *precious* `links`)
     - `_setStatusProperties` (The IE9 status quirk was moved to the client Response constructor)

    Maybe the `Response.toError` function could be moved to `ResponseBase` as well, but that's something for another day :)
    
I hope that this PR satisfies your code requirements. If not please let me know and I could improve it further. 