### PR TITLE
Send payload in query string for GET and HEAD shorthand API

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -525,10 +525,10 @@ Request.prototype.auth = function(user, pass, options){
       this.username = user;
       this.password = pass;
     break;
-      
+
     case 'bearer': // usage would be .auth(accessToken, { type: 'bearer' })
       this.set('Authorization', 'Bearer ' + user);
-    break;  
+    break;
   }
   return this;
 };
@@ -807,7 +807,7 @@ request.get = function(url, data, fn){
 request.head = function(url, data, fn){
   var req = request('HEAD', url);
   if ('function' == typeof data) fn = data, data = null;
-  if (data) req.send(data);
+  if (data) req.query(data);
   if (fn) req.end(fn);
   return req;
 };

--- a/lib/node/index.js
+++ b/lib/node/index.js
@@ -974,7 +974,13 @@ methods.forEach(function(method){
   request[name] = function(url, data, fn){
     var req = request(method, url);
     if ('function' == typeof data) fn = data, data = null;
-    if (data) req.send(data);
+    if (data) {
+      if (method === 'GET' || method === 'HEAD') {
+        req.query(data);
+      } else {
+        req.send(data);
+      }
+    }
     fn && req.end(fn);
     return req;
   };

--- a/test/request.js
+++ b/test/request.js
@@ -656,6 +656,26 @@ it('GET querystring with strings and objects', function(next){
   });
 });
 
+it('GET shorthand payload goes to querystring', function(next){
+  request
+  .get(uri + '/querystring', {foo: 'FOO', bar: 'BAR'}, function(err, res){
+    try {
+    assert.deepEqual(res.body, { foo: 'FOO', bar: 'BAR' });
+    next();
+    } catch(e) { next(e); }
+  });
+});
+
+it('HEAD shorthand payload goes to querystring', function(next){
+  request
+  .head(uri + '/querystring-in-header', {foo: 'FOO', bar: 'BAR'}, function(err, res){
+    try {
+    assert.deepEqual(JSON.parse(res.headers.query), { foo: 'FOO', bar: 'BAR' });
+    next();
+    } catch(e) { next(e); }
+  });
+});
+
 it('request(method, url)', function(next){
   request('GET', uri + '/foo').end(function(err, res){
     try {

--- a/test/support/server.js
+++ b/test/support/server.js
@@ -227,6 +227,11 @@ app.get('/querystring', function(req, res){
   res.send(req.query);
 });
 
+app.get('/querystring-in-header', function(req, res){
+  res.set('query', JSON.stringify(req.query));
+  res.send();
+});
+
 app.get('/echo-header/:field', function(req, res){
   res.send(req.headers[req.params.field]);
 });


### PR DESCRIPTION
Partially addresses #534. Browser and node are now consistent for
both GET and HEAD, but only the shorthand APIs behave this way.