### PR TITLE
Errno for timeouts

### DIFF
--- a/lib/request-base.js
+++ b/lib/request-base.js
@@ -554,13 +554,14 @@ RequestBase.prototype.sortQuery = function(sort) {
  * @api private
  */
 
-RequestBase.prototype._timeoutError = function(reason, timeout){
+RequestBase.prototype._timeoutError = function(reason, timeout, errno){
   if (this._aborted) {
     return;
   }
   var err = new Error(reason + timeout + 'ms exceeded');
   err.timeout = timeout;
   err.code = 'ECONNABORTED';
+  err.errno = errno;
   this.timedout = true;
   this.abort();
   this.callback(err);
@@ -572,13 +573,13 @@ RequestBase.prototype._setTimeouts = function() {
   // deadline
   if (this._timeout && !this._timer) {
     this._timer = setTimeout(function(){
-      self._timeoutError('Timeout of ', self._timeout);
+      self._timeoutError('Timeout of ', self._timeout, 'ETIME');
     }, this._timeout);
   }
   // response timeout
   if (this._responseTimeout && !this._responseTimeoutTimer) {
     this._responseTimeoutTimer = setTimeout(function(){
-      self._timeoutError('Response timeout of ', self._responseTimeout);
+      self._timeoutError('Response timeout of ', self._responseTimeout, 'ETIMEDOUT');
     }, this._responseTimeout);
   }
 }

--- a/test/timeout.js
+++ b/test/timeout.js
@@ -64,6 +64,7 @@ describe('.timeout(ms)', function(){
       .end(function(err, res){
         assert(err, 'expected an error');
         assert.equal('ECONNABORTED', err.code, 'expected abort error code')
+        assert.equal('ETIME', err.errno);
         done();
       });
     });
@@ -76,6 +77,7 @@ describe('.timeout(ms)', function(){
         assert(err, 'expected an error');
         assert.equal('number', typeof err.timeout, 'expected an error with .timeout');
         assert.equal('ECONNABORTED', err.code, 'expected abort error code')
+        assert.equal('ETIMEDOUT', err.errno);
         done();
       });
     });


### PR DESCRIPTION
Add errno to distinguish between response timeout and body download timeout

The existing `err.code` can't be changed, since it'd technically be a breaking change.

The new `errno = ETIMEDOUT` code is almost exactly what it should be. The other `ETIME` is stretching the meaning "timer expired" a bit, but at least its still a valid posix code.