### PR TITLE
Removing memory leaks

### DIFF
--- a/lib/node/index.js
+++ b/lib/node/index.js
@@ -58,6 +58,12 @@ exports.agent = require('./agent');
  */
 
 function noop(){};
+function doRemoveListener(eventemitter, eventname, eventhandler) {
+  eventemitter.removeListener(eventname, eventhandler);
+  if (eventemitter.listenerCount(eventname) < 1) {
+    eventemitter.on(eventname, noop);
+  }
+}
 
 /**
  * Expose `Response`.
@@ -131,6 +137,7 @@ function _initHeaders(req) {
  * @api public
  */
 
+
 function Request(method, url) {
   Stream.call(this);
   if ('string' != typeof url) url = format(url);
@@ -147,7 +154,8 @@ function Request(method, url) {
   this.qsRaw = [];
   this._redirectList = [];
   this._streamRequest = false;
-  this.once('end', this.clearTimeout.bind(this));
+  this._unitRequest = null;
+  //this.once('end', this.clearTimeout.bind(this));
 }
 
 /**
@@ -156,6 +164,29 @@ function Request(method, url) {
  */
 util.inherits(Request, Stream);
 RequestBase(Request.prototype);
+
+Request.prototype.destroy = function () {
+  this.clearTimeout();
+  if (this._unitRequest) {
+    this._unitRequest.destroy();
+  }
+  this._unitRequest = null;
+  this._streamRequest = null;
+  this._redirectList = null;
+  this.qsRaw = null;
+  this.qs = null;
+  this.cookies = null;
+  this._redirects = null;
+  this.writable = null;
+  this.url = null;
+  this.method = null;
+  if (this._formData) {
+    this._formData.removeAllListeners();
+  }
+  this._formData = null;
+  this._agent = null;
+  this.removeAllListeners();
+};
 
 /**
  * Queue the given `file` as an attachment to the specified `field`,
@@ -206,14 +237,15 @@ Request.prototype.attach = function(field, file, options){
   return this;
 };
 
+Request.prototype._onFormDataError = function (err) {
+  this.emit('error', err);
+  this.abort();
+};
+
 Request.prototype._getFormData = function() {
   if (!this._formData) {
     this._formData = new FormData();
-    var that = this;
-    this._formData.on('error', function(err) {
-      that.emit('error', err);
-      that.abort();
-    });
+    this._formData.on('error', this._onFormDataError.bind(this));
   }
   return this._formData;
 };
@@ -348,27 +380,9 @@ Request.prototype.pipe = function(stream, options){
 };
 
 Request.prototype._pipeContinue = function(stream, options){
-  var self = this;
-  this.req.once('response', function(res){
-    // redirect
-    var redirect = isRedirect(res.statusCode);
-    if (redirect && self._redirects++ != self._maxRedirects) {
-      return self._redirect(res)._pipeContinue(stream, options);
-    }
-
-    self.res = res;
-    self._emitResponse();
-    if (self._aborted) return;
-
-    if (self._shouldUnzip(res)) {
-      res.pipe(zlib.createUnzip()).pipe(stream, options);
-    } else {
-      res.pipe(stream, options);
-    }
-    res.once('end', function(){
-      self.emit('end');
-    });
-  });
+  if (this._unitRequest) {
+    this._unitRequest._pipeContinue(stream, options);
+  }
   return stream;
 };
 
@@ -556,7 +570,6 @@ Request.prototype.cert = function(cert){
 Request.prototype.request = function(){
   if (this.req) return this.req;
 
-  var self = this;
   var options = {};
   var url = this.url;
   var retries = this._retries;
@@ -598,22 +611,7 @@ Request.prototype.request = function(){
   this.protocol = url.protocol;
   this.host = url.host;
 
-  // expose events
-  req.once('drain', function(){ self.emit('drain'); });
-
-  req.once('error', function(err){
-    // flag abortion here for out timeouts
-    // because node will emit a faux-error "socket hang up"
-    // when request is aborted before a connection is made
-    if (self._aborted) return;
-    // if not the same, we are in the **old** (cancelled) request,
-    // so need to continue (same as for above)
-    if (self._retries !== retries) return;
-    // if we've received a response then we don't want to let
-    // an error in the request blow up the response
-    if (self.response) return;
-    self.callback(err);
-  });
+  this._unitRequest = new UnitRequest(this, req);
 
   // auth
   if (url.auth) {
@@ -664,7 +662,9 @@ Request.prototype.callback = function(err, res){
 
   if (!err) {
     if (this._isResponseOK(res)) {
-      return fn(err, res);
+      fn(err, res);
+      this.destroy();
+      return;
     }
 
     var msg = 'Unsuccessful HTTP response';
@@ -685,6 +685,7 @@ Request.prototype.callback = function(err, res){
   }
 
   fn(err, res);
+  this.destroy();
 };
 
 /**
@@ -733,18 +734,6 @@ Request.prototype._isHost = function _isHost(obj) {
  * @api public
  */
 
-Request.prototype._emitResponse = function(body, files){
-    var response = new Response(this);
-    this.response = response;
-    response.redirects = this._redirectList;
-    if (undefined !== body) {
-      response.body = body;
-    }
-    response.files = files;
-    this.emit('response', response);
-    return response;
-};
-
 Request.prototype.end = function(fn){
   this.request();
   debug('%s %s', this.method, this.url);
@@ -789,130 +778,7 @@ Request.prototype._end = function() {
     }
   }
 
-  // response
-  req.once('response', function(res){
-    debug('%s %s -> %s', self.method, self.url, res.statusCode);
-
-    if (self._responseTimeoutTimer) {
-      clearTimeout(self._responseTimeoutTimer);
-    }
-
-    if (self.piped) {
-      return;
-    }
-
-    var max = self._maxRedirects;
-    var mime = utils.type(res.headers['content-type'] || '') || 'text/plain';
-    var type = mime.split('/')[0];
-    var multipart = 'multipart' == type;
-    var redirect = isRedirect(res.statusCode);
-    var parser = self._parser;
-
-    self.res = res;
-
-    // redirect
-    if (redirect && self._redirects++ != max) {
-      return self._redirect(res);
-    }
-
-    if ('HEAD' == self.method) {
-      self.emit('end');
-      self.callback(null, self._emitResponse());
-      return;
-    }
-
-    // zlib support
-    if (self._shouldUnzip(res)) {
-      unzip(req, res);
-    }
-
-    if (!parser) {
-      if (this._responseType) {
-        parser = exports.parse.image; // It's actually a generic Buffer
-        buffer = true;
-      } else if (multipart) {
-        var form = new formidable.IncomingForm();
-        parser = form.parse.bind(form);
-        buffer = true;
-      } else if (isImageOrVideo(mime)) {
-        parser = exports.parse.image;
-        buffer = true; // For backwards-compatibility buffering default is ad-hoc MIME-dependent
-      } else if (exports.parse[mime]) {
-        parser = exports.parse[mime];
-      } else if ('text' == type) {
-        parser = exports.parse.text;
-        buffer = (buffer !== false);
-
-        // everyone wants their own white-labeled json
-      } else if (isJSON(mime)) {
-        parser = exports.parse['application/json'];
-        buffer = (buffer !== false);
-      } else if (buffer) {
-        parser = exports.parse.text;
-      }
-    }
-
-    // by default only buffer text/*, json and messed up thing from hell
-    if (undefined === buffer && isText(mime) || isJSON(mime)) {
-      buffer = true;
-    }
-
-    var parserHandlesEnd = false;
-    if (parser) {
-      try {
-        // Unbuffered parsers are supposed to emit response early,
-        // which is weird BTW, because response.body won't be there.
-        parserHandlesEnd = buffer;
-
-        parser(res, function(err, obj, files) {
-          if (self.timedout) {
-            // Timeout has already handled all callbacks
-            return;
-          }
-
-          // Intentional (non-timeout) abort is supposed to preserve partial response,
-          // even if it doesn't parse.
-          if (err && !self._aborted) {
-            return self.callback(err);
-          }
-
-          if (parserHandlesEnd) {
-            self.emit('end');
-            self.callback(null, self._emitResponse(obj, files));
-          }
-        });
-      } catch (err) {
-        self.callback(err);
-        return;
-      }
-    }
-
-    self.res = res;
-
-    // unbuffered
-    if (!buffer) {
-      debug('unbuffered %s %s', self.method, self.url);
-      self.callback(null, self._emitResponse());
-      if (multipart) return // allow multipart to handle end event
-      res.once('end', function(){
-        debug('end %s %s', self.method, self.url);
-        self.emit('end');
-      })
-      return;
-    }
-
-    // terminating events
-    res.once('error', function(err){
-      self.callback(err, null);
-    });
-    if (!parserHandlesEnd) res.once('end', function(){
-      debug('end %s %s', self.method, self.url);
-      // TODO: unless buffering emit earlier to stream
-      self.emit('end');
-      self.callback(null, self._emitResponse());
-    });
-  });
-
+  this._unitRequest._setResponseHandler();
   this.emit('request', this);
 
   // if a FormData instance got created, then we send that as the request body
@@ -927,40 +793,41 @@ Request.prototype._end = function() {
     }
 
     // attempt to get "Content-Length" header
-    formData.getLength(function(err, length) {
-      // TODO: Add chunked encoding when no length (if err)
-
-      debug('got FormData Content-Length: %s', length);
-      if ('number' == typeof length) {
-        req.setHeader('Content-Length', length);
-      }
-
-      var getProgressMonitor = function () {
-        var lengthComputable = true;
-        var total = req.getHeader('Content-Length');
-        var loaded = 0;
-
-        var progress = new Stream.Transform();
-        progress._transform = function (chunk, encoding, cb) {
-          loaded += chunk.length;
-          self.emit('progress', {
-            direction: 'upload',
-            lengthComputable: lengthComputable,
-            loaded: loaded,
-            total: total
-          });
-          cb(null, chunk);
-        };
-        return progress;
-      };
-      formData.pipe(getProgressMonitor()).pipe(req);
-    });
+    formData.getLength(this._onFormDataLength.bind(this, req));
   } else {
     req.end(data);
   }
 
   return this;
 };
