### PR TITLE
Use query instead of send for HEAD requests

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -807,7 +807,7 @@ request.get = function(url, data, fn){
 request.head = function(url, data, fn){
   var req = request('HEAD', url);
   if ('function' == typeof data) fn = data, data = null;
-  if (data) req.send(data);
+  if (data) req.query(data);
   if (fn) req.end(fn);
   return req;
 };


### PR DESCRIPTION
As per [my comment](https://github.com/visionmedia/superagent/issues/534#issuecomment-297592130) on issue #534.

I don't know if you'll be willing to accept such change, but it didn't require much effort.