### PR TITLE
Warn about bogus timeout options

### DIFF
--- a/lib/request-base.js
+++ b/lib/request-base.js
@@ -120,11 +120,17 @@ RequestBase.prototype.timeout = function timeout(options){
     return this;
   }
 
-  if ('undefined' !== typeof options.deadline) {
-    this._timeout = options.deadline;
-  }
-  if ('undefined' !== typeof options.response) {
-    this._responseTimeout = options.response;
+  for(var option in options) {
+    switch(option) {
+      case 'deadline':
+        this._timeout = options.deadline;
+        break;
+      case 'response':
+        this._responseTimeout = options.response;
+        break;
+      default:
+        console.warn("Unknown timeout option", option);
+    }
   }
   return this;
 };


### PR DESCRIPTION
`.timeout({request:1000})` is an easy mistake to make.