### PR TITLE
Check for ownProperty before adding header

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -785,7 +785,9 @@ Request.prototype._end = function() {
   // set header fields
   for (var field in this.header) {
     if (null == this.header[field]) continue;
-    xhr.setRequestHeader(field, this.header[field]);
+
+    if (this.header.hasOwnProperty(field))
+      xhr.setRequestHeader(field, this.header[field]);
   }
 
   if (this._responseType) {

--- a/lib/node/index.js
+++ b/lib/node/index.js
@@ -629,7 +629,8 @@ Request.prototype.request = function(){
   if (this.cookies) req.setHeader('Cookie', this.cookies);
 
   for (var key in this.header) {
-    req.setHeader(key, this.header[key]);
+    if (this.header.hasOwnProperty(key))
+      req.setHeader(key, this.header[key]);
   }
 
   try {

--- a/test/basic.js
+++ b/test/basic.js
@@ -197,6 +197,26 @@ describe('request', function(){
     })
   })
 
+  describe('set headers', function() {
+    before(function() {
+      Object.prototype.invalid = '\n';
+    });
+
+    after(function() {
+      delete Object.prototype.invalid;
+    });
+
+    it('should only set headers for ownProperties of header', function(done) {
+      try {
+        request
+          .get(uri + '/echo')
+          .end(done);
+      } catch (e) {
+        done(e)
+      }
+    });
+  });
+
   describe('res.charset', function(){
     it('should be set when present', function(done){
       request


### PR DESCRIPTION
Hello everyone

An issue was filled on chai-http chaijs/chai-http#153

The issuer was adding a property to the prototype of Object which was making `superagent` throw a TypeError when setting a header. (I know you should not be adding properties to the prototype of Object, but the truth is that you can).

So, to prevent that for happening. This PR adds a check for `hasOwnProperty` before setting the header.

I also added a test that reproduces it.

Thank you 😄