+
+Request.prototype._onFormDataLength = function (req, err, length) {
+  // TODO: Add chunked encoding when no length (if err)
+
+  debug('got FormData Content-Length: %s', length);
+  if ('number' == typeof length) {
+    req.setHeader('Content-Length', length);
+  }
+
+  this._formData.pipe(this._getProgressMonitor(req)).pipe(req);
+};
+
+Request.prototype._getProgressMonitor = function (req) {
+  var progress = new Stream.Transform();
+  progress._transform = this._progressTransform.bind(this, {loaded: 0, total: req.getHeader('Content-Length')});
+  return progress;
+}
+
+Request.prototype._progressTransform = function (transformobj, chunk, encoding, cb) {
+  transformobj.loaded += chunk.length;
+  this.emit('progress', {
+    direction: 'upload',
+    lengthComputable: true,
+    loaded: transformobj.loaded,
+    total: transformobj.total
+  });
+  cb(null, chunk);
+}
 
 /**
  * Check whether response has a non-0-sized gzip-encoded body
@@ -1049,3 +916,281 @@ function isJSON(mime) {
 function isRedirect(code) {
   return ~[301, 302, 303, 305, 307, 308].indexOf(code);
 }
+
+
+function UnitRequest (reqinstance, req) {
+  this.emitDrainer = this.emitDrain.bind(this);
+  this.onErrorer = this.onError.bind(this);
+  this.onReqResponseForPipeContinueer = this.onReqResponseForPipeContinue.bind(this);
+  this.onReqResponseer = this.onReqResponse.bind(this);
+  this.destroyer = this.destroy.bind(this);
+  this.errorToCallbacker = this.errorToCallback.bind(this);
+  this.onParserHandlesEnder = this.onParserHandlesEnd.bind(this);
+  this.reqInstance = reqinstance;
+  this.req = req;
+  this.res = null;
+  this.response = null;
+  this.parserHandlesEnd = null;
+  req.once('drain', this.emitDrainer);
+  req.once('error', this.onErrorer);
+  req.once('abort', this.reqAbortToCallback.bind(this));
+  req.once('aborted', this.reqAbortToCallback.bind(this));
+}
+UnitRequest.prototype.destroy = function () {
+  this.parserHandlesEnd = null;
+  this.response = null;
+  if (this.res) {
+    this.res.removeAllListeners();
+  }
+  this.res = null;
+  if (this.req) {
+    doRemoveListener(this.req, 'drain', this.emitDrainer);
+    doRemoveListener(this.req, 'error', this.onErrorer);
+    doRemoveListener(this.req, 'response', this.onReqResponseForPipeContinueer);
+    doRemoveListener(this.req, 'response', this.onReqResponseer);
+    doRemoveListener(this.req, 'end', this.destroyer);
+    doRemoveListener(this.req, 'error', this.errorToCallbacker);
+    doRemoveListener(this.req, 'end', this.onParserHandlesEnder);
+  }
+  this.req = null;
+  if (this.reqInstance) {
+    debug('end %s %s', this.reqInstance.method, this.reqInstance.url);
+    this.reqInstance.emit('end');
+  }
+  this.reqInstance = null;
+  this.onParserHandlesEnder = null;
+  this.errorToCallbacker = null;
+  this.destroyer = null;
+  this.onReqResponseer = null;
+  this.onReqResponseForPipeContinueer = null;
+  this.onErrorer = null;
+  this.emitDrainer = null;
+};
+UnitRequest.prototype.emitDrain = function () {
+  if (!this.reqInstance) return;
+  this.reqInstance.emit('drain');
+};
+UnitRequest.prototype.onError = function (err) {
+  var reqinst = this.reqInstance;
+  if (!reqinst) return;
+  // flag abortion here for out timeouts
+  // because node will emit a faux-error "socket hang up"
+  // when request is aborted before a connection is made
+  if (reqinst._aborted) {
+    this.destroy();
+    return;
+  }
+  // if not the same, we are in the **old** (cancelled) request,
+  // so need to continue (same as for above)
+  if (reqinst._unitRequest !== this) return;
+  // if we've received a response then we don't want to let
+  // an error in the request blow up the response
+  if (this.response) return;
+  reqinst.callback(err);
+};
+UnitRequest.prototype._pipeContinue = function (stream, options) {
+  console.log('set response handler in _pipeContinue');
+  this.req.once('response', this.onReqResponseForPipeContinueer);
+};
+UnitRequest.prototype._setResponseHandler = function () {
+  if (!this.req) return;
+  this.req.once('response', this.onReqResponseer);
+};
+UnitRequest.prototype.onReqResponseForPipeContinue = function (res) {
+  var reqinst = this.reqInstance, redirect;
+  if (!reqinst) return;
+  redirect = isRedirect(res.statusCode);
+  if (redirect && reqinst._redirects++ != reqinst._maxRedirects) {
+    return reqinst._redirect(res)._pipeContinue(stream, options);
+  }
+
+  this.res = res;
+  this._emitResponse();
+  if (reqinst._aborted) {
+    this.destroy();
+    return;
+  }
+
+  if (reqinst._shouldUnzip(res)) {
+    res.pipe(zlib.createUnzip()).pipe(stream, options);
+  } else {
+    res.pipe(stream, options);
+  }
+  this.attachToResTermination();
+};
+UnitRequest.prototype.onReqResponse = function (res) {
+  var reqinst = this.reqInstance;
+  if (!reqinst) return;
+  debug('%s %s -> %s', reqinst.method, reqinst.url, res.statusCode);
+
+  if (reqinst._responseTimeoutTimer) {
+    clearTimeout(reqinst._responseTimeoutTimer);
+  }
+
+  if (reqinst.piped) {
+    this.destroy();
+    return;
+  }
+
+  var max = reqinst._maxRedirects;
+  var mime = utils.type(res.headers['content-type'] || '') || 'text/plain';
+  var type = mime.split('/')[0];
+  var multipart = 'multipart' == type;
+  var redirect = isRedirect(res.statusCode);
+  var parser = reqinst._parser;
+  var buffer = reqinst.buffer;
+
+  this.res = res;
+
+  // redirect
+  if (redirect && reqinst._redirects++ != max) {
+    reqinst._redirect(res);
+    this.destroy();
+    return;
+  }
+
+  if ('HEAD' == reqinst.method) {
+    reqinst.emit('end');
+    this.invokeCallback(null, this._emitResponse());
+    return;
+  }
+
+  // zlib support
+  if (reqinst._shouldUnzip(res)) {
+    unzip(this.req, res);
+  }
+
+  if (!parser) {
+    if (this._responseType) {
+      parser = exports.parse.image; // It's actually a generic Buffer
+      buffer = true;
+    } else if (multipart) {
+      var form = new formidable.IncomingForm();
+      parser = form.parse.bind(form);
+      buffer = true;
+    } else if (isImageOrVideo(mime)) {
+      parser = exports.parse.image;
+      buffer = true; // For backwards-compatibility buffering default is ad-hoc MIME-dependent
+    } else if (exports.parse[mime]) {
+      parser = exports.parse[mime];
+    } else if ('text' == type) {
+      parser = exports.parse.text;
+      buffer = (buffer !== false);
+
+      // everyone wants their own white-labeled json
+    } else if (isJSON(mime)) {
+      parser = exports.parse['application/json'];
+      buffer = (buffer !== false);
+    } else if (buffer) {
+      parser = exports.parse.text;
+    }
+  }
+
+  // by default only buffer text/*, json and messed up thing from hell
+  if (undefined === buffer && isText(mime) || isJSON(mime)) {
+    buffer = true;
+  }
+
+  this.parserHandlesEnd = false;
+  if (parser) {
+    try {
+      // Unbuffered parsers are supposed to emit response early,
+      // which is weird BTW, because response.body won't be there.
+      this.parserHandlesEnd = buffer;
+      parser(res, this.onParserResult.bind(this));
+    } catch (err) {
+      this.invokeCallback(err);
+      return;
+    }
+  }
+
+  this.res = res;
+
+  // unbuffered
+  if (!buffer) {
+    debug('unbuffered %s %s', reqinst.method, reqinst.url);
+    reqinst.callback(null, this._emitResponse());
+    if (multipart) {
+      this.destroy();
+      return; 
+    }
+    this.attachToResTermination();
+    return;
+  }
+
+  // terminating events
+  this.attachToResTermination();
+  if (!this.parserHandlesEnd) res.once('end', this.onParserHandlesEnder);
+};
+UnitRequest.prototype._emitResponse = function (body, files) {
+  var reqinst = this.reqInstance;
+  if (!reqinst) {
+    return;
+  }
+  response = new Response(this);
+  this.response = response;
+  response.redirects = this._redirectList;
+  if (undefined !== body) {
+    response.body = body;
+  }
+  response.files = files;
+  reqinst.emit('response', response);
+  return response;
+};
+UnitRequest.prototype.onParserResult = function (err, obj, files) {
+  var reqinst = this.reqInstance;
+  if (!reqinst) return;
+  if (reqinst.timedout) {
+    // Timeout has already handled all callbacks
+    this.destroy();
+    return;
+  }
+
+  // Intentional (non-timeout) abort is supposed to preserve partial response,
+  // even if it doesn't parse.
+  if (err && !reqinst._aborted) {
+    return this.invokeCallback(err);
+  }
+
+  if (this.parserHandlesEnd) {
+    reqinst.emit('end');
+    this.invokeCallback(null, this._emitResponse(obj, files));
+  }
+  this.destroy();
+};
+UnitRequest.prototype.errorToCallback = function (err) {
+  this.invokeCallback(err, null);
+};
+UnitRequest.prototype.reqAbortToCallback = function () {
+  /*
+  var err = new Error('Request aborted by client');
+  err.code = 'ECONNABORTED';
+  err.timeout = 1;
+  return this.errorToCallback(err);
+  */
+  if (this.destroyer) {
+    setTimeout(this.destroyer, 1000);
+  }
+};
+UnitRequest.prototype.onParserHandlesEnd = function () {
+  var reqinst = this.reqInstance;
+  if (!reqinst) return;
+  debug('end %s %s', reqinst.method, reqinst.url);
+  // TODO: unless buffering emit earlier to stream
+  reqinst.emit('end');
+  this.invokeCallback(null, this._emitResponse());
+};
+UnitRequest.prototype.toJSON = function () {
+  return this.reqInstance ? this.reqInstance.toJSON() : '{}';
+};
+UnitRequest.prototype.attachToResTermination = function () {
+  this.res.once('error', this.errorToCallbacker);
+  //this.res.once('aborted', this.destroyer);
+  //this.res.once('close', this.destroyer);
+};
+UnitRequest.prototype.invokeCallback = function (err, res) {
+  var reqinst = this.reqInstance;
+  if (!reqinst) return;
+  reqinst.callback(err, res);
+  this.destroy();
+};

