### PR TITLE
validate retry() `count` and allow setting to 0

### DIFF
--- a/lib/request-base.js
+++ b/lib/request-base.js
@@ -140,7 +140,8 @@ RequestBase.prototype.timeout = function timeout(options){
  */
 
 RequestBase.prototype.retry = function retry(count){
-  this._maxRetries = count || 1;
+  if (count == null || count < 0) count = 1;
+  this._maxRetries = count;
   this._retries = 0;
   return this;
 };

--- a/lib/request-base.js
+++ b/lib/request-base.js
@@ -140,7 +140,8 @@ RequestBase.prototype.timeout = function timeout(options){
  */
 
 RequestBase.prototype.retry = function retry(count){
-  if (count == null || count < 0) count = 1;
+  if (count == null) count = 1;
+  if (count < 0) count = 0;
   this._maxRetries = count;
   this._retries = 0;
   return this;

--- a/lib/request-base.js
+++ b/lib/request-base.js
@@ -140,8 +140,9 @@ RequestBase.prototype.timeout = function timeout(options){
  */
 
 RequestBase.prototype.retry = function retry(count){
-  if (count == null) count = 1;
-  if (count < 0) count = 0;
+  // Default to 1 if no count passed or true
+  if (!('0' in arguments) || count === true) count = 1;
+  if (count == null || count <= 0) count = 0;
   this._maxRetries = count;
   this._retries = 0;
   return this;

--- a/test/retry.js
+++ b/test/retry.js
@@ -26,14 +26,14 @@ describe('.retry(count)', function(){
     });
   });
 
-  it('should handle server error after repeat attempt', function(done){
+  it('should not retry if passed an invalid number', function(done){
     request
     .get(base + '/error')
-    .retry(2)
+    .retry(-2)
     .end(function(err, res){
       try {
       assert(err, 'expected an error');
-      assert.equal(2, err.retries, 'expected an error with .retries');
+      assert.equal(undefined, err.retries, 'expected an error without .retries');
       assert.equal(500, err.status, 'expected an error status of 500');
       done();
       } catch(err) {
@@ -42,14 +42,14 @@ describe('.retry(count)', function(){
     });
   });
 
-  it('should retry if passed an invalid number', function(done){
+  it('should handle server error after repeat attempt', function(done){
     request
     .get(base + '/error')
-    .retry(-2)
+    .retry(2)
     .end(function(err, res){
       try {
       assert(err, 'expected an error');
-      assert.equal(1, err.retries, 'expected an error with .retries');
+      assert.equal(2, err.retries, 'expected an error with .retries');
       assert.equal(500, err.status, 'expected an error status of 500');
       done();
       } catch(err) {

--- a/test/retry.js
+++ b/test/retry.js
@@ -42,6 +42,22 @@ describe('.retry(count)', function(){
     });
   });
 
+  it('should not retry if passed undefined', function(done){
+    request
+    .get(base + '/error')
+    .retry(undefined)
+    .end(function(err, res){
+      try {
+      assert(err, 'expected an error');
+      assert.equal(undefined, err.retries, 'expected an error without .retries');
+      assert.equal(500, err.status, 'expected an error status of 500');
+      done();
+      } catch(err) {
+        done(err);
+      }
+    });
+  });
+
   it('should handle server error after repeat attempt', function(done){
     request
     .get(base + '/error')
@@ -62,6 +78,22 @@ describe('.retry(count)', function(){
     request
     .get(base + '/error')
     .retry()
+    .end(function(err, res){
+      try {
+      assert(err, 'expected an error');
+      assert.equal(1, err.retries, 'expected an error with .retries');
+      assert.equal(500, err.status, 'expected an error status of 500');
+      done();
+      } catch(err) {
+        done(err);
+      }
+    });
+  });
+
+  it('should retry if passed "true"', function(done){
+    request
+    .get(base + '/error')
+    .retry(true)
     .end(function(err, res){
       try {
       assert(err, 'expected an error');

--- a/test/retry.js
+++ b/test/retry.js
@@ -10,6 +10,22 @@ function uniqid() {
 describe('.retry(count)', function(){
   this.timeout(15000);
 
+  it('should not retry if passed "0"', function(done){
+    request
+    .get(base + '/error')
+    .retry(0)
+    .end(function(err, res){
+      try {
+      assert(err, 'expected an error');
+      assert.equal(undefined, err.retries, 'expected an error without .retries');
+      assert.equal(500, err.status, 'expected an error status of 500');
+      done();
+      } catch(err) {
+        done(err);
+      }
+    });
+  });
+
   it('should handle server error after repeat attempt', function(done){
     request
     .get(base + '/error')
@@ -18,6 +34,38 @@ describe('.retry(count)', function(){
       try {
       assert(err, 'expected an error');
       assert.equal(2, err.retries, 'expected an error with .retries');
+      assert.equal(500, err.status, 'expected an error status of 500');
+      done();
+      } catch(err) {
+        done(err);
+      }
+    });
+  });
+
+  it('should retry if passed an invalid number', function(done){
+    request
+    .get(base + '/error')
+    .retry(-2)
+    .end(function(err, res){
+      try {
+      assert(err, 'expected an error');
+      assert.equal(1, err.retries, 'expected an error with .retries');
+      assert.equal(500, err.status, 'expected an error status of 500');
+      done();
+      } catch(err) {
+        done(err);
+      }
+    });
+  });
+
+  it('should retry if passed nothing', function(done){
+    request
+    .get(base + '/error')
+    .retry()
+    .end(function(err, res){
+      try {
+      assert(err, 'expected an error');
+      assert.equal(1, err.retries, 'expected an error with .retries');
       assert.equal(500, err.status, 'expected an error status of 500');
       done();
       } catch(err) {


### PR DESCRIPTION
I’m afraid I made a design error by disallowing setting retry count to `0`. This fix makes the following changes:

- passing `0/null/undefined/negative numbers` does not enable retry
- passing nothing or `true` defaults to `1` retry