### PR TITLE
Fixed setting correct cookies for redirects

### DIFF
--- a/lib/node/index.js
+++ b/lib/node/index.js
@@ -613,12 +613,12 @@ Request.prototype.request = function(){
   if (url.search)
     this.query(url.search.substr(1));
 
-  // add cookies
-  if (this.cookies) req.setHeader('Cookie', this.cookies);
-
   for (var key in this.header) {
     req.setHeader(key, this.header[key]);
   }
+
+  // add cookies
+  if (this.cookies) req.setHeader('Cookie', this.cookies);
 
   try {
     this._appendQueryString(req);

--- a/lib/node/index.js
+++ b/lib/node/index.js
@@ -26,6 +26,7 @@ var pkg = require('../../package.json');
 var RequestBase = require('../request-base');
 var isFunction = require('../is-function');
 var shouldRetry = require('../should-retry');
+var CookieJar = require('cookiejar');
 
 var request = exports = module.exports = function(method, url) {
   // callback
@@ -618,7 +619,19 @@ Request.prototype.request = function(){
   }
 
   // add cookies
-  if (this.cookies) req.setHeader('Cookie', this.cookies);
+  if (this.cookies) {
+    if(this.header.hasOwnProperty('cookie')) {
+      // merge
+      var tmpJar = new CookieJar.CookieJar();
+      tmpJar.setCookies(this.cookies.split(';')) ;
+      // existing header over-rides instance cookie jar
+      tmpJar.setCookies(this.header.cookie.split(';'));
+      req.setHeader('Cookie',tmpJar.getCookies(CookieJar.CookieAccessInfo.All).toValueString());
+      tmpJar = null;
+    } else {
+      req.setHeader('Cookie', this.cookies);
+    }
+  }
 
   try {
     this._appendQueryString(req);


### PR DESCRIPTION
When using superagent, I discovered that if a response included a setcookie header, and was a redirect (e.g. 303), the new cookies were not being included in the redirected request, when they should be.

By applying cookies to redirect req after setting headers, rather than before, it prevents the old cookie headers overwriting the updated one from the cookiejar.

When a `cookie` header already exists in `this` which is the case with a redirect, the `// add cookies` code was being wiped out by the old cookie header.

```javascript
// add cookies
if (this.cookies) req.setHeader('Cookie', this.cookies);

for (var key in this.header) {
    req.setHeader(key, this.header[key]);
}
```
By switching them around, if an old `Cookie` header existed, it is wiped by updated cookies from the cookiejar.

```javascript
for (var key in this.header) {
    req.setHeader(key, this.header[key]);
}

// add cookies
if (this.cookies) req.setHeader('Cookie', this.cookies);
```

I'm sorry I don't have a test script for it.  It has taken me most of the day to track this down.  Thought the problem was in my code (that is where it usually is :)).

Hope you will accept my PR.

Regards,
Damien.


