### PR TITLE
More friendly for frontend-bundlers

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -12,7 +12,7 @@ if (typeof window !== 'undefined') { // Browser window
   root = this;
 }
 
-var Emitter = require('emitter');
+var Emitter = require('component-emitter');
 var RequestBase = require('./request-base');
 var isObject = require('./is-object');
 var isFunction = require('./is-function');

--- a/package.json
+++ b/package.json
@@ -52,7 +52,6 @@
   },
   "browser": {
     "./lib/node/index.js": "./lib/client.js",
-    "emitter": "component-emitter",
     "./test/support/server.js": "./test/support/blank.js"
   },
   "component": {


### PR DESCRIPTION
Since lib/client.js is only consumed by browsers, `component-emitter` can be required directly. The way it is now, bundlers will have to memorize this `emitter` shim when resolving `superagent` 

This will make superagent work in Fuse-box