### PR TITLE
Throw when using unsupported mix of send and field

### DIFF
--- a/lib/request-base.js
+++ b/lib/request-base.js
@@ -289,7 +289,7 @@ RequestBase.prototype.field = function(name, val) {
   }
 
   if (this._data) {
-    console.error(".field() can't be used if .send() is used. Please use only .send() or only .field() & .attach()");
+    throw new Error(".field() can't be used if .send() is used. Please use only .send() or only .field() & .attach()");
   }
 
   if (isObject(name)) {
@@ -429,7 +429,7 @@ RequestBase.prototype.send = function(data){
   var type = this._header['content-type'];
 
   if (this._formData) {
-    console.error(".send() can't be used if .attach() or .field() is used. Please use only .send() or only .field() & .attach()");
+    throw new Error(".send() can't be used if .attach() or .field() is used. Please use only .send() or only .field() & .attach()");
   }
 
   if (isObj && !this._data) {

--- a/test/client/request.js
+++ b/test/client/request.js
@@ -70,6 +70,29 @@ it('defaults attached files to original file names', function(next){
     });
 });
 
+it('attach() cannot be mixed with send()', function(){
+  if (!window.FormData || !window.File) {
+    // Skip test if FormData is are not supported by browser
+    return;
+  }
+
+  assert.throws(function(){
+    var file = new File([""], "image.jpg", { type: "image/jpeg" });
+    request
+    .post('/echo')
+    .attach('image', file)
+    .send('hi');
+  });
+
+  assert.throws(function(){
+    var file = new File([""], "image.jpg", { type: "image/jpeg" });
+    request
+    .post('/echo')
+    .send('hi')
+    .attach('image', file);
+  });
+});
+
 it('GET invalid json', function(next) {
   request
   .get('/invalid-json')

--- a/test/form.js
+++ b/test/form.js
@@ -114,4 +114,21 @@ describe('req.field', function(){
       .field('name')
     }, /val/);
   });
+
+  it('cannot be mixed with send()', function(){
+    assert.throws(function(){
+      request
+      .post('/echo')
+      .field('form', 'data')
+      .send('hi');
+    });
+
+    assert.throws(function(){
+      request
+      .post('/echo')
+      .send('hi')
+      .field('form', 'data');
+    });
+  });
+
 });


### PR DESCRIPTION
Harsher version of #1153. Probably a breaking change.

Related to #1152

I suggest releasing warning version first, and the throwing version sometime later