--- a/lib/node/parsers/image.js
+++ b/lib/node/parsers/image.js
@@ -1,10 +1,32 @@
-module.exports = function(res, fn){
-  var data = []; // Binary data needs binary storage
+function dataHandler (handleobj, chunk) {
+  if (!(handleobj && handleobj.data)) return;
+  handleobj.data.push(chunk);
+}
 
-  res.on('data', function(chunk){
-      data.push(chunk);
-  });
-  res.on('end', function () {
-      fn(null, Buffer.concat(data));
-  });
+function endHandler (handleobj) {
+  if (!(handleobj && handleobj.fn && handleobj.res)) return;
+  handleobj.fn(null, Buffer.concat(handleobj.data));
+  handleobj.res.removeListener('data', handleobj.dataHandler);
+  handleobj.res.removeListener('end', handleobj.endHandler);
+  handleobj.dataHandler = null;
+  handleobj.endHandler = null;
+  handleobj.res = null;
+  handleobj.fn = null;
+  handleobj.data = null;
+}
+
+module.exports = function(res, fn){
+  var handleobj = {
+    res: res,
+    fn: fn,
+    data: [],
+    dataHandler: null,
+    endHandler: null
+  }; // Binary data needs binary storage
+
+  handleobj.dataHandler = dataHandler.bind(null, handleobj);
+  handleobj.endHandler = endHandler.bind(null, handleobj);
+
+  res.on('data', handleobj.dataHandler);
+  res.on('end', handleobj.endHandler);
 };

--- a/lib/node/parsers/json.js
+++ b/lib/node/parsers/json.js
@@ -1,19 +1,42 @@
+function dataHandler (handleobj, chunk) {
+  if (!(handleobj && handleobj.res)) return;
+  handleobj.res.text += chunk;
+}
+
+function endHandler (handleobj) {
+  var body, err;
+  if (!(handleobj && handleobj.res && handleobj.fn)) return;
+  try {
+    body = handleobj.res.text && JSON.parse(handleobj.res.text);
+  } catch (e) {
+    err = e;
+    // issue #675: return the raw response if the response parsing fails
+    err.rawResponse = handleobj.res.text || null;
+    // issue #876: return the http status code if the response parsing fails
+    err.statusCode = handleobj.res.statusCode;
+  } finally {
+    handleobj.fn(err, body);
+    handleobj.res.removeListener('data', handleobj.dataHandler);
+    handleobj.res.removeListener('end', handleobj.endHandler);
+    handleobj.fn = null;
+    handleobj.res = null;
+    handleobj.dataHandler = null;
+    handleobj.endHandler = null;
+  }
+}
 
 module.exports = function parseJSON(res, fn){
+  var handleobj = {
+    res: res,
+    fn: fn,
+    dataHandler: null,
+    endHandler: null
+  };
   res.text = '';
   res.setEncoding('utf8');
-  res.on('data', function(chunk){ res.text += chunk;});
-  res.on('end', function(){
-    try {
-      var body = res.text && JSON.parse(res.text);
-    } catch (e) {
-      var err = e;
-      // issue #675: return the raw response if the response parsing fails
-      err.rawResponse = res.text || null;
-      // issue #876: return the http status code if the response parsing fails
-      err.statusCode = res.statusCode;
-    } finally {
-      fn(err, body);
-    }
-  });
+  handleobj.dataHandler = dataHandler.bind(null, handleobj);
+  handleobj.endHandler = endHandler.bind(null, handleobj);
+
+  res.on('data', handleobj.dataHandler);
+  res.on('end', handleobj.endHandler);
 };

--- a/lib/node/parsers/text.js
+++ b/lib/node/parsers/text.js
@@ -1,7 +1,30 @@
+function dataHandler(handleobj, chunk) {
+  if (!(handleobj && handleobj.res)) return;
+  handleobj.res.text += chunk;
+}
+
+function endHandler(handleobj) {
+  if (!(handleobj && handleobj.res && handleobj.fn)) return;
+  handleobj.fn(); //null, res.text); //consistency??
+  handleobj.res.removeListener('data', handleobj.dataHandler);
+  handleobj.res.removeListener('end', handleobj.endHandler);
+  handleobj.res = null;
+  handleobj.fn = null;
+  handleobj.dataHandler = null;
+  handleobj.endHandler = null;
+}
 
 module.exports = function(res, fn){
+  var handleobj = {
+    res: res,
+    fn: fn,
+    dataHandler: null,
+    endHandler: null
+  };
   res.text = '';
   res.setEncoding('utf8');
-  res.on('data', function(chunk){ res.text += chunk; });
-  res.on('end', fn);
+  handleobj.dataHandler = dataHandler.bind(null, handleobj);
+  handleobj.endHandler = endHandler.bind(null, handleobj);
+  res.on('data', handleobj.dataHandler);
+  res.on('end', handleobj.endHandler);
 };

--- a/lib/node/parsers/urlencoded.js
+++ b/lib/node/parsers/urlencoded.js
@@ -5,15 +5,39 @@
 
 var qs = require('qs');
 
+function dataHandler (handleobj, chunk) {
+  if (!(handleobj && handleobj.res)) return;
+  handleobj.res.text += chunk;
+}
+
+function endHandler (handleobj) {
+  if (!(handleobj && handleobj.fn)) return;
+  try {
+    handleobj.fn(null, qs.parse(handleobj.res.text));
+  } catch (err) {
+    handleobj.fn(err);
+  }
+  if (handleobj.res) {
+    handleobj.res.removeListener('data', handleobj.dataHandler);
+    handleobj.res.removeListener('end', handleobj.endHandler);
+  }
+  handleobj.res = null;
+  handleobj.fn = null;
+  handleobj.dataHandler = null;
+  handleobj.endHandler = null;
+}
+
 module.exports = function(res, fn){
+  var handleobj = {
+    res: res,
+    fn: fn,
+    dataHandler: null,
+    endHandler: null
+  };
   res.text = '';
   res.setEncoding('ascii');
-  res.on('data', function(chunk){ res.text += chunk; });
-  res.on('end', function(){
-    try {
-      fn(null, qs.parse(res.text));
-    } catch (err) {
-      fn(err);
-    }
-  });
+  handleobj.dataHandler = dataHandler.bind(null, handleobj);
+  handleobj.endHandler = endHandler.bind(null, handleobj);
+  res.on('data', handleobj.dataHandler)
+  res.on('end', handleobj.endHandler);
 };

--- a/lib/node/response.js
+++ b/lib/node/response.js
@@ -11,6 +11,8 @@ var ResponseBase = require('../response-base');
  * Expose `Response`.
  */
 
+function noop(){}
+
 module.exports = Response;
 
 /**
@@ -30,6 +32,10 @@ module.exports = Response;
 function Response(req) {
   Stream.call(this);
   var res = this.res = req.res;
+  this.dataEmitter = this.emit.bind(this, 'data');
+  this.ender = this.onResEnd.bind(this);
+  this.closer = this.onResClose.bind(this);
+  this.errorer = this.onResError.bind(this);
   this.request = req;
   this.req = req.req;
   this.text = res.text;
@@ -40,10 +46,12 @@ function Response(req) {
   this._setStatusProperties(res.statusCode);
   this._setHeaderProperties(this.header);
   this.setEncoding = res.setEncoding.bind(res);
-  res.on('data', this.emit.bind(this, 'data'));
-  res.on('end', this.emit.bind(this, 'end'));
-  res.on('close', this.emit.bind(this, 'close'));
-  res.on('error', this.emit.bind(this, 'error'));
+  res.on('data', this.dataEmitter);
+  res.on('end', this.ender);
+  res.on('close', this.closer);
+  res.on('error', this.errorer);
+  res.on('finish', this.ender);
+  res.on('aborted', this.ender);
 }
 
 /**
@@ -53,13 +61,60 @@ function Response(req) {
 util.inherits(Response, Stream);
 ResponseBase(Response.prototype);
 
+Response.prototype._cleanUp = function () {
+  if (this.res) {
+    if (this.dataEmitter) {
+      this.res.removeListener('data', this.dataEmitter);
+    }
+    if (this.ender) {
+      this.res.removeListener('end', this.ender);
+      this.res.removeListener('aborted', this.ender);
+      this.res.removeListener('finish', this.ender);
+    }
+    if (this.closer) {
+      this.res.removeListener('close', this.closer);
+    }
+    if (this.errorer) {
+      this.res.removeListener('error', this.errorer);
+    }
+  }
+  this.setEncoding = noop;
+  this.header = null;
+  this.buffered = null;
+  this.files = null;
+  this.body = null;
+  this.text = null;
+  this.req = null;
+  this.request = null;
+  this.errorer = null;
+  this.closer = null;
+  this.ender = null;
+  this.dataEmitter = null;
+  this.res = null;
+};
+
+Response.prototype.onResEnd = function () {
+  this.emit('end');
+  this._cleanUp();
+};
+
+Response.prototype.onResClose = function () {
+  this.emit('close');
+  this._cleanUp();
+};
+
+Response.prototype.onResError = function (error) {
+  this.emit('error', error);
+  this._cleanUp();
+};
 
 /**
  * Implements methods of a `ReadableStream`
  */
 
 Response.prototype.destroy = function(err){
-  this.res.destroy(err);
+  this._cleanUp();
+  ReadableStream.prototype.destroy.call(this);
 };
 
 /**

--- a/lib/node/unzip.js
+++ b/lib/node/unzip.js
@@ -15,55 +15,111 @@ var zlib = require('zlib');
  * @api private
  */
 
+function noop () {}
+
+function onUnzipError (unzipobj, err) {
+  if (!(unzipobj && unzipobj.stream)) return;
+  if (err && err.code === 'Z_BUF_ERROR') { // unexpected end of file is ignored by browsers and curl
+    unzipobj.stream.emit('end');
+    return;
+  }
+  unzipobj.stream.emit('error', err);
+}
+
+function onUnzipData (unzipobj, buf) {
+  if (!unzipobj.stream) return;
+  if (unzipobj.decoder) {
+    var str = unzipobj.decoder.write(buf);
+    if (str.length) unzipobj.stream.emit('data', str);
+  } else {
+    unzipobj.stream.emit('data', buf);
+  }
+}
+
+function onUnzipEnd (unzipobj) {
+  if (unzipobj.unzip) {
+    if (unzipobj.res) {
+      unzipobj.res.unpipe(unzipobj.unzip);
+    }
+    if (unzipobj.dataHandler) {
+      unzipobj.unzip.removeListener('data', unzipobj.dataHandler);
+    }
+    if (unzipobj.errorHandler) {
+      unzipobj.unzip.removeListener('error', unzipobj.errorHandler);
+    }
+    if (unzipobj.endHandler) {
+      unzipobj.unzip.removeListener('end', unzipobj.endHandler);
+    }
+  }
+  unzipobj.dataHandler = null;
+  unzipobj.errorHandler = null;
+  unzipobj.endHandler = null;
+  unzipobj.unzip = null;
+  unzipobj.decoder = null;
+  if (unzipobj.stream) {
+    unzipobj.stream.emit('end');
+    unzipobj.stream.req = null;
+    unzipobj.stream.removeAllListeners();
+  }
+  unzipobj.stream = null;
+  if (unzipobj.res && unzipobj._on) {
+    unzipobj.res.setEncoding = noop;
+    unzipobj.res.on = unzipobj._on;
+  }
+  unzipobj._on = null;
+  unzipobj.res = null;
+}
+
+function encodingSetter (unzipobj, type) {
+  unzipobj.decoder = new StringDecoder(type);
+}
+
+function resOnSubstitute (unzipobj, type, fn) {
+  if (!(unzipobj && unzipobj.stream && unzipobj._on && unzipobj.res)) return;
+  if ('data' == type) {
+    unzipobj.stream.on(type, fn);
+  } else if ('error' == type || 'end' == type) {
+    unzipobj.stream.on(type, fn);
+    unzipobj._on.call(unzipobj.res, type, fn);
+  } else {
+    unzipobj._on.call(unzipobj.res, type, fn);
+  }
+  return this;
+}
+
 exports.unzip = function(req, res){
   var unzip = zlib.createUnzip();
-  var stream = new Stream;
-  var decoder;
+  var unzipobj = {
+    stream: new Stream,
+    res: res,
+    _on: res.on,
+    unzip: unzip,
+    decoder: null,
+    dataHandler: null,
+    errorHandler: null,
+    endHandler: null
+  };
+
+  unzipobj.errorHandler = onUnzipError.bind(null, unzipobj);
+  unzipobj.dataHandler = onUnzipData.bind(null, unzipobj);
+  unzipobj.endHandler = onUnzipEnd.bind(null, unzipobj);
 
   // make node responseOnEnd() happy
-  stream.req = req;
+  unzipobj.stream.req = req;
 
-  unzip.on('error', function(err){
-    if (err && err.code === 'Z_BUF_ERROR') { // unexpected end of file is ignored by browsers and curl
-      stream.emit('end');
-      return;
-    }
-    stream.emit('error', err);
-  });
+  unzip.on('error', unzipobj.errorHandler);
 
   // pipe to unzip
   res.pipe(unzip);
 
   // override `setEncoding` to capture encoding
-  res.setEncoding = function(type){
-    decoder = new StringDecoder(type);
-  };
+  res.setEncoding = encodingSetter.bind(null, unzipobj);
 
   // decode upon decompressing with captured encoding
-  unzip.on('data', function(buf){
-    if (decoder) {
-      var str = decoder.write(buf);
-      if (str.length) stream.emit('data', str);
-    } else {
-      stream.emit('data', buf);
-    }
-  });
+  unzip.on('data', unzipobj.dataHandler);
 
-  unzip.on('end', function(){
-    stream.emit('end');
-  });
+  unzip.on('end', unzipobj.endHandler);
 
   // override `on` to capture data listeners
-  var _on = res.on;
-  res.on = function(type, fn){
-    if ('data' == type || 'end' == type) {
-      stream.on(type, fn);
-    } else if ('error' == type) {
-      stream.on(type, fn);
-      _on.call(res, type, fn);
-    } else {
-      _on.call(res, type, fn);
-    }
-    return this;
-  };
+  res.on = resOnSubstitute.bind(null, unzipobj);
 };


### PR DESCRIPTION
The proposed PR affects only the __Node.js__ side.

We use `superagent` implicitly, through the `image-resolver` module that we use heavily on our servers (up to 4500 `superagent` requests per hour). We found that in 10 hours around 400 MB of garbage gets produced. This figure of 400 MB is obtained by comparing a relatively steady memory usage of our server of 300 MB (with this PR applied) compared to 700 MB of memory usage after 10 hours of operation (without this PR applied); of course, without this PR, the memory consumption of our server keeps rising all the time, in a saw-tooth shaped manner.

Regarding the very PR:

1. `Request` had to undergo the hardest refactor - `UnitRequest` was introduced to model a single request to a remote server.
2. All other changes are rather trivial; they were introduced to let the garbage collector do its job. Greatest care was taken in order to (according to the use case) properly remove appropriate event handlers so that all bound references get released.