### PR TITLE
Allow optional body/data in DELETE requests

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -847,16 +847,19 @@ request.options = function(url, data, fn){
 };
 
 /**
- * DELETE `url` with optional callback `fn(res)`.
+ * DELETE `url` with optional `data` and callback `fn(res)`.
  *
  * @param {String} url
+ * @param {Mixed} [data]
  * @param {Function} [fn]
  * @return {Request}
  * @api public
  */
 
-function del(url, fn){
+function del(url, data, fn){
   var req = request('DELETE', url);
+  if ('function' == typeof data) fn = data, data = null;
+  if (data) req.send(data);
   if (fn) req.end(fn);
   return req;
 };


### PR DESCRIPTION
endpoints with DELETE methods can accept a body in the request, we need this feature in superagent so we can use `supertest` to test delete endpoints.