### PR TITLE
[WIP] add `Request.retry`

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -17,6 +17,7 @@ var RequestBase = require('./request-base');
 var isObject = require('./is-object');
 var isFunction = require('./is-function');
 var ResponseBase = require('./response-base');
+var shouldRetry = require('./should-retry');
 
 /**
  * Noop.
@@ -390,6 +391,8 @@ function Request(method, url) {
   this.url = url;
   this.header = {}; // preserves header name case
   this._header = {}; // coerces header names to lowercase
+  this._retries = 0;
+  this._maxRetries = 0;
   this.on('end', function(){
     var err = null;
     var res = null;
@@ -528,18 +531,18 @@ Request.prototype.auth = function(user, pass, options){
 };
 
 /**
-* Add query-string `val`.
-*
-* Examples:
-*
-*   request.get('/shoes')
-*     .query('size=10')
-*     .query({ color: 'blue' })
-*
-* @param {Object|String} val
-* @return {Request} for chaining
-* @api public
-*/
+ * Add query-string `val`.
+ *
+ * Examples:
+ *
+ *   request.get('/shoes')
+ *     .query('size=10')
+ *     .query({ color: 'blue' })
+ *
+ * @param {Object|String} val
+ * @return {Request} for chaining
+ * @api public
+ */
 
 Request.prototype.query = function(val){
   if ('string' != typeof val) val = serialize(val);
@@ -590,14 +593,51 @@ Request.prototype._getFormData = function(){
  */
 
 Request.prototype.callback = function(err, res){
+  // console.log(this._retries, this._maxRetries)
+  if (this._maxRetries && this._retries++ < this._maxRetries && shouldRetry(err, res)) {
+    var timeout = 0;
+    var responseTimeout = 0;
+    if (err && err.timeout) {
+      if (err.message.indexOf('Response') == 0) {
+        responseTimeout = err.timeout;
+      } else {
+        timeout = err.timeout;
+      }
+    }
+    return this._retry(timeout, responseTimeout);
+  }
+
   var fn = this._callback;
   this.clearTimeout();
 
   if (err) {
+    if (this._maxRetries) err.attempts = this._retries;
     this.emit('error', err);
   }
 
   fn(err, res);
+};
+
+/**
+ * Retry request
+ *
+ * @return {Request} for chaining
+ * @api private
+ */
+
+Request.prototype._retry = function(timeout, responseTimeout) {
+  this.clearTimeout();
+
+  this._timeout = timeout;
+  this._responseTimeout = responseTimeout;
+  this._aborted = false;
+  this.timedout = false;
+  delete this._timer;
+  delete this._responseTimeoutTimer;
+
+  this._endCalled = false;
+  this.end(this._callback);
+  return this;
 };
 
 /**

--- a/lib/client.js
+++ b/lib/client.js
@@ -600,7 +600,7 @@ Request.prototype.callback = function(err, res){
   this.clearTimeout();
 
   if (err) {
-    if (this._maxRetries) err.attempts = this._retries;
+    if (this._maxRetries) err.retries = this._retries - 1;
     this.emit('error', err);
   }
 

--- a/lib/client.js
+++ b/lib/client.js
@@ -684,10 +684,6 @@ Request.prototype._isHost = function _isHost(obj) {
  */
 
 Request.prototype.end = function(fn){
-  var self = this;
-  var xhr = this.xhr = request.getXHR();
-  var data = this._formData || this._data;
-
   if (this._endCalled) {
     console.warn("Warning: .end() was called twice. This is not supported in superagent");
   }
@@ -695,6 +691,19 @@ Request.prototype.end = function(fn){
 
   // store callback
   this._callback = fn || noop;
+
+  // querystring
+  this._appendQueryString();
+
+  return this._end();
+};
+
+Request.prototype._end = function() {
+  var self = this;
+  var xhr = this.xhr = request.getXHR();
+  var data = this._formData || this._data;
+
+  this._setTimeouts();
 
   // state change
   xhr.onreadystatechange = function(){
@@ -738,11 +747,6 @@ Request.prototype.end = function(fn){
       // https://connect.microsoft.com/IE/feedback/details/837245/xmlhttprequest-upload-throws-invalid-argument-when-used-from-web-worker-context
     }
   }
-
-  // querystring
-  this._appendQueryString();
-
-  this._setTimeouts();
 
   // initiate request
   try {

--- a/lib/client.js
+++ b/lib/client.js
@@ -619,28 +619,6 @@ Request.prototype.callback = function(err, res){
 };
 
 /**
- * Retry request
- *
- * @return {Request} for chaining
- * @api private
- */
-
-Request.prototype._retry = function(timeout, responseTimeout) {
-  this.clearTimeout();
-
-  this._timeout = timeout;
-  this._responseTimeout = responseTimeout;
-  this._aborted = false;
-  this.timedout = false;
-  delete this._timer;
-  delete this._responseTimeoutTimer;
-
-  this._endCalled = false;
-  this.end(this._callback);
-  return this;
-};
-
-/**
  * Invoke callback with x-domain error.
  *
  * @api private

--- a/lib/client.js
+++ b/lib/client.js
@@ -391,8 +391,6 @@ function Request(method, url) {
   this.url = url;
   this.header = {}; // preserves header name case
   this._header = {}; // coerces header names to lowercase
-  this._retries = 0;
-  this._maxRetries = 0;
   this.on('end', function(){
     var err = null;
     var res = null;

--- a/lib/client.js
+++ b/lib/client.js
@@ -593,16 +593,7 @@ Request.prototype._getFormData = function(){
 Request.prototype.callback = function(err, res){
   // console.log(this._retries, this._maxRetries)
   if (this._maxRetries && this._retries++ < this._maxRetries && shouldRetry(err, res)) {
-    var timeout = 0;
-    var responseTimeout = 0;
-    if (err && err.timeout) {
-      if (err.message.indexOf('Response') == 0) {
-        responseTimeout = err.timeout;
-      } else {
-        timeout = err.timeout;
-      }
-    }
-    return this._retry(timeout, responseTimeout);
+    return this._retry();
   }
 
   var fn = this._callback;

--- a/lib/node/index.js
+++ b/lib/node/index.js
@@ -142,8 +142,6 @@ function Request(method, url) {
   this.writable = true;
   this._redirects = 0;
   this.redirects(method === 'HEAD' ? 0 : 5);
-  this._retries = 0;
-  this._maxRetries = 0;
   this.cookies = '';
   this.qs = {};
   this.qsRaw = [];

--- a/lib/node/index.js
+++ b/lib/node/index.js
@@ -647,12 +647,9 @@ Request.prototype.request = function(){
  */
 
 Request.prototype.callback = function(err, res){
-  console.trace(this._retries, this._maxRetries)
-  var attempts = 0;
-  if (this._retries++ <= this._maxRetries && utils.shouldRetry(err, res)) {
+  // console.log(this._retries, this._maxRetries)
+  if (this._maxRetries && this._retries++ <= this._maxRetries && utils.shouldRetry(err, res)) {
     return this._retry();
-  } else if (this._maxRetries > 0) {
-    attempts = this._retries - 1;
   }
 
   // Avoid the error which is emitted from 'socket hang up' to cause the fn undefined error on JS runtime.
@@ -675,7 +672,7 @@ Request.prototype.callback = function(err, res){
   }
 
   err.response = res;
-  if (attempts) err.attempts = attempts;
+  if (this._maxRetries) err.attempts = this._retries - 1;
 
   // only emit error event if there is a listener
   // otherwise we assume the callback to `.end()` will get the error

--- a/lib/node/index.js
+++ b/lib/node/index.js
@@ -25,6 +25,7 @@ var util = require('util');
 var pkg = require('../../package.json');
 var RequestBase = require('../request-base');
 var isFunction = require('../is-function');
+var shouldRetry = require('../should-retry');
 
 var request = exports = module.exports = function(method, url) {
   // callback
@@ -485,7 +486,6 @@ Request.prototype._retry = function(timeout, responseTimeout) {
   delete this._responseTimeoutTimer;
 
   this._endCalled = false;
-  this._retrying = true;
   this.end(this._callback);
   return this;
 };
@@ -662,7 +662,7 @@ Request.prototype.request = function(){
 
 Request.prototype.callback = function(err, res){
   // console.log(this._retries, this._maxRetries)
-  if (this._maxRetries && this._retries++ <= this._maxRetries && utils.shouldRetry(err, res)) {
+  if (this._maxRetries && this._retries++ < this._maxRetries && shouldRetry(err, res)) {
     var timeout = 0;
     var responseTimeout = 0;
     if (err && err.timeout) {
@@ -695,7 +695,7 @@ Request.prototype.callback = function(err, res){
   }
 
   err.response = res;
-  if (this._maxRetries) err.attempts = this._retries - 1;
+  if (this._maxRetries) err.attempts = this._retries;
 
   // only emit error event if there is a listener
   // otherwise we assume the callback to `.end()` will get the error

--- a/lib/node/index.js
+++ b/lib/node/index.js
@@ -550,6 +550,7 @@ Request.prototype.request = function(){
   var self = this;
   var options = {};
   var url = this.url;
+  var retries = this._retries;
 
   // default to http://
   if (0 != url.indexOf('http')) url = 'http://' + url;
@@ -596,8 +597,9 @@ Request.prototype.request = function(){
     // because node will emit a faux-error "socket hang up"
     // when request is aborted before a connection is made
     if (self._aborted) return;
-    // flag retry here for out timeouts (same as above)
-    if (self._retries) return;
+    // if not the same, we are in the **old** (cancelled) request,
+    // so need to continue (same as for above)
+    if (self._retries !== retries) return;
     // if we've recieved a response then we don't want to let
     // an error in the request blow up the response
     if (self.response) return;

--- a/lib/node/index.js
+++ b/lib/node/index.js
@@ -661,7 +661,7 @@ Request.prototype.callback = function(err, res){
   }
 
   err.response = res;
-  if (this._maxRetries) err.attempts = this._retries;
+  if (this._maxRetries) err.retries = this._retries - 1;
 
   // only emit error event if there is a listener
   // otherwise we assume the callback to `.end()` will get the error

--- a/lib/node/index.js
+++ b/lib/node/index.js
@@ -636,16 +636,7 @@ Request.prototype.request = function(){
 Request.prototype.callback = function(err, res){
   // console.log(this._retries, this._maxRetries)
   if (this._maxRetries && this._retries++ < this._maxRetries && shouldRetry(err, res)) {
-    var timeout = 0;
-    var responseTimeout = 0;
-    if (err && err.timeout) {
-      if (err.message.indexOf('Response') == 0) {
-        responseTimeout = err.timeout;
-      } else {
-        timeout = err.timeout;
-      }
-    }
-    return this._retry(timeout, responseTimeout);
+    return this._retry();
   }
 
   // Avoid the error which is emitted from 'socket hang up' to cause the fn undefined error on JS runtime.

--- a/lib/node/index.js
+++ b/lib/node/index.js
@@ -141,6 +141,8 @@ function Request(method, url) {
   this.writable = true;
   this._redirects = 0;
   this.redirects(method === 'HEAD' ? 0 : 5);
+  this._retries = 0;
+  this._maxRetries = 0;
   this.cookies = '';
   this.qs = {};
   this.qsRaw = [];
@@ -462,6 +464,20 @@ Request.prototype._redirect = function(res){
   return this;
 };
 
+Request.prototype._retry = function() {
+  console.log('_retry')
+  this.clearTimeout();
+
+  this.set(this.req._headers);
+  this.req.removeAllListeners();
+  delete this.req;
+
+  this._endCalled = false;
+  this.emit('retry');
+  this.end(this._callback);
+  return this;
+};
+
 /**
  * Set Authorization field value with `user` and `pass`.
  *
@@ -631,6 +647,14 @@ Request.prototype.request = function(){
  */
 
 Request.prototype.callback = function(err, res){
+  console.trace(this._retries, this._maxRetries)
+  var attempts = 0;
+  if (this._retries++ <= this._maxRetries && utils.shouldRetry(err, res)) {
+    return this._retry();
+  } else if (this._maxRetries > 0) {
+    attempts = this._retries - 1;
+  }
+
   // Avoid the error which is emitted from 'socket hang up' to cause the fn undefined error on JS runtime.
   var fn = this._callback || noop;
   this.clearTimeout();
@@ -651,6 +675,7 @@ Request.prototype.callback = function(err, res){
   }
 
   err.response = res;
+  if (attempts) err.attempts = attempts;
 
   // only emit error event if there is a listener
   // otherwise we assume the callback to `.end()` will get the error

--- a/lib/node/index.js
+++ b/lib/node/index.js
@@ -731,11 +731,7 @@ Request.prototype._emitResponse = function(body, files){
 };
 
 Request.prototype.end = function(fn){
-  var self = this;
-  var data = this._data;
   var req = this.request();
-  var buffer = this._buffer;
-  var method = this.method;
   debug('%s %s', this.method, this.url);
 
   if (this._endCalled) {
@@ -752,6 +748,16 @@ Request.prototype.end = function(fn){
   } catch (e) {
     return this.callback(e);
   }
+
+  return this._end();
+};
+
+Request.prototype._end = function() {
+  var self = this;
+  var data = this._data;
+  var req = this.req;
+  var buffer = this._buffer;
+  var method = this.method;
 
   this._setTimeouts();
 

--- a/lib/node/index.js
+++ b/lib/node/index.js
@@ -466,31 +466,6 @@ Request.prototype._redirect = function(res){
 };
 
 /**
- * Retry request
- *
- * @return {Request} for chaining
- * @api private
- */
-
-Request.prototype._retry = function(timeout, responseTimeout) {
-  this.clearTimeout();
-
-  this.set(this.req._headers);
-  delete this.req;
-
-  this._timeout = timeout;
-  this._responseTimeout = responseTimeout;
-  this._aborted = false;
-  this.timedout = false;
-  delete this._timer;
-  delete this._responseTimeoutTimer;
-
-  this._endCalled = false;
-  this.end(this._callback);
-  return this;
-};
-
-/**
  * Set Authorization field value with `user` and `pass`.
  *
  * Examples:

--- a/lib/node/index.js
+++ b/lib/node/index.js
@@ -464,16 +464,28 @@ Request.prototype._redirect = function(res){
   return this;
 };
 
-Request.prototype._retry = function() {
-  console.log('_retry')
+/**
+ * Retry request
+ *
+ * @return {Request} for chaining
+ * @api private
+ */
+
+Request.prototype._retry = function(timeout, responseTimeout) {
   this.clearTimeout();
 
   this.set(this.req._headers);
-  this.req.removeAllListeners();
   delete this.req;
 
+  this._timeout = timeout;
+  this._responseTimeout = responseTimeout;
+  this._aborted = false;
+  this.timedout = false;
+  delete this._timer;
+  delete this._responseTimeoutTimer;
+
   this._endCalled = false;
-  this.emit('retry');
+  this._retrying = true;
   this.end(this._callback);
   return this;
 };
@@ -611,6 +623,8 @@ Request.prototype.request = function(){
     // because node will emit a faux-error "socket hang up"
     // when request is aborted before a connection is made
     if (self._aborted) return;
+    // flag retry here for out timeouts (same as above)
+    if (self._retries) return;
     // if we've recieved a response then we don't want to let
     // an error in the request blow up the response
     if (self.response) return;
@@ -649,7 +663,16 @@ Request.prototype.request = function(){
 Request.prototype.callback = function(err, res){
   // console.log(this._retries, this._maxRetries)
   if (this._maxRetries && this._retries++ <= this._maxRetries && utils.shouldRetry(err, res)) {
-    return this._retry();
+    var timeout = 0;
+    var responseTimeout = 0;
+    if (err && err.timeout) {
+      if (err.message.indexOf('Response') == 0) {
+        responseTimeout = err.timeout;
+      } else {
+        timeout = err.timeout;
+      }
+    }
+    return this._retry(timeout, responseTimeout);
   }
 
   // Avoid the error which is emitted from 'socket hang up' to cause the fn undefined error on JS runtime.

--- a/lib/request-base.js
+++ b/lib/request-base.js
@@ -130,6 +130,21 @@ RequestBase.prototype.timeout = function timeout(options){
 };
 
 /**
+ * Set number of retry attempts on error.
+ *
+ * Failed requests will be retried 'count' times if timeout or err.code >= 500.
+ *
+ * @param {Number} count
+ * @return {Request} for chaining
+ * @api public
+ */
+
+RequestBase.prototype.retry = function retry(count){
+  this._retries = count || 0;
+  return this;
+};
+
+/**
  * Promise support
  *
  * @param {Function} resolve

--- a/lib/request-base.js
+++ b/lib/request-base.js
@@ -44,6 +44,8 @@ function mixin(obj) {
 RequestBase.prototype.clearTimeout = function _clearTimeout(){
   clearTimeout(this._timer);
   clearTimeout(this._responseTimeoutTimer);
+  delete this._timer;
+  delete this._responseTimeoutTimer;
   return this;
 };
 
@@ -161,8 +163,6 @@ RequestBase.prototype._retry = function() {
 
   this._aborted = false;
   this.timedout = false;
-  delete this._timer;
-  delete this._responseTimeoutTimer;
 
   return this._end();
 };

--- a/lib/request-base.js
+++ b/lib/request-base.js
@@ -155,7 +155,6 @@ RequestBase.prototype._retry = function() {
 
   // node
   if (this.req) {
-    this.set(this.req._headers);
     delete this.req;
   }
 

--- a/lib/request-base.js
+++ b/lib/request-base.js
@@ -155,7 +155,8 @@ RequestBase.prototype._retry = function() {
 
   // node
   if (this.req) {
-    delete this.req;
+    this.req = null;
+    this.req = this.request();
   }
 
   this._aborted = false;
@@ -163,9 +164,7 @@ RequestBase.prototype._retry = function() {
   delete this._timer;
   delete this._responseTimeoutTimer;
 
-  this._endCalled = false;
-  this.end(this._callback);
-  return this;
+  return this._end();
 };
 
 /**

--- a/lib/request-base.js
+++ b/lib/request-base.js
@@ -140,7 +140,8 @@ RequestBase.prototype.timeout = function timeout(options){
  */
 
 RequestBase.prototype.retry = function retry(count){
-  this._retries = count || 0;
+  this._maxRetries = count || 1;
+  this._retries = 0;
   return this;
 };
 

--- a/lib/request-base.js
+++ b/lib/request-base.js
@@ -42,8 +42,6 @@ function mixin(obj) {
  */
 
 RequestBase.prototype.clearTimeout = function _clearTimeout(){
-  this._timeout = 0;
-  this._responseTimeout = 0;
   clearTimeout(this._timer);
   clearTimeout(this._responseTimeoutTimer);
   return this;
@@ -152,7 +150,7 @@ RequestBase.prototype.retry = function retry(count){
  * @api private
  */
 
-RequestBase.prototype._retry = function(timeout, responseTimeout) {
+RequestBase.prototype._retry = function() {
   this.clearTimeout();
 
   // node
@@ -161,8 +159,6 @@ RequestBase.prototype._retry = function(timeout, responseTimeout) {
     delete this.req;
   }
 
-  this._timeout = timeout;
-  this._responseTimeout = responseTimeout;
   this._aborted = false;
   this.timedout = false;
   delete this._timer;

--- a/lib/request-base.js
+++ b/lib/request-base.js
@@ -146,6 +146,34 @@ RequestBase.prototype.retry = function retry(count){
 };
 
 /**
+ * Retry request
+ *
+ * @return {Request} for chaining
+ * @api private
+ */
+
+RequestBase.prototype._retry = function(timeout, responseTimeout) {
+  this.clearTimeout();
+
+  // node
+  if (this.req) {
+    this.set(this.req._headers);
+    delete this.req;
+  }
+
+  this._timeout = timeout;
+  this._responseTimeout = responseTimeout;
+  this._aborted = false;
+  this.timedout = false;
+  delete this._timer;
+  delete this._responseTimeoutTimer;
+
+  this._endCalled = false;
+  this.end(this._callback);
+  return this;
+};
+
+/**
  * Promise support
  *
  * @param {Function} resolve

--- a/lib/should-retry.js
+++ b/lib/should-retry.js
@@ -1,0 +1,22 @@
+var ERROR_CODES = [
+  'ECONNRESET',
+  'ETIMEDOUT',
+  'EADDRINFO',
+  'ESOCKETTIMEDOUT'
+];
+
+/**
+ * Determine if a request should be retried.
+ * (Borrowed from segmentio/superagent-retry)
+ *
+ * @param {Error} err
+ * @param {Response} [res]
+ * @returns {Boolean}
+ */
+module.exports = function shouldRetry(err, res) {
+  if (err && err.code && ~ERROR_CODES.indexOf(err.code)) return true;
+  if (res && res.status && res.status >= 500) return true;
+  // Superagent timeout
+  if (err && 'timeout' in err && err.code == 'ECONNABORTED') return true;
+  return false;
+};

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -66,3 +66,26 @@ exports.cleanHeader = function(header, shouldStripCookie){
   }
   return header;
 };
+
+var ERROR_CODES = [
+  'ECONNRESET',
+  'ETIMEDOUT',
+  'EADDRINFO',
+  'ESOCKETTIMEDOUT'
+];
+
+/**
+ * Determine if a request should be retried.
+ * (Borrowed from segmentio/superagent-retry)
+ *
+ * @param {Error} err
+ * @param {Response} [res]
+ * @returns {Boolean}
+ */
+exports.shouldRetry = function(err, res) {
+  if (err && err.code && ~ERROR_CODES.indexOf(err.code)) return true;
+  if (res && res.status && res.status >= 500) return true;
+  // Superagent timeout
+  if (err && 'timeout' in err && err.code == 'ECONNABORTED') return true;
+  return false;
+};

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -66,26 +66,3 @@ exports.cleanHeader = function(header, shouldStripCookie){
   }
   return header;
 };
-
-var ERROR_CODES = [
-  'ECONNRESET',
-  'ETIMEDOUT',
-  'EADDRINFO',
-  'ESOCKETTIMEDOUT'
-];
-
-/**
- * Determine if a request should be retried.
- * (Borrowed from segmentio/superagent-retry)
- *
- * @param {Error} err
- * @param {Response} [res]
- * @returns {Boolean}
- */
-exports.shouldRetry = function(err, res) {
-  if (err && err.code && ~ERROR_CODES.indexOf(err.code)) return true;
-  if (res && res.status && res.status >= 500) return true;
-  // Superagent timeout
-  if (err && 'timeout' in err && err.code == 'ECONNABORTED') return true;
-  return false;
-};

--- a/test/redirects.js
+++ b/test/redirects.js
@@ -37,6 +37,32 @@ describe('request', function(){
         }
       });
     })
+
+    it('should successfully redirect after retry on error', function(done){
+      var id = Math.random() * 1000000 * Date.now();
+      request
+      .get(base + '/error/redirect/' + id)
+      .retry(2)
+      .end(function(err, res){
+        assert(res.ok, 'response should be ok');
+        assert(res.text, 'first movie page');
+        done();
+      });
+    });
+
+    it('should preserve retries across redirects', function(done) {
+      var id = Math.random() * 1000000 * Date.now();
+      request
+      .get(base + '/error/redirect-error' + id)
+      .retry(2)
+      .end(function(err, res){
+        assert(err, 'expected an error');
+        assert.equal(2, err.retries, 'expected an error with .retries');
+        assert.equal(500, err.status, 'expected an error status of 500');
+        done();
+      });
+
+    });
   });
 
   describe('on 303', function(){

--- a/test/retry.js
+++ b/test/retry.js
@@ -1,0 +1,40 @@
+var setup = require('./support/setup');
+var base = setup.uri;
+var assert = require('assert');
+var request = require('../');
+
+describe('.retry(count)', function(){
+  this.timeout(15000);
+
+  it('should handle server error after repeat attempt', function(done){
+    request
+    .get(base + '/error')
+    .retry(2)
+    .end(function(err, res){
+      assert(err, 'expected an error');
+      assert.equal(3, err.attempts, 'expected an error with .attempts');
+      assert.equal(500, err.status, 'expected an error status of 500');
+      done();
+    });
+  });
+
+  it('should handle successful request after repeat attempt from server error', function(done){
+    request
+    .get(base + '/error/ok')
+    .retry(2)
+    .end(function(err, res){
+      assert(res instanceof request.Response, 'respond with Response');
+      assert(res.ok, 'response should be ok');
+      assert(res.text, 'res.text');
+      done();
+    });
+  });
+
+  it('should handle successful redirected request after repeat attempt from server error');
+
+  it('should handle server timeout error after repeat attempt');
+
+  it('should handle successful request after repeat attempt from server timeout');
+
+  it('should emit event on retry');
+})

--- a/test/retry.js
+++ b/test/retry.js
@@ -12,7 +12,7 @@ describe('.retry(count)', function(){
     .retry(2)
     .end(function(err, res){
       assert(err, 'expected an error');
-      assert.equal(3, err.attempts, 'expected an error with .attempts');
+      assert.equal(2, err.retries, 'expected an error with .attempts');
       assert.equal(500, err.status, 'expected an error status of 500');
       done();
     });
@@ -36,7 +36,7 @@ describe('.retry(count)', function(){
     .retry(2)
     .end(function(err, res){
       assert(err, 'expected an error');
-      assert.equal(3, err.attempts, 'expected an error with .attempts');
+      assert.equal(2, err.retries, 'expected an error with .attempts');
       assert.equal('number', typeof err.timeout, 'expected an error with .timeout');
       assert.equal('ECONNABORTED', err.code, 'expected abort error code')
       done();

--- a/test/retry.js
+++ b/test/retry.js
@@ -57,5 +57,30 @@ describe('.retry(count)', function(){
     });
   });
 
+  it('should correctly abort a retry attempt', function(done) {
+    var aborted = false;
+    var req = request
+    .get(base + '/delay/200')
+    .timeout(100)
+    .retry(2)
+    .end(function(err, res){
+      try {
+        assert(false, 'should not complete the request');
+      } catch(e) { done(e); }
+    });
+
+    req.on('abort', function() {
+      aborted = true;
+    });
+
+    setTimeout(function() {
+      req.abort();
+      setTimeout(function() {
+        assert(aborted, 'should be aborted');
+        done();
+      }, 150)
+    }, 150);
+  });
+
   it('should handle successful redirected request after repeat attempt from server error');
 })

--- a/test/retry.js
+++ b/test/retry.js
@@ -19,8 +19,9 @@ describe('.retry(count)', function(){
   });
 
   it('should handle successful request after repeat attempt from server error', function(done){
+    var id = Math.random() * 1000000 * Date.now();
     request
-    .get(base + '/error/ok')
+    .get(base + '/error/ok/' + id)
     .retry(2)
     .end(function(err, res){
       assert(res.ok, 'response should be ok');
@@ -44,8 +45,9 @@ describe('.retry(count)', function(){
   });
 
   it('should handle successful request after repeat attempt from server timeout', function(done) {
+    var id = Math.random() * 1000000 * Date.now();
     request
-    .get(base + '/delay/150/ok')
+    .get(base + '/delay/150/ok/' + id)
     .timeout(50)
     .retry(2)
     .end(function(err, res){

--- a/test/retry.js
+++ b/test/retry.js
@@ -23,7 +23,6 @@ describe('.retry(count)', function(){
     .get(base + '/error/ok')
     .retry(2)
     .end(function(err, res){
-      assert(res instanceof request.Response, 'respond with Response');
       assert(res.ok, 'response should be ok');
       assert(res.text, 'res.text');
       done();
@@ -50,7 +49,6 @@ describe('.retry(count)', function(){
     .timeout(50)
     .retry(2)
     .end(function(err, res){
-      assert(res instanceof request.Response, 'respond with Response');
       assert(res.ok, 'response should be ok');
       assert(res.text, 'res.text');
       done();

--- a/test/retry.js
+++ b/test/retry.js
@@ -30,11 +30,32 @@ describe('.retry(count)', function(){
     });
   });
 
+  it('should handle server timeout error after repeat attempt', function(done) {
+    request
+    .get(base + '/delay/150')
+    .timeout(50)
+    .retry(2)
+    .end(function(err, res){
+      assert(err, 'expected an error');
+      assert.equal(3, err.attempts, 'expected an error with .attempts');
+      assert.equal('number', typeof err.timeout, 'expected an error with .timeout');
+      assert.equal('ECONNABORTED', err.code, 'expected abort error code')
+      done();
+    });
+  });
+
+  it('should handle successful request after repeat attempt from server timeout', function(done) {
+    request
+    .get(base + '/delay/150/ok')
+    .timeout(50)
+    .retry(2)
+    .end(function(err, res){
+      assert(res instanceof request.Response, 'respond with Response');
+      assert(res.ok, 'response should be ok');
+      assert(res.text, 'res.text');
+      done();
+    });
+  });
+
   it('should handle successful redirected request after repeat attempt from server error');
-
-  it('should handle server timeout error after repeat attempt');
-
-  it('should handle successful request after repeat attempt from server timeout');
-
-  it('should emit event on retry');
 })

--- a/test/support/server.js
+++ b/test/support/server.js
@@ -417,30 +417,51 @@ app.get('/if-mod', function(req, res){
   }
 });
 
-var errored = {};
+var called = {};
 app.get('/error/ok/:id', function(req, res) {
   var id = req.params.id;
-  if (!errored[id]) {
-    errored[id] = true;
+  if (!called[id]) {
+    called[id] = true;
     res.status(500).send('boom');
   } else {
-    res.send('ok');
-    delete errored[id];
+    res.send(req.headers);
+    delete called[id];
   }
 });
 
-var delayed = {};
 app.get('/delay/:ms/ok/:id', function(req, res){
   var id = req.params.id;
-  if (!delayed[id]) {
-    delayed[id] = true;
+  if (!called[id]) {
+    called[id] = true;
     var ms = ~~req.params.ms;
     setTimeout(function(){
       res.sendStatus(200);
     }, ms);
   } else {
     res.send('ok');
-    delete delayed[id];
+    delete called[id];
+  }
+});
+
+app.get('/error/redirect/:id', function(req, res) {
+  var id = req.params.id;
+  if (!called[id]) {
+    called[id] = true;
+    res.status(500).send('boom');
+  } else {
+    res.redirect('/movies');
+    delete called[id];
+  }
+});
+
+app.get('/error/redirect-error:id', function(req, res) {
+  var id = req.params.id;
+  if (!called[id]) {
+    called[id] = true;
+    res.status(500).send('boom');
+  } else {
+    res.redirect('/error');
+    delete called[id];
   }
 });
 

--- a/test/support/server.js
+++ b/test/support/server.js
@@ -417,13 +417,26 @@ app.get('/if-mod', function(req, res){
   }
 });
 
-var attempts = 0;
+var errAttempts = 0;
 app.get('/error/ok', function(req, res) {
-  if (!attempts++) {
+  if (!errAttempts++) {
     res.status(500).send('boom');
   } else {
     res.send('ok');
-    attempts = 0;
+    errAttempts = 0;
+  }
+});
+
+var delayAttempts = 0;
+app.get('/delay/:ms/ok', function(req, res){
+  if (!delayAttempts++) {
+    var ms = ~~req.params.ms;
+    setTimeout(function(){
+      res.sendStatus(200);
+    }, ms);
+  } else {
+    res.send('ok');
+    delayAttempts = 0;
   }
 });
 

--- a/test/support/server.js
+++ b/test/support/server.js
@@ -417,4 +417,14 @@ app.get('/if-mod', function(req, res){
   }
 });
 
+var attempts = 0;
+app.get('/error/ok', function(req, res) {
+  if (!attempts++) {
+    res.status(500).send('boom');
+  } else {
+    res.send('ok');
+    attempts = 0;
+  }
+});
+
 app.listen(process.env.ZUUL_PORT);

--- a/test/support/server.js
+++ b/test/support/server.js
@@ -417,26 +417,30 @@ app.get('/if-mod', function(req, res){
   }
 });
 
-var errAttempts = 0;
-app.get('/error/ok', function(req, res) {
-  if (!errAttempts++) {
+var errored = {};
+app.get('/error/ok/:id', function(req, res) {
+  var id = req.params.id;
+  if (!errored[id]) {
+    errored[id] = true;
     res.status(500).send('boom');
   } else {
     res.send('ok');
-    errAttempts = 0;
+    delete errored[id];
   }
 });
 
-var delayAttempts = 0;
-app.get('/delay/:ms/ok', function(req, res){
-  if (!delayAttempts++) {
+var delayed = {};
+app.get('/delay/:ms/ok/:id', function(req, res){
+  var id = req.params.id;
+  if (!delayed[id]) {
+    delayed[id] = true;
     var ms = ~~req.params.ms;
     setTimeout(function(){
       res.sendStatus(200);
     }, ms);
   } else {
     res.send('ok');
-    delayAttempts = 0;
+    delete delayed[id];
   }
 });
 


### PR DESCRIPTION
I'm just opening this early sketch to see if there is interest in adding a `Request.retry` method. I'm aware of [segmentio/superagent-retry](https://github.com/segmentio/superagent-retry), but it relies on some hacky behaviour to reset state between attempts, and doesn't seem to work with newer versions of `superagent`. There would seem to be quite a bit of resetting necessary to make this work properly for errors, timeouts, and aborts, so I think it might be better done as a core method rather than a plugin.

In any case, I'd be happy to work on adding this if there is interest.

Progress:
- [x] Node: retry for errors
- [x] Node: retry for timeouts
- [x] Browser: retry for errors
- [x] Browser: retry for timeouts
- [x] Node: retry with redirects
- [x] refactor `end()` into 2 phases for "lightweight" retry?