### PR TITLE
client: handle `xhr.open()` errors

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -738,10 +738,15 @@ Request.prototype.end = function(fn){
   this._setTimeouts();
 
   // initiate request
-  if (this.username && this.password) {
-    xhr.open(this.method, this.url, true, this.username, this.password);
-  } else {
-    xhr.open(this.method, this.url, true);
+  try {
+    if (this.username && this.password) {
+      xhr.open(this.method, this.url, true, this.username, this.password);
+    } else {
+      xhr.open(this.method, this.url, true);
+    }
+  } catch (err) {
+    // see #1149
+    return this.callback(err);
   }
 
   // CORS

--- a/test/client/request.js
+++ b/test/client/request.js
@@ -1,3 +1,4 @@
+
 var assert = require('assert');
 var request = require('../../');
 
@@ -277,6 +278,15 @@ it('parse should take precedence over default parse', function(done){
   .end(function(err, res){
     assert(res.ok);
     assert(res.body === 'customText: 200');
+    done();
+  });
+});
+
+it('handles `xhr.open()` errors', function(done){
+  request
+  .get('http://foo\0.com') // throws "Failed to execute 'open' on 'XMLHttpRequest': Invalid URL"
+  .end(function(err, res){
+    assert(err);
     done();
   });
 });


### PR DESCRIPTION
Closes #1149.