### PR TITLE
Add optional callback to retry

### DIFF
--- a/lib/request-base.js
+++ b/lib/request-base.js
@@ -139,12 +139,13 @@ RequestBase.prototype.timeout = function timeout(options){
  * @api public
  */
 
-RequestBase.prototype.retry = function retry(count){
+RequestBase.prototype.retry = function retry(count, fn){
   // Default to 1 if no count passed or true
   if (arguments.length === 0 || count === true) count = 1;
   if (count <= 0) count = 0;
   this._maxRetries = count;
   this._retries = 0;
+  this._retryCallback = fn;
   return this;
 };
 
@@ -157,7 +158,9 @@ RequestBase.prototype.retry = function retry(count){
 
 RequestBase.prototype._retry = function() {
   this.clearTimeout();
-
+  if (this._retryCallback) {
+    this._retryCallback(this);
+  }
   // node
   if (this.req) {
     this.req = null;

--- a/lib/request-base.js
+++ b/lib/request-base.js
@@ -135,6 +135,7 @@ RequestBase.prototype.timeout = function timeout(options){
  * Failed requests will be retried 'count' times if timeout or err.code >= 500.
  *
  * @param {Number} count
+ * @param {Function} [fn]
  * @return {Request} for chaining
  * @api public
  */

--- a/test/retry.js
+++ b/test/retry.js
@@ -223,20 +223,18 @@ describe('.retry(count)', function(){
 
   it('should execute callback on retry if passed', function(done) {
     var callbackCallCount = 0;
-    var retries = 2;
     function retryCallback(request) {
-      console.log(request);
       callbackCallCount++;
     }
     request
       .get(base + '/error')
-      .retry(retries, retryCallback)
+      .retry(2, retryCallback)
       .end(function(err, res){
         try {
           assert(err, 'expected an error');
-          assert.equal(retries, err.retries, 'expected an error with .retries');
+          assert.equal(2, err.retries, 'expected an error with .retries');
           assert.equal(500, err.status, 'expected an error status of 500');
-          assert.equal(retries, callbackCallCount, 'expected the callback to be called on retry');
+          assert.equal(2, callbackCallCount, 'expected the callback to be called on each retry');
           done();
         } catch(err) {
           done(err);

--- a/test/retry.js
+++ b/test/retry.js
@@ -227,18 +227,18 @@ describe('.retry(count)', function(){
       callbackCallCount++;
     }
     request
-      .get(base + '/error')
-      .retry(2, retryCallback)
-      .end(function(err, res){
-        try {
-          assert(err, 'expected an error');
-          assert.equal(2, err.retries, 'expected an error with .retries');
-          assert.equal(500, err.status, 'expected an error status of 500');
-          assert.equal(2, callbackCallCount, 'expected the callback to be called on each retry');
-          done();
-        } catch(err) {
-          done(err);
-        }
-      });
+    .get(base + '/error')
+    .retry(2, retryCallback)
+    .end(function(err, res){
+      try {
+        assert(err, 'expected an error');
+        assert.equal(2, err.retries, 'expected an error with .retries');
+        assert.equal(500, err.status, 'expected an error status of 500');
+        assert.equal(2, callbackCallCount, 'expected the callback to be called on each retry');
+        done();
+      } catch(err) {
+        done(err);
+      }
+    });
   });
 })

--- a/test/retry.js
+++ b/test/retry.js
@@ -220,4 +220,26 @@ describe('.retry(count)', function(){
       }
     });
   });
+
+  it('should execute callback on retry if passed', function(done) {
+    var callbackCallCount = 0;
+    var retries = 1;
+    function retryCallback() {
+      callbackCallCount++;
+    }
+    request
+      .get(base + '/error')
+      .retry(retries, retryCallback)
+      .end(function(err, res){
+        try {
+          assert(err, 'expected an error');
+          assert.equal(1, err.retries, 'expected an error with .retries');
+          assert.equal(500, err.status, 'expected an error status of 500');
+          assert.equal(retries, callbackCallCount, 'expected the callback to be called on retry');
+          done();
+        } catch(err) {
+          done(err);
+        }
+      });
+  });
 })

--- a/test/retry.js
+++ b/test/retry.js
@@ -223,8 +223,9 @@ describe('.retry(count)', function(){
 
   it('should execute callback on retry if passed', function(done) {
     var callbackCallCount = 0;
-    var retries = 1;
-    function retryCallback() {
+    var retries = 2;
+    function retryCallback(request) {
+      console.log(request);
       callbackCallCount++;
     }
     request
@@ -233,7 +234,7 @@ describe('.retry(count)', function(){
       .end(function(err, res){
         try {
           assert(err, 'expected an error');
-          assert.equal(1, err.retries, 'expected an error with .retries');
+          assert.equal(retries, err.retries, 'expected an error with .retries');
           assert.equal(500, err.status, 'expected an error status of 500');
           assert.equal(retries, callbackCallCount, 'expected the callback to be called on retry');
           done();


### PR DESCRIPTION
The new retry feature is very useful, but there's no way to get any insight into which requests might be failing or why they need to be retried. I've added an optional callback parameter to `retry` so we can either report, log, or otherwise keep track of how or why retry is called for certain requests.

We're using superagent to send 100s of requests simultaneously, so knowing when we are falling into the retry logic is important. Hopefully others will find this useful as well.