### PR TITLE
Update request-base.js

### DIFF
--- a/lib/request-base.js
+++ b/lib/request-base.js
@@ -133,7 +133,7 @@ RequestBase.prototype.timeout = function timeout(options){
  * Promise support
  *
  * @param {Function} resolve
- * @param {Function} reject
+ * @param {Function} [reject]
  * @return {Request}
  */
 


### PR DESCRIPTION
Hello, superagent team!

Recently, after upgrading my WebStorm to 2016 version, I've discovered a JSDoc problem with it, caused by superagent code. Each time I write code like 
```javascript
return Q()
  .then(function() {})
```
WebStorm nags me about some 'Invalid number of parameters, expected 2' issue. A workaround is to just pass null as a second argument, but it sucks to do each time. Digging around led me to this PR - it seems that WebStorm picks up your JSDoc for every .then method. I understand that it may be an issue of WebStorm rather than superagent, but still, could you accept this as a temporary solution? It just makes reject argument optional from JSDoc point of view.

The problem and solution was checked on WebStorm 2016.3.2
