### PR TITLE
Allow crossDomain errors to be retried (#1194)

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -203,6 +203,15 @@ You can also use the `.query()` method for HEAD requests. The following will pro
 
 SuperAgent will automatically serialize JSON and forms. If you want to send the payload in a custom format, you can replace the built-in serialization with `.serialize()` method.
 
+## Retrying requests
+
+When given the `.retry()` method, SuperAgent will automatically retry requests, if they fail in a way that is transient or could be due to a flaky Internet connection. `.retry()` takes an optional argument which is the maximum number of times to retry failed requests; the default is 3 times.
+
+     request
+       .get('http://example.com/search')
+       .retry(2)
+       .end(callback);
+
 ## Setting Accept
 
 In a similar fashion to the `.type()` method it is also possible to set the `Accept` header via the short hand method `.accept()`. Which references `request.types` as well allowing you to specify either the full canonicalized MIME type name as `type/subtype`, or the extension suffix form as "xml", "json", "png", etc. for convenience:

--- a/lib/should-retry.js
+++ b/lib/should-retry.js
@@ -18,5 +18,6 @@ module.exports = function shouldRetry(err, res) {
   if (res && res.status && res.status >= 500) return true;
   // Superagent timeout
   if (err && 'timeout' in err && err.code == 'ECONNABORTED') return true;
+  if (err && 'crossDomain' in err) return true;
   return false;
 };

--- a/test/client/xdomain.js
+++ b/test/client/xdomain.js
@@ -30,5 +30,21 @@ describe('xdomain', function(){
         next();
       });
     });
+
+    it('should handle x-domain failure after repeat attempts', function(next){
+      request
+      .get('//tunne127.com')
+      .retry(2)
+      .end(function(err, res){
+        try {
+          assert(err, 'error missing');
+          assert(err.crossDomain, 'not .crossDomain');
+          assert.equal(2, err.retries, 'expected an error with .retries');
+          next();
+        } catch(err) {
+          next(err);
+        }
+      });
+    });
   }
 });


### PR DESCRIPTION
When using the retry() functionality on a bad connection, the browser can sometimes fail during a CORS OPTIONS request, which currently doesn't get retried. Superagent throws an error with crossDomain: true property in this case. We should retry instead, since the next attempt might succeed.