### PR TITLE
Blob should not cause parse errors

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -312,9 +312,14 @@ function Response(req, options) {
   // other headers fails.
   this.header['content-type'] = this.xhr.getResponseHeader('content-type');
   this._setHeaderProperties(this.header);
-  this.body = this.req.method != 'HEAD'
-    ? this._parseBody(this.text ? this.text : this.xhr.response)
-    : null;
+
+  if (null === this.text && req._responseType) {
+    this.body = this.xhr.response;
+  } else {
+    this.body = this.req.method != 'HEAD'
+      ? this._parseBody(this.text ? this.text : this.xhr.response)
+      : null;
+  }
 }
 
 ResponseBase(Response.prototype);

--- a/lib/client.js
+++ b/lib/client.js
@@ -402,10 +402,11 @@ function Request(method, url) {
         // ie9 doesn't have 'response' property
         err.rawResponse = typeof self.xhr.responseType == 'undefined' ? self.xhr.responseText : self.xhr.response;
         // issue #876: return the http status code if the response parsing fails
-        err.statusCode = self.xhr.status ? self.xhr.status : null;
+        err.status = self.xhr.status ? self.xhr.status : null;
+        err.statusCode = err.status; // backwards-compat only
       } else {
         err.rawResponse = null;
-        err.statusCode = null;
+        err.status = null;
       }
 
       return self.callback(err);


### PR DESCRIPTION
Previous test was incorrect. It was looking for error caused by Blob being accidentally parsed as JSON, which doesn't make sense when responseType was explicitly set to be Blob.