### PR TITLE
Add request query params and body to debug

### DIFF
--- a/lib/node/index.js
+++ b/lib/node/index.js
@@ -723,7 +723,7 @@ Request.prototype._emitResponse = function(body, files){
 
 Request.prototype.end = function(fn){
   this.request();
-  debug('%s %s', this.method, this.url);
+  debug('%s %s?%s %s', this.method, this.url, qs.stringify(this.qs), JSON.stringify(this._data));
 
   if (this._endCalled) {
     console.warn("Warning: .end() was called twice. This is not supported in superagent");


### PR DESCRIPTION
I find myself often wanting to be able to log and reproduce superagent requests. Using `DEBUG=superagent` almost allows me to do this, however, without query params or body data I often find it's not enough information. This adds query params and body data to the `debug` call in `end`.

I know it's sometimes considered not a best practice to log request bodies as they can be large or contain sensitive information like API tokens, so I'd be happy to move that to a separate debug namespace maybe `superagent:body` if preferred.