### PR TITLE
remove duplicated query params

### DIFF
--- a/lib/node/index.js
+++ b/lib/node/index.js
@@ -306,7 +306,10 @@ Request.prototype.accept = function(type){
 
 Request.prototype.query = function(val){
   if ('string' == typeof val) {
-    this.qsRaw.push(val);
+    // do not push it if it is already present in order to avoid duplicated query params
+    if (this.qsRaw.indexOf(val) < 0) {
+      this.qsRaw.push(val);
+    }
     return this;
   }
 


### PR DESCRIPTION
this bug occurs when using new retry feature and using query params in the URL string instead of passing it via the .query({qs: 'present'}) object.