### PR TITLE
Fixed being able to define own parsers when their mime type starts with text/

### DIFF
--- a/lib/node/index.js
+++ b/lib/node/index.js
@@ -825,11 +825,11 @@ Request.prototype._end = function() {
       } else if (isImage(mime)) {
         parser = exports.parse.image;
         buffer = true; // For backwards-compatibility buffering default is ad-hoc MIME-dependent
+      } else if (exports.parse[mime]) {
+        parser = exports.parse[mime];
       } else if ('text' == type) {
         parser = exports.parse.text;
         buffer = (buffer !== false);
-      } else if (exports.parse[mime]) {
-        parser = exports.parse[mime];
 
         // everyone wants their own white-labeled json
       } else if (isJSON(mime)) {


### PR DESCRIPTION
I am attempting to set my own parser as follows:

```javascript
var jsdom = require('jsdom') ;
var request = require('superagent');

request.parse['text/html'] = function(res,fn) {
	res.text = '';
	res.setEncoding('utf8');
	res.on('data', function (chunk) {
		res.text += chunk;
	});
	res.on('end', function () {
		jsdom.env({
			html: res.text,
			url: url,
			done: function (err, window) { // res.body === window
				console.log('parsed document') ;
				fn(err, window);
			}
		});
	});
} ;

var agent = request.agent() ; // Gimme cookies....

agent.get(url)
.buffer(true)
.then(...) ;
```

Without this PR, the `parsed document` string is never output as the default `text` parser is used, even when the mime type returned in the response is `text/html`. 

By switching the order of the logic for determining which parser to use (the more specific test, before the less specific), any parser that is set that starts with text/ will override (as it should) the default `text` parser.

Other examples where user-supplied parsers won't execute equally apply to the following example mime types:

- text/csv
- text/rtf
- text/css

Are there any unintended consequences of this change that you can foresee?

Cheers,
Damien.