### PR TITLE
Add bearer token support

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -501,13 +501,16 @@ Request.prototype.accept = function(type){
  * Set Authorization field value with `user` and `pass`.
  *
  * @param {String} user
- * @param {String} pass
- * @param {Object} options with 'type' property 'auto' or 'basic' (default 'basic')
+ * @param {String} [pass] optional in case of using 'bearer' as type
+ * @param {Object} options with 'type' property 'auto', 'basic' or 'bearer' (default 'basic')
  * @return {Request} for chaining
  * @api public
  */
 
 Request.prototype.auth = function(user, pass, options){
+  if (typeof pass === 'object' && pass !== null) { // pass is optional and can substitute for options
+    options = pass;
+  }
   if (!options) {
     options = {
       type: 'function' === typeof btoa ? 'basic' : 'auto',
@@ -523,6 +526,10 @@ Request.prototype.auth = function(user, pass, options){
       this.username = user;
       this.password = pass;
     break;
+      
+    case 'bearer': // usage would be .auth(accessToken, { type: 'bearer' })
+      this.set('Authorization', 'Bearer ' + user);
+    break;  
   }
   return this;
 };

--- a/lib/node/index.js
+++ b/lib/node/index.js
@@ -468,18 +468,30 @@ Request.prototype._redirect = function(res){
  *   .auth('tobi', 'learnboost')
  *   .auth('tobi:learnboost')
  *   .auth('tobi')
+ *   .auth(accessToken, { type: 'bearer' })
  *
  * @param {String} user
- * @param {String} pass
+ * @param {String} [pass]
+ * @param {Object} [options] options with authorization type 'basic' or 'bearer' ('basic' is default)
  * @return {Request} for chaining
  * @api public
  */
 
-Request.prototype.auth = function(user, pass){
+Request.prototype.auth = function(user, pass, options){
   if (1 === arguments.length) pass = '';
-  if (!~user.indexOf(':')) user = user + ':';
-  var str = new Buffer(user + pass).toString('base64');
-  return this.set('Authorization', 'Basic ' + str);
+  if (2 === arguments.length && typeof pass === 'object') options = pass;
+  if (!options) {
+    options = { type: 'basic' };
+  }
+  switch (options.type) {
+    case 'bearer':
+      return this.set('Authorization', 'Bearer ' + user);    
+      
+    default: // 'basic'
+      if (!~user.indexOf(':')) user = user + ':';
+      var str = new Buffer(user + pass).toString('base64');
+      return this.set('Authorization', 'Basic ' + str);    
+  }
 };
 
 /**


### PR DESCRIPTION
This would add bearer token support to the `auth` method (both for client and for node).

```js
.auth(accessToken, { type: 'bearer' })
```
Notice I made pass optional since bearer authorization doesn't need a 2nd argument.