### PR TITLE
Docs to master branch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,20 +36,20 @@ superagent.js: lib/node/*.js lib/node/parsers/*.js
 test-server:
 	@node test/server
 
-docs: index.html test-docs docs/index.md
+docs: docs/index.html test-docs docs/index.md
 
-index.html: docs/index.md docs/head.html docs/tail.html
+docs/index.html: docs/index.md docs/head.html docs/tail.html
 	marked < $< \
 		| cat docs/head.html - docs/tail.html \
 		> $@
 
 docclean:
-	rm -f index.html test.html
+	rm -f docs/index.html docs/test.html
 
 test-docs: docs/head.html docs/tail.html
 	make test REPORTER=doc \
 		| cat docs/head.html - docs/tail.html \
-		> test.html
+		> docs/test.html
 
 clean:
 	rm -fr superagent.js components

--- a/docs/head.html
+++ b/docs/head.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf8">
     <title>SuperAgent — elegant API for AJAX in Node and browsers</title>
-    <link rel="stylesheet" href="docs/style.css">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/tocbot/3.0.0/tocbot.css">
+    <link rel="stylesheet" href="style.css">
   </head>
   <body>
     <ul id="menu"></ul>

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,481 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf8">
+    <title>SuperAgent — elegant API for AJAX in Node and browsers</title>
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/tocbot/3.0.0/tocbot.css">
+    <link rel="stylesheet" href="style.css">
+  </head>
+  <body>
+    <ul id="menu"></ul>
+    <div id="content">
+<h1 id="superagent">SuperAgent</h1>
+<p>SuperAgent is light-weight progressive ajax API crafted for flexibility, readability, and a low learning curve after being frustrated with many of the existing request APIs. It also works with Node.js!</p>
+<pre><code> request
+   .post(&#39;/api/pet&#39;)
+   .send({ name: &#39;Manny&#39;, species: &#39;cat&#39; })
+   .set(&#39;X-API-Key&#39;, &#39;foobar&#39;)
+   .set(&#39;Accept&#39;, &#39;application/json&#39;)
+   .end(function(err, res){
+     if (err || !res.ok) {
+       alert(&#39;Oh no! error&#39;);
+     } else {
+       alert(&#39;yay got &#39; + JSON.stringify(res.body));
+     }
+   });
+</code></pre><h2 id="test-documentation">Test documentation</h2>
+<p>The following <a href="test.html">test documentation</a> was generated with <a href="http://mochajs.org/">Mocha&#39;s</a> &quot;doc&quot; reporter, and directly reflects the test suite. This provides an additional source of documentation.</p>
+<h2 id="request-basics">Request basics</h2>
+<p>A request can be initiated by invoking the appropriate method on the <code>request</code> object, then calling <code>.end()</code> to send the request. For example a simple <strong>GET</strong> request:</p>
+<pre><code> request
+   .get(&#39;/search&#39;)
+   .end(function(err, res){
+
+   });
+</code></pre><p>A method string may also be passed:</p>
+<pre><code>request(&#39;GET&#39;, &#39;/search&#39;).end(callback);
+</code></pre><p>ES6 promises are supported. <em>Instead</em> of <code>.end()</code> you can call <code>.then()</code>:</p>
+<pre><code>request(&#39;GET&#39;, &#39;/search&#39;).then(success, failure);
+</code></pre><p>The <strong>Node</strong> client may also provide absolute URLs. In browsers absolute URLs won&#39;t work unless the server implements <a href="#cors">CORS</a>.</p>
+<pre><code> request
+   .get(&#39;http://example.com/search&#39;)
+   .end(function(err, res){
+
+   });
+</code></pre><p>The <strong>Node</strong> client supports making requests to <a href="http://en.wikipedia.org/wiki/Unix_domain_socket">Unix Domain Sockets</a>:</p>
+<pre><code> // pattern: https?+unix://SOCKET_PATH/REQUEST_PATH
+ //          Use `%2F` as `/` in SOCKET_PATH
+ request
+   .get(&#39;http+unix://%2Fabsolute%2Fpath%2Fto%2Funix.sock/search&#39;)
+   .end(function(err, res){
+
+   });
+</code></pre><p><strong>DELETE</strong>, <strong>HEAD</strong>, <strong>PATCH</strong>, <strong>POST</strong>, and <strong>PUT</strong> requests can also be used, simply change the method name:</p>
+<pre><code>request
+  .head(&#39;/favicon.ico&#39;)
+  .end(function(err, res){
+
+  });
+</code></pre><p><strong>DELETE</strong> can be also called as <code>.del()</code> for compatibility with old IE where <code>delete</code> is a reserved word.</p>
+<p>  The HTTP method defaults to <strong>GET</strong>, so if you wish, the following is valid:</p>
+<pre><code> request(&#39;/search&#39;, function(err, res){
+
+ });
+</code></pre><h2 id="setting-header-fields">Setting header fields</h2>
+<p>Setting header fields is simple, invoke <code>.set()</code> with a field name and value:</p>
+<pre><code> request
+   .get(&#39;/search&#39;)
+   .set(&#39;API-Key&#39;, &#39;foobar&#39;)
+   .set(&#39;Accept&#39;, &#39;application/json&#39;)
+   .end(callback);
+</code></pre><p>You may also pass an object to set several fields in a single call:</p>
+<pre><code> request
+   .get(&#39;/search&#39;)
+   .set({ &#39;API-Key&#39;: &#39;foobar&#39;, Accept: &#39;application/json&#39; })
+   .end(callback);
+</code></pre><h2 id="-get-requests"><code>GET</code> requests</h2>
+<p>The <code>.query()</code> method accepts objects, which when used with the <strong>GET</strong> method will form a query-string. The following will produce the path <code>/search?query=Manny&amp;range=1..5&amp;order=desc</code>.</p>
+<pre><code> request
+   .get(&#39;/search&#39;)
+   .query({ query: &#39;Manny&#39; })
+   .query({ range: &#39;1..5&#39; })
+   .query({ order: &#39;desc&#39; })
+   .end(function(err, res){
+
+   });
+</code></pre><p>Or as a single object:</p>
+<pre><code>request
+  .get(&#39;/search&#39;)
+  .query({ query: &#39;Manny&#39;, range: &#39;1..5&#39;, order: &#39;desc&#39; })
+  .end(function(err, res){
+
+  });
+</code></pre><p>The <code>.query()</code> method accepts strings as well:</p>
+<pre><code>  request
+    .get(&#39;/querystring&#39;)
+    .query(&#39;search=Manny&amp;range=1..5&#39;)
+    .end(function(err, res){
+
+    });
+</code></pre><p>Or joined:</p>
+<pre><code>  request
+    .get(&#39;/querystring&#39;)
+    .query(&#39;search=Manny&#39;)
+    .query(&#39;range=1..5&#39;)
+    .end(function(err, res){
+
+    });
+</code></pre><h2 id="-head-requests"><code>HEAD</code> requests</h2>
+<p>You can also use the <code>.query()</code> method for HEAD requests. The following will produce the path <code>/users?email=joe@smith.com</code>.</p>
+<pre><code>  request
+    .head(&#39;/users&#39;)
+    .query({ email: &#39;joe@smith.com&#39; })
+    .end(function(err, res){
+
+    });
+</code></pre><h2 id="-post-put-requests"><code>POST</code> / <code>PUT</code> requests</h2>
+<p>A typical JSON <strong>POST</strong> request might look a little like the following, where we set the Content-Type header field appropriately, and &quot;write&quot; some data, in this case just a JSON string.</p>
+<pre><code>  request.post(&#39;/user&#39;)
+    .set(&#39;Content-Type&#39;, &#39;application/json&#39;)
+    .send(&#39;{&quot;name&quot;:&quot;tj&quot;,&quot;pet&quot;:&quot;tobi&quot;}&#39;)
+    .end(callback)
+</code></pre><p>Since JSON is undoubtably the most common, it&#39;s the <em>default</em>! The following example is equivalent to the previous.</p>
+<pre><code>  request.post(&#39;/user&#39;)
+    .send({ name: &#39;tj&#39;, pet: &#39;tobi&#39; })
+    .end(callback)
+</code></pre><p>Or using multiple <code>.send()</code> calls:</p>
+<pre><code>  request.post(&#39;/user&#39;)
+    .send({ name: &#39;tj&#39; })
+    .send({ pet: &#39;tobi&#39; })
+    .end(callback)
+</code></pre><p>By default sending strings will set the <code>Content-Type</code> to <code>application/x-www-form-urlencoded</code>,
+  multiple calls will be concatenated with <code>&amp;</code>, here resulting in <code>name=tj&amp;pet=tobi</code>:</p>
+<pre><code>  request.post(&#39;/user&#39;)
+    .send(&#39;name=tj&#39;)
+    .send(&#39;pet=tobi&#39;)
+    .end(callback);
+</code></pre><p>SuperAgent formats are extensible, however by default &quot;json&quot; and &quot;form&quot; are supported. To send the data as <code>application/x-www-form-urlencoded</code> simply invoke <code>.type()</code> with &quot;form&quot;, where the default is &quot;json&quot;. This request will <strong>POST</strong> the body &quot;name=tj&amp;pet=tobi&quot;.</p>
+<pre><code>  request.post(&#39;/user&#39;)
+    .type(&#39;form&#39;)
+    .send({ name: &#39;tj&#39; })
+    .send({ pet: &#39;tobi&#39; })
+    .end(callback)
+</code></pre><h2 id="setting-the-content-type-">Setting the <code>Content-Type</code></h2>
+<p>The obvious solution is to use the <code>.set()</code> method:</p>
+<pre><code> request.post(&#39;/user&#39;)
+   .set(&#39;Content-Type&#39;, &#39;application/json&#39;)
+</code></pre><p>As a short-hand the <code>.type()</code> method is also available, accepting
+the canonicalized MIME type name complete with type/subtype, or
+simply the extension name such as &quot;xml&quot;, &quot;json&quot;, &quot;png&quot;, etc:</p>
+<pre><code> request.post(&#39;/user&#39;)
+   .type(&#39;application/json&#39;)
+
+ request.post(&#39;/user&#39;)
+   .type(&#39;json&#39;)
+
+ request.post(&#39;/user&#39;)
+   .type(&#39;png&#39;)
+</code></pre><h2 id="serializing-request-body">Serializing request body</h2>
+<p>SuperAgent will automatically serialize JSON and forms. If you want to send the payload in a custom format, you can replace the built-in serialization with <code>.serialize()</code> method.</p>
+<h2 id="retrying-requests">Retrying requests</h2>
+<p>When given the <code>.retry()</code> method, SuperAgent will automatically retry requests, if they fail in a way that is transient or could be due to a flaky Internet connection. <code>.retry()</code> takes an optional argument which is the maximum number of times to retry failed requests; the default is 3 times.</p>
+<pre><code> request
+   .get(&#39;http://example.com/search&#39;)
+   .retry(2)
+   .end(callback);
+</code></pre><h2 id="setting-accept">Setting Accept</h2>
+<p>In a similar fashion to the <code>.type()</code> method it is also possible to set the <code>Accept</code> header via the short hand method <code>.accept()</code>. Which references <code>request.types</code> as well allowing you to specify either the full canonicalized MIME type name as <code>type/subtype</code>, or the extension suffix form as &quot;xml&quot;, &quot;json&quot;, &quot;png&quot;, etc. for convenience:</p>
+<pre><code> request.get(&#39;/user&#39;)
+   .accept(&#39;application/json&#39;)
+
+ request.get(&#39;/user&#39;)
+   .accept(&#39;json&#39;)
+
+ request.post(&#39;/user&#39;)
+   .accept(&#39;png&#39;)
+</code></pre><h3 id="facebook-and-accept-json">Facebook and Accept JSON</h3>
+<p>If you are calling Facebook&#39;s API, be sure to send an <code>Accept: application/json</code> header in your request. If you don&#39;t do this, Facebook will respond with <code>Content-Type: text/javascript; charset=UTF-8</code>, which SuperAgent will not parse and thus <code>res.body</code> will be undefined. You can do this with either <code>req.accept(&#39;json&#39;)</code> or <code>req.header(&#39;Accept&#39;, &#39;application/json&#39;)</code>. See <a href="https://github.com/visionmedia/superagent/issues/1078">issue 1078</a> for details.</p>
+<h2 id="query-strings">Query strings</h2>
+<p>  <code>req.query(obj)</code> is a method which may be used to build up a query-string. For example populating <code>?format=json&amp;dest=/login</code> on a <strong>POST</strong>:</p>
+<pre><code>request
+  .post(&#39;/&#39;)
+  .query({ format: &#39;json&#39; })
+  .query({ dest: &#39;/login&#39; })
+  .send({ post: &#39;data&#39;, here: &#39;wahoo&#39; })
+  .end(callback);
+</code></pre><p>By default the query string is not assembled in any particular order. An asciibetically-sorted query string can be enabled with <code>req.sortQuery()</code>. You may also provide a custom sorting comparison function with <code>req.sortQuery(myComparisonFn)</code>. The comparison function should take 2 arguments and return a negative/zero/positive integer.</p>
+<pre><code class="lang-js"> // default order
+ request.get(&#39;/user&#39;)
+   .query(&#39;name=Nick&#39;)
+   .query(&#39;search=Manny&#39;)
+   .sortQuery()
+   .end(callback)
+
+ // customized sort function
+ request.get(&#39;/user&#39;)
+   .query(&#39;name=Nick&#39;)
+   .query(&#39;search=Manny&#39;)
+   .sortQuery(function(a, b){
+     return a.length - b.length;
+   })
+   .end(callback)
+</code></pre>
+<h2 id="tls-options">TLS options</h2>
+<p>In Node.js SuperAgent supports methods to configure HTTPS requests:</p>
+<ul>
+<li><code>.ca()</code>: Set the CA certificate(s) to trust</li>
+<li><code>.cert()</code>: Set the client certificate chain(s)</li>
+<li><code>.key()</code>: Set the client private key(s)</li>
+<li><code>.pfx()</code>: Set the client PFX or PKCS12 encoded private key and certificate chain</li>
+</ul>
+<p>For more information, see Node.js <a href="https://nodejs.org/api/https.html#https_https_request_options_callback">https.request docs</a>.</p>
+<pre><code class="lang-js">var key = fs.readFileSync(&#39;key.pem&#39;),
+    cert = fs.readFileSync(&#39;cert.pem&#39;);
+
+request
+  .post(&#39;/client-auth&#39;)
+  .key(key)
+  .cert(cert)
+  .end(callback);
+</code></pre>
+<pre><code class="lang-js">var ca = fs.readFileSync(&#39;ca.cert.pem&#39;);
+
+request
+  .post(&#39;https://localhost/private-ca-server&#39;)
+  .ca(ca)
+  .end(callback);
+</code></pre>
+<h2 id="parsing-response-bodies">Parsing response bodies</h2>
+<p>SuperAgent will parse known response-body data for you, currently supporting <code>application/x-www-form-urlencoded</code>, <code>application/json</code>, and <code>multipart/form-data</code>.</p>
+<p>You can set a custom parser (that takes precedence over built-in parsers) with the <code>.buffer(true).parse(fn)</code> method. If response buffering is not enabled (<code>.buffer(false)</code>) then the <code>response</code> event will be emitted without waiting for the body parser to finish, so <code>response.body</code> won&#39;t be available.</p>
+<h3 id="json-urlencoded">JSON / Urlencoded</h3>
+<p>The property <code>res.body</code> is the parsed object, for example if a request responded with the JSON string &#39;{&quot;user&quot;:{&quot;name&quot;:&quot;tobi&quot;}}&#39;, <code>res.body.user.name</code> would be &quot;tobi&quot;. Likewise the x-www-form-urlencoded value of &quot;user[name]=tobi&quot; would yield the same result. Only one level of nesting is supported. If you need more complex data, send JSON instead.</p>
+<p>Arrays are sent by repeating the key. <code>.send({color: [&#39;red&#39;,&#39;blue&#39;]})</code> sends <code>color=red&amp;color=blue</code>. If you want the array keys to contain <code>[]</code> in their name, you must add it yourself, as SuperAgent doesn&#39;t add it automatically.</p>
+<h3 id="multipart">Multipart</h3>
+<p>The Node client supports <em>multipart/form-data</em> via the <a href="https://github.com/felixge/node-formidable">Formidable</a> module. When parsing multipart responses, the object <code>res.files</code> is also available to you. Suppose for example a request responds with the following multipart body:</p>
+<pre><code>--whoop
+Content-Disposition: attachment; name=&quot;image&quot;; filename=&quot;tobi.png&quot;
+Content-Type: image/png
+
+... data here ...
+--whoop
+Content-Disposition: form-data; name=&quot;name&quot;
+Content-Type: text/plain
+
+Tobi
+--whoop--
+</code></pre><p>You would have the values <code>res.body.name</code> provided as &quot;Tobi&quot;, and <code>res.files.image</code> as a <code>File</code> object containing the path on disk, filename, and other properties.</p>
+<h3 id="binary">Binary</h3>
+<p>In browsers, you may use <code>.responseType(&#39;blob&#39;)</code> to request handling of binary response bodies. This API is unnecessary when running in node.js. The supported argument values for this method are</p>
+<ul>
+<li><code>&#39;blob&#39;</code> passed through to the XmlHTTPRequest <code>responseType</code> property</li>
+<li><code>&#39;arraybuffer&#39;</code> passed through to the XmlHTTPRequest <code>responseType</code> property</li>
+</ul>
+<pre><code class="lang-js">req.get(&#39;/binary.data&#39;)
+  .responseType(&#39;blob&#39;)
+  .end(function (error, res) {
+    // res.body will be a browser native Blob type here
+  });
+</code></pre>
+<p>For more information, see the Mozilla Developer Network <a href="https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/responseType">xhr.responseType docs</a>.</p>
+<h2 id="response-properties">Response properties</h2>
+<p>Many helpful flags and properties are set on the <code>Response</code> object, ranging from the response text, parsed response body, header fields, status flags and more.</p>
+<h3 id="response-text">Response text</h3>
+<p>The <code>res.text</code> property contains the unparsed response body string. This property is always present for the client API, and only when the mime type matches &quot;text/<em>&quot;, &quot;</em>/json&quot;, or &quot;x-www-form-urlencoded&quot; by default for node. The reasoning is to conserve memory, as buffering text of large bodies such as multipart files or images is extremely inefficient. To force buffering see the &quot;Buffering responses&quot; section.</p>
+<h3 id="response-body">Response body</h3>
+<p>Much like SuperAgent can auto-serialize request data, it can also automatically parse it. When a parser is defined for the Content-Type, it is parsed, which by default includes &quot;application/json&quot; and &quot;application/x-www-form-urlencoded&quot;. The parsed object is then available via <code>res.body</code>.</p>
+<h3 id="response-header-fields">Response header fields</h3>
+<p>The <code>res.header</code> contains an object of parsed header fields, lowercasing field names much like node does. For example <code>res.header[&#39;content-length&#39;]</code>.</p>
+<h3 id="response-content-type">Response Content-Type</h3>
+<p>The Content-Type response header is special-cased, providing <code>res.type</code>, which is void of the charset (if any). For example the Content-Type of &quot;text/html; charset=utf8&quot; will provide &quot;text/html&quot; as <code>res.type</code>, and the <code>res.charset</code> property would then contain &quot;utf8&quot;.</p>
+<h3 id="response-status">Response status</h3>
+<p>The response status flags help determine if the request was a success, among other useful information, making SuperAgent ideal for interacting with RESTful web services. These flags are currently defined as:</p>
+<pre><code> var type = status / 100 | 0;
+
+ // status / class
+ res.status = status;
+ res.statusType = type;
+
+ // basics
+ res.info = 1 == type;
+ res.ok = 2 == type;
+ res.clientError = 4 == type;
+ res.serverError = 5 == type;
+ res.error = 4 == type || 5 == type;
+
+ // sugar
+ res.accepted = 202 == status;
+ res.noContent = 204 == status || 1223 == status;
+ res.badRequest = 400 == status;
+ res.unauthorized = 401 == status;
+ res.notAcceptable = 406 == status;
+ res.notFound = 404 == status;
+ res.forbidden = 403 == status;
+</code></pre><h2 id="aborting-requests">Aborting requests</h2>
+<p>To abort requests simply invoke the <code>req.abort()</code> method.</p>
+<h2 id="timeouts">Timeouts</h2>
+<p>Sometimes networks and servers get &quot;stuck&quot; and never respond after accepting a request. Set timeouts to avoid requests waiting forever.</p>
+<ul>
+<li><p><code>req.timeout({deadline:ms})</code> or <code>req.timeout(ms)</code> (where <code>ms</code> is a number of milliseconds &gt; 0) sets a deadline for the entire request (including all redirects) to complete. If the response isn&#39;t fully downloaded within that time, the request will be aborted.</p>
+</li>
+<li><p><code>req.timeout({response:ms})</code> sets maximum time to wait for the first byte to arrive from the server, but it does not limit how long the entire download can take. Response timeout should be a few seconds longer than just the time it takes server to respond, because it also includes time to make DNS lookup, TCP/IP and TLS connections.</p>
+</li>
+</ul>
+<p>You should use both <code>deadline</code> and <code>response</code> timeouts. This way you can use a short response timeout to detect unresponsive networks quickly, and a long deadline to give time for downloads on slow, but reliable, networks.</p>
+<pre><code>request
+  .get(&#39;/big-file?network=slow&#39;)
+  .timeout({
+    response: 5000,  // Wait 5 seconds for the server to start sending,
+    deadline: 60000, // but allow 1 minute for the file to finish loading.
+  })
+  .end(function(err, res){
+    if (err.timeout) { /* timed out! */ }
+  });
+</code></pre><p>Timeout errors have a <code>.timeout</code> property.</p>
+<h2 id="authentication">Authentication</h2>
+<p>In both Node and browsers auth available via the <code>.auth()</code> method:</p>
+<pre><code>request
+  .get(&#39;http://local&#39;)
+  .auth(&#39;tobi&#39;, &#39;learnboost&#39;)
+  .end(callback);
+</code></pre><p>In the <em>Node</em> client Basic auth can be in the URL as &quot;user:pass&quot;:</p>
+<pre><code>request.get(&#39;http://tobi:learnboost@local&#39;).end(callback);
+</code></pre><p>By default only <code>Basic</code> auth is used. In browser you can add <code>{type:&#39;auto&#39;}</code> to enable all methods built-in in the browser (Digest, NTLM, etc.):</p>
+<pre><code>request.auth(&#39;digest&#39;, &#39;secret&#39;, {type:&#39;auto&#39;})
+</code></pre><h2 id="following-redirects">Following redirects</h2>
+<p>By default up to 5 redirects will be followed, however you may specify this with the <code>res.redirects(n)</code> method:</p>
+<pre><code>request
+  .get(&#39;/some.png&#39;)
+  .redirects(2)
+  .end(callback);
+</code></pre><h2 id="preserving-cookies">Preserving cookies</h2>
+<p>In Node SuperAgent does not save cookies by default, but you can use the <code>.agent()</code> method to create a copy of SuperAgent that saves cookies. Each copy has a separate cookie jar.</p>
+<pre><code>const agent = request.agent();
+agent
+  .post(&#39;/login&#39;)
+  .then(() =&gt; {
+    return agent.get(&#39;/cookied-page&#39;);
+  });
+</code></pre><p>In browsers cookies are managed automatically by the browser, and there is no <code>.agent()</code> method.</p>
+<h2 id="piping-data">Piping data</h2>
+<p>The Node client allows you to pipe data to and from the request. For example piping a file&#39;s contents as the request:</p>
+<pre><code>const request = require(&#39;superagent&#39;);
+const fs = require(&#39;fs&#39;);
+
+const stream = fs.createReadStream(&#39;path/to/my.json&#39;);
+const req = request.post(&#39;/somewhere&#39;);
+req.type(&#39;json&#39;);
+stream.pipe(req);
+</code></pre><p>Or piping the response to a file:</p>
+<pre><code>const stream = fs.createWriteStream(&#39;path/to/my.json&#39;);
+const req = request.get(&#39;/some.json&#39;);
+req.pipe(stream);
+</code></pre><h2 id="multipart-requests">Multipart requests</h2>
+<p>SuperAgent is also great for <em>building</em> multipart requests for which it provides methods <code>.attach()</code> and <code>.field()</code>.</p>
+<h3 id="attaching-files">Attaching files</h3>
+<p>As mentioned a higher-level API is also provided, in the form of <code>.attach(name, [path], [filename])</code> and <code>.field(name, value)</code>/<code>.field(object)</code>. Attaching several files is simple, you can also provide a custom filename for the attachment, otherwise the basename of the attached file is used.</p>
+<pre><code>request
+  .post(&#39;/upload&#39;)
+  .attach(&#39;avatar&#39;, &#39;path/to/tobi.png&#39;, &#39;user.png&#39;)
+  .attach(&#39;image&#39;, &#39;path/to/loki.png&#39;)
+  .attach(&#39;file&#39;, &#39;path/to/jane.png&#39;)
+  .end(callback);
+</code></pre><h3 id="field-values">Field values</h3>
+<p>Much like form fields in HTML, you can set field values with the <code>.field(name, value)</code> method. Suppose you want to upload a few images with your name and email, your request might look something like this:</p>
+<pre><code> request
+   .post(&#39;/upload&#39;)
+   .field(&#39;user[name]&#39;, &#39;Tobi&#39;)
+   .field(&#39;user[email]&#39;, &#39;tobi@learnboost.com&#39;)
+   .field(&#39;friends[]&#39;, [&#39;loki&#39;, &#39;jane&#39;])
+   .attach(&#39;image&#39;, &#39;path/to/tobi.png&#39;)
+   .end(callback);
+</code></pre><h2 id="compression">Compression</h2>
+<p>The node client supports compressed responses, best of all, you don&#39;t have to do anything! It just works.</p>
+<h2 id="buffering-responses">Buffering responses</h2>
+<p>To force buffering of response bodies as <code>res.text</code> you may invoke <code>req.buffer()</code>. To undo the default of buffering for text responses such as &quot;text/plain&quot;, &quot;text/html&quot; etc you may invoke <code>req.buffer(false)</code>.</p>
+<p>When buffered the <code>res.buffered</code> flag is provided, you may use this to handle both buffered and unbuffered responses in the same callback.</p>
+<h2 id="cors">CORS</h2>
+<p>For security reasons, browsers will block cross-origin requests unless the server opts-in using CORS headers. Browsers will also make extra <strong>OPTIONS</strong> requests to check what HTTP headers and methods are allowed by the server. <a href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Access_control_CORS">Read more about CORS</a>.</p>
+<p>The <code>.withCredentials()</code> method enables the ability to send cookies from the origin, however only when <code>Access-Control-Allow-Origin</code> is <em>not</em> a wildcard (&quot;*&quot;), and <code>Access-Control-Allow-Credentials</code> is &quot;true&quot;.</p>
+<pre><code>request
+  .get(&#39;http://api.example.com:4001/&#39;)
+  .withCredentials()
+  .then(function(res){
+    assert.equal(200, res.status);
+    assert.equal(&#39;tobi&#39;, res.text);
+  })
+</code></pre><h2 id="error-handling">Error handling</h2>
+<p>Your callback function will always be passed two arguments: error and response. If no error occurred, the first argument will be null:</p>
+<pre><code>request
+ .post(&#39;/upload&#39;)
+ .attach(&#39;image&#39;, &#39;path/to/tobi.png&#39;)
+ .end(function(err, res){
+
+ });
+</code></pre><p>An &quot;error&quot; event is also emitted, with you can listen for:</p>
+<pre><code>request
+  .post(&#39;/upload&#39;)
+  .attach(&#39;image&#39;, &#39;path/to/tobi.png&#39;)
+  .on(&#39;error&#39;, handle)
+  .end(function(err, res){
+
+  });
+</code></pre><p>Note that a 4xx or 5xx response with super agent <strong>are</strong> considered an error by default. For example if you get a 500 or 403 response, this status information will be available via <code>err.status</code>. Errors from such responses also contain an <code>err.response</code> field with all of the properties mentioned in &quot;<a href="#response-properties">Response properties</a>&quot;. The library behaves in this way to handle the common case of wanting success responses and treating HTTP error status codes as errors while still allowing for custom logic around specific error conditions.</p>
+<p>Network failures, timeouts, and other errors that produce no response will contain no <code>err.status</code> or <code>err.response</code> fields.</p>
+<p>If you wish to handle 404 or other HTTP error responses, you can query the <code>err.status</code> property. When an HTTP error occurs (4xx or 5xx response) the <code>res.error</code> property is an <code>Error</code> object, this allows you to perform checks such as:</p>
+<pre><code>if (err &amp;&amp; err.status === 404) {
+  alert(&#39;oh no &#39; + res.body.message);
+}
+else if (err) {
+  // all other error types we handle generically
+}
+</code></pre><p>Alternatively, you can use the <code>.ok(callback)</code> method to decide whether a response is an error or not. The callback to the <code>ok</code> function gets a response and returns <code>true</code> if the response should be interpreted as success.</p>
+<pre><code>request.get(&#39;/404&#39;)
+  .ok(res =&gt; res.status &lt; 500)
+  .then(response =&gt; {
+    // reads 404 page as a successful response
+  })
+</code></pre><h2 id="progress-tracking">Progress tracking</h2>
+<p>SuperAgent fires <code>progress</code> events on upload and download of large files.</p>
+<pre><code>request.post(url)
+  .attach(&#39;field_name&#39;, file)
+  .on(&#39;progress&#39;, event =&gt; {
+    /* the event is:
+    {
+      direction: &quot;upload&quot; or &quot;download&quot;
+      percent: 0 to 100 // may be missing if file size is unknown
+      total: // total file size, may be missing
+      loaded: // bytes downloaded or uploaded so far
+    } */
+  })
+  .end()
+</code></pre><h2 id="promise-and-generator-support">Promise and Generator support</h2>
+<p>SuperAgent&#39;s request is a &quot;thenable&quot; object that&#39;s compatible with JavaScript promises and <code>async</code>/<code>await</code> syntax. Do not call <code>.end()</code> if you&#39;re using promises.</p>
+<p>Libraries like <a href="https://github.com/tj/co">co</a> or a web framework like <a href="https://github.com/koajs/koa">koa</a> can <code>yield</code> on any SuperAgent method:</p>
+<pre><code>const req = request
+  .get(&#39;http://local&#39;)
+  .auth(&#39;tobi&#39;, &#39;learnboost&#39;);
+const res = yield req;
+</code></pre><p>Note that SuperAgent expects the global <code>Promise</code> object to be present. You&#39;ll need a polyfill to use promises in Internet Explorer or Node.js 0.10.</p>
+<h2 id="browser-and-node-versions">Browser and node versions</h2>
+<p>SuperAgent has two implementations: one for web browsers (using XHR) and one for Node.JS (using core http module). By default Browserify and WebPack will pick the browser version.</p>
+<p>If want to use WebPack to compile code for Node.JS, you <em>must</em> specify <a href="https://webpack.github.io/docs/configuration.html#target">node target</a> in its configuration.</p>
+<h3 id="using-browser-version-in-electron">Using browser version in electron</h3>
+<p><a href="http://electron.atom.io/">Electron</a> developers report if you would prefer to use the browser version of SuperAgent instead of the Node version, you can <code>require(&#39;superagent/superagent&#39;)</code>. Your requests will now show up in the Chrome developer tools Network tab. Note this environment is not covered by automated test suite and not officially supported.</p>
+
+    </div>
+    <a href="http://github.com/visionmedia/superagent"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_white_ffffff.png" alt="Fork me on GitHub"></a>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.2.1/jquery.min.js"></script>
+    <script>
+      $('code').each(function(){
+        $(this).html(highlight($(this).text()));
+      });
+
+      function highlight(js) {
+        return js
+          .replace(/</g, '&lt;')
+          .replace(/>/g, '&gt;')
+          .replace(/('.*?')/gm, '<span class="string">$1</span>')
+          .replace(/(\d+\.\d+)/gm, '<span class="number">$1</span>')
+          .replace(/(\d+)/gm, '<span class="number">$1</span>')
+          .replace(/\bnew *(\w+)/gm, '<span class="keyword">new</span> <span class="init">$1</span>')
+          .replace(/\b(function|new|throw|return|var|if|else)\b/gm, '<span class="keyword">$1</span>')
+      }
+    </script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/tocbot/3.0.0/tocbot.js"></script>
+    <script>
+      // Only use tocbot for main docs, not test docs
+      if (document.querySelector('#superagent')) {
+        tocbot.init({
+          // Where to render the table of contents.
+          tocSelector: '#menu',
+          // Where to grab the headings to build the table of contents.
+          contentSelector: '#content',
+          // Which headings to grab inside of the contentSelector element.
+          headingSelector: 'h2',
+          smoothScroll: false
+        });
+      }
+    </script>
+  </body>
+</html>

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,7 +1,7 @@
 
 # SuperAgent
 
- SuperAgent is light-weight progressive ajax API crafted for flexibility, readability, and a low learning curve after being frustrated with many of the existing request APIs. It also works with Node.js!
+SuperAgent is light-weight progressive ajax API crafted for flexibility, readability, and a low learning curve after being frustrated with many of the existing request APIs. It also works with Node.js!
 
      request
        .post('/api/pet')
@@ -18,11 +18,11 @@
 
 ## Test documentation
 
-  The following [test documentation](docs/test.html) was generated with [Mocha's](http://mochajs.org/) "doc" reporter, and directly reflects the test suite. This provides an additional source of documentation.
+The following [test documentation](test.html) was generated with [Mocha's](http://mochajs.org/) "doc" reporter, and directly reflects the test suite. This provides an additional source of documentation.
 
 ## Request basics
 
- A request can be initiated by invoking the appropriate method on the `request` object, then calling `.end()` to send the request. For example a simple __GET__ request:
+A request can be initiated by invoking the appropriate method on the `request` object, then calling `.end()` to send the request. For example a simple __GET__ request:
 
      request
        .get('/search')
@@ -30,7 +30,7 @@
 
        });
 
-  A method string may also be passed:
+A method string may also be passed:
 
     request('GET', '/search').end(callback);
 
@@ -38,7 +38,7 @@ ES6 promises are supported. *Instead* of `.end()` you can call `.then()`:
 
     request('GET', '/search').then(success, failure);
 
- The __Node__ client may also provide absolute URLs. In browsers absolute URLs won't work unless the server implements [CORS](#cors).
+The __Node__ client may also provide absolute URLs. In browsers absolute URLs won't work unless the server implements [CORS](#cors).
 
      request
        .get('http://example.com/search')
@@ -46,7 +46,7 @@ ES6 promises are supported. *Instead* of `.end()` you can call `.then()`:
 
        });
 
- The __Node__ client supports making requests to [Unix Domain Sockets](http://en.wikipedia.org/wiki/Unix_domain_socket):
+The __Node__ client supports making requests to [Unix Domain Sockets](http://en.wikipedia.org/wiki/Unix_domain_socket):
 
      // pattern: https?+unix://SOCKET_PATH/REQUEST_PATH
      //          Use `%2F` as `/` in SOCKET_PATH
@@ -56,7 +56,7 @@ ES6 promises are supported. *Instead* of `.end()` you can call `.then()`:
 
        });
 
-  __DELETE__, __HEAD__, __PATCH__, __POST__, and __PUT__ requests can also be used, simply change the method name:
+__DELETE__, __HEAD__, __PATCH__, __POST__, and __PUT__ requests can also be used, simply change the method name:
 
     request
       .head('/favicon.ico')
@@ -64,7 +64,7 @@ ES6 promises are supported. *Instead* of `.end()` you can call `.then()`:
 
       });
 
-  __DELETE__ can be also called as `.del()` for compatibility with old IE where `delete` is a reserved word.
+__DELETE__ can be also called as `.del()` for compatibility with old IE where `delete` is a reserved word.
 
   The HTTP method defaults to __GET__, so if you wish, the following is valid:
 
@@ -74,7 +74,7 @@ ES6 promises are supported. *Instead* of `.end()` you can call `.then()`:
 
 ## Setting header fields
 
-  Setting header fields is simple, invoke `.set()` with a field name and value:
+Setting header fields is simple, invoke `.set()` with a field name and value:
 
      request
        .get('/search')
@@ -82,7 +82,7 @@ ES6 promises are supported. *Instead* of `.end()` you can call `.then()`:
        .set('Accept', 'application/json')
        .end(callback);
 
-  You may also pass an object to set several fields in a single call:
+You may also pass an object to set several fields in a single call:
 
      request
        .get('/search')
@@ -91,7 +91,7 @@ ES6 promises are supported. *Instead* of `.end()` you can call `.then()`:
 
 ## `GET` requests
 
- The `.query()` method accepts objects, which when used with the __GET__ method will form a query-string. The following will produce the path `/search?query=Manny&range=1..5&order=desc`.
+The `.query()` method accepts objects, which when used with the __GET__ method will form a query-string. The following will produce the path `/search?query=Manny&range=1..5&order=desc`.
 
      request
        .get('/search')
@@ -102,7 +102,7 @@ ES6 promises are supported. *Instead* of `.end()` you can call `.then()`:
 
        });
 
-  Or as a single object:
+Or as a single object:
 
     request
       .get('/search')
@@ -111,7 +111,7 @@ ES6 promises are supported. *Instead* of `.end()` you can call `.then()`:
 
       });
 
-  The `.query()` method accepts strings as well:
+The `.query()` method accepts strings as well:
 
       request
         .get('/querystring')
@@ -120,7 +120,7 @@ ES6 promises are supported. *Instead* of `.end()` you can call `.then()`:
 
         });
 
-  Or joined:
+Or joined:
 
       request
         .get('/querystring')
@@ -143,27 +143,27 @@ You can also use the `.query()` method for HEAD requests. The following will pro
 
 ## `POST` / `PUT` requests
 
-  A typical JSON __POST__ request might look a little like the following, where we set the Content-Type header field appropriately, and "write" some data, in this case just a JSON string.
+A typical JSON __POST__ request might look a little like the following, where we set the Content-Type header field appropriately, and "write" some data, in this case just a JSON string.
 
       request.post('/user')
         .set('Content-Type', 'application/json')
         .send('{"name":"tj","pet":"tobi"}')
         .end(callback)
 
-  Since JSON is undoubtably the most common, it's the _default_! The following example is equivalent to the previous.
+Since JSON is undoubtably the most common, it's the _default_! The following example is equivalent to the previous.
 
       request.post('/user')
         .send({ name: 'tj', pet: 'tobi' })
         .end(callback)
 
-  Or using multiple `.send()` calls:
+Or using multiple `.send()` calls:
 
       request.post('/user')
         .send({ name: 'tj' })
         .send({ pet: 'tobi' })
         .end(callback)
 
-  By default sending strings will set the `Content-Type` to `application/x-www-form-urlencoded`,
+By default sending strings will set the `Content-Type` to `application/x-www-form-urlencoded`,
   multiple calls will be concatenated with `&`, here resulting in `name=tj&pet=tobi`:
 
       request.post('/user')
@@ -171,7 +171,7 @@ You can also use the `.query()` method for HEAD requests. The following will pro
         .send('pet=tobi')
         .end(callback);
 
-  SuperAgent formats are extensible, however by default "json" and "form" are supported. To send the data as `application/x-www-form-urlencoded` simply invoke `.type()` with "form", where the default is "json". This request will __POST__ the body "name=tj&pet=tobi".
+SuperAgent formats are extensible, however by default "json" and "form" are supported. To send the data as `application/x-www-form-urlencoded` simply invoke `.type()` with "form", where the default is "json". This request will __POST__ the body "name=tj&pet=tobi".
 
       request.post('/user')
         .type('form')
@@ -181,14 +181,14 @@ You can also use the `.query()` method for HEAD requests. The following will pro
 
 ## Setting the `Content-Type`
 
-  The obvious solution is to use the `.set()` method:
+The obvious solution is to use the `.set()` method:
 
      request.post('/user')
        .set('Content-Type', 'application/json')
 
-  As a short-hand the `.type()` method is also available, accepting
-  the canonicalized MIME type name complete with type/subtype, or
-  simply the extension name such as "xml", "json", "png", etc:
+As a short-hand the `.type()` method is also available, accepting
+the canonicalized MIME type name complete with type/subtype, or
+simply the extension name such as "xml", "json", "png", etc:
 
      request.post('/user')
        .type('application/json')
@@ -240,7 +240,7 @@ If you are calling Facebook's API, be sure to send an `Accept: application/json`
       .send({ post: 'data', here: 'wahoo' })
       .end(callback);
 
-  By default the query string is not assembled in any particular order. An asciibetically-sorted query string can be enabled with `req.sortQuery()`. You may also provide a custom sorting comparison function with `req.sortQuery(myComparisonFn)`. The comparison function should take 2 arguments and return a negative/zero/positive integer.
+By default the query string is not assembled in any particular order. An asciibetically-sorted query string can be enabled with `req.sortQuery()`. You may also provide a custom sorting comparison function with `req.sortQuery(myComparisonFn)`. The comparison function should take 2 arguments and return a negative/zero/positive integer.
 
 ```js
  // default order
@@ -293,19 +293,19 @@ request
 
 ## Parsing response bodies
 
-  SuperAgent will parse known response-body data for you, currently supporting `application/x-www-form-urlencoded`, `application/json`, and `multipart/form-data`.
+SuperAgent will parse known response-body data for you, currently supporting `application/x-www-form-urlencoded`, `application/json`, and `multipart/form-data`.
 
-  You can set a custom parser (that takes precedence over built-in parsers) with the `.buffer(true).parse(fn)` method. If response buffering is not enabled (`.buffer(false)`) then the `response` event will be emitted without waiting for the body parser to finish, so `response.body` won't be available.
+You can set a custom parser (that takes precedence over built-in parsers) with the `.buffer(true).parse(fn)` method. If response buffering is not enabled (`.buffer(false)`) then the `response` event will be emitted without waiting for the body parser to finish, so `response.body` won't be available.
 
 ### JSON / Urlencoded
 
-  The property `res.body` is the parsed object, for example if a request responded with the JSON string '{"user":{"name":"tobi"}}', `res.body.user.name` would be "tobi". Likewise the x-www-form-urlencoded value of "user[name]=tobi" would yield the same result. Only one level of nesting is supported. If you need more complex data, send JSON instead.
+The property `res.body` is the parsed object, for example if a request responded with the JSON string '{"user":{"name":"tobi"}}', `res.body.user.name` would be "tobi". Likewise the x-www-form-urlencoded value of "user[name]=tobi" would yield the same result. Only one level of nesting is supported. If you need more complex data, send JSON instead.
 
-  Arrays are sent by repeating the key. `.send({color: ['red','blue']})` sends `color=red&color=blue`. If you want the array keys to contain `[]` in their name, you must add it yourself, as SuperAgent doesn't add it automatically.
+Arrays are sent by repeating the key. `.send({color: ['red','blue']})` sends `color=red&color=blue`. If you want the array keys to contain `[]` in their name, you must add it yourself, as SuperAgent doesn't add it automatically.
 
 ### Multipart
 
-  The Node client supports _multipart/form-data_ via the [Formidable](https://github.com/felixge/node-formidable) module. When parsing multipart responses, the object `res.files` is also available to you. Suppose for example a request responds with the following multipart body:
+The Node client supports _multipart/form-data_ via the [Formidable](https://github.com/felixge/node-formidable) module. When parsing multipart responses, the object `res.files` is also available to you. Suppose for example a request responds with the following multipart body:
 
     --whoop
     Content-Disposition: attachment; name="image"; filename="tobi.png"
@@ -319,7 +319,7 @@ request
     Tobi
     --whoop--
 
-  You would have the values `res.body.name` provided as "Tobi", and `res.files.image` as a `File` object containing the path on disk, filename, and other properties.
+You would have the values `res.body.name` provided as "Tobi", and `res.files.image` as a `File` object containing the path on disk, filename, and other properties.
 
 ### Binary
 
@@ -340,32 +340,27 @@ For more information, see the Mozilla Developer Network [xhr.responseType docs](
 
 ## Response properties
 
-  Many helpful flags and properties are set on the `Response` object, ranging from the response text, parsed response body, header fields, status flags and more.
+Many helpful flags and properties are set on the `Response` object, ranging from the response text, parsed response body, header fields, status flags and more.
 
 ### Response text
 
-  The `res.text` property contains the unparsed response body string. This
-  property is always present for the client API, and only when the mime type
-  matches "text/*", "*/json", or "x-www-form-urlencoded" by default for node. The
-  reasoning is to conserve memory, as buffering text of large bodies such as multipart files or images is extremely inefficient.
-
-  To force buffering see the "Buffering responses" section.
+The `res.text` property contains the unparsed response body string. This property is always present for the client API, and only when the mime type matches "text/*", "*/json", or "x-www-form-urlencoded" by default for node. The reasoning is to conserve memory, as buffering text of large bodies such as multipart files or images is extremely inefficient. To force buffering see the "Buffering responses" section.
 
 ### Response body
 
-  Much like SuperAgent can auto-serialize request data, it can also automatically parse it. When a parser is defined for the Content-Type, it is parsed, which by default includes "application/json" and "application/x-www-form-urlencoded". The parsed object is then available via `res.body`.
+Much like SuperAgent can auto-serialize request data, it can also automatically parse it. When a parser is defined for the Content-Type, it is parsed, which by default includes "application/json" and "application/x-www-form-urlencoded". The parsed object is then available via `res.body`.
 
 ### Response header fields
 
-  The `res.header` contains an object of parsed header fields, lowercasing field names much like node does. For example `res.header['content-length']`.
+The `res.header` contains an object of parsed header fields, lowercasing field names much like node does. For example `res.header['content-length']`.
 
 ### Response Content-Type
 
-  The Content-Type response header is special-cased, providing `res.type`, which is void of the charset (if any). For example the Content-Type of "text/html; charset=utf8" will provide "text/html" as `res.type`, and the `res.charset` property would then contain "utf8".
+The Content-Type response header is special-cased, providing `res.type`, which is void of the charset (if any). For example the Content-Type of "text/html; charset=utf8" will provide "text/html" as `res.type`, and the `res.charset` property would then contain "utf8".
 
 ### Response status
 
-  The response status flags help determine if the request was a success, among other useful information, making SuperAgent ideal for interacting with RESTful web services. These flags are currently defined as:
+The response status flags help determine if the request was a success, among other useful information, making SuperAgent ideal for interacting with RESTful web services. These flags are currently defined as:
 
      var type = status / 100 | 0;
 
@@ -391,7 +386,7 @@ For more information, see the Mozilla Developer Network [xhr.responseType docs](
 
 ## Aborting requests
 
-  To abort requests simply invoke the `req.abort()` method.
+To abort requests simply invoke the `req.abort()` method.
 
 ## Timeouts
 
@@ -417,7 +412,7 @@ Timeout errors have a `.timeout` property.
 
 ## Authentication
 
-  In both Node and browsers auth available via the `.auth()` method:
+In both Node and browsers auth available via the `.auth()` method:
 
     request
       .get('http://local')
@@ -425,17 +420,17 @@ Timeout errors have a `.timeout` property.
       .end(callback);
 
 
-  In the _Node_ client Basic auth can be in the URL as "user:pass":
+In the _Node_ client Basic auth can be in the URL as "user:pass":
 
     request.get('http://tobi:learnboost@local').end(callback);
 
-  By default only `Basic` auth is used. In browser you can add `{type:'auto'}` to enable all methods built-in in the browser (Digest, NTLM, etc.):
+By default only `Basic` auth is used. In browser you can add `{type:'auto'}` to enable all methods built-in in the browser (Digest, NTLM, etc.):
 
     request.auth('digest', 'secret', {type:'auto'})
 
 ## Following redirects
 
-  By default up to 5 redirects will be followed, however you may specify this with the `res.redirects(n)` method:
+By default up to 5 redirects will be followed, however you may specify this with the `res.redirects(n)` method:
 
     request
       .get('/some.png')
@@ -444,7 +439,7 @@ Timeout errors have a `.timeout` property.
 
 ## Preserving cookies
 
-  In Node SuperAgent does not save cookies by default, but you can use the `.agent()` method to create a copy of SuperAgent that saves cookies. Each copy has a separate cookie jar.
+In Node SuperAgent does not save cookies by default, but you can use the `.agent()` method to create a copy of SuperAgent that saves cookies. Each copy has a separate cookie jar.
 
     const agent = request.agent();
     agent
@@ -453,11 +448,11 @@ Timeout errors have a `.timeout` property.
         return agent.get('/cookied-page');
       });
 
-  In browsers cookies are managed automatically by the browser, and there is no `.agent()` method.
+In browsers cookies are managed automatically by the browser, and there is no `.agent()` method.
 
 ## Piping data
 
-  The Node client allows you to pipe data to and from the request. For example piping a file's contents as the request:
+The Node client allows you to pipe data to and from the request. For example piping a file's contents as the request:
 
     const request = require('superagent');
     const fs = require('fs');
@@ -467,7 +462,7 @@ Timeout errors have a `.timeout` property.
     req.type('json');
     stream.pipe(req);
 
-  Or piping the response to a file:
+Or piping the response to a file:
 
     const stream = fs.createWriteStream('path/to/my.json');
     const req = request.get('/some.json');
@@ -475,11 +470,11 @@ Timeout errors have a `.timeout` property.
 
 ## Multipart requests
 
-  SuperAgent is also great for _building_ multipart requests for which it provides methods `.attach()` and `.field()`.
+SuperAgent is also great for _building_ multipart requests for which it provides methods `.attach()` and `.field()`.
 
 ### Attaching files
 
-  As mentioned a higher-level API is also provided, in the form of `.attach(name, [path], [filename])` and `.field(name, value)`/`.field(object)`. Attaching several files is simple, you can also provide a custom filename for the attachment, otherwise the basename of the attached file is used.
+As mentioned a higher-level API is also provided, in the form of `.attach(name, [path], [filename])` and `.field(name, value)`/`.field(object)`. Attaching several files is simple, you can also provide a custom filename for the attachment, otherwise the basename of the attached file is used.
 
     request
       .post('/upload')
@@ -490,7 +485,7 @@ Timeout errors have a `.timeout` property.
 
 ### Field values
 
-  Much like form fields in HTML, you can set field values with the `.field(name, value)` method. Suppose you want to upload a few images with your name and email, your request might look something like this:
+Much like form fields in HTML, you can set field values with the `.field(name, value)` method. Suppose you want to upload a few images with your name and email, your request might look something like this:
 
      request
        .post('/upload')
@@ -502,22 +497,19 @@ Timeout errors have a `.timeout` property.
 
 ## Compression
 
-  The node client supports compressed responses, best of all, you don't have to do anything! It just works.
+The node client supports compressed responses, best of all, you don't have to do anything! It just works.
 
 ## Buffering responses
 
-  To force buffering of response bodies as `res.text` you may invoke `req.buffer()`. To undo the default of buffering for text responses such
-  as "text/plain", "text/html" etc you may invoke `req.buffer(false)`.
+To force buffering of response bodies as `res.text` you may invoke `req.buffer()`. To undo the default of buffering for text responses such as "text/plain", "text/html" etc you may invoke `req.buffer(false)`.
 
-  When buffered the `res.buffered` flag is provided, you may use this to
-  handle both buffered and unbuffered responses in the same callback.
+When buffered the `res.buffered` flag is provided, you may use this to handle both buffered and unbuffered responses in the same callback.
 
 ## CORS
 
-  For security reasons, browsers will block cross-origin requests unless the server opts-in using CORS headers. Browsers will also make extra __OPTIONS__ requests to check what HTTP headers and methods are allowed by the server. [Read more about CORS](https://developer.mozilla.org/en-US/docs/Web/HTTP/Access_control_CORS).
+For security reasons, browsers will block cross-origin requests unless the server opts-in using CORS headers. Browsers will also make extra __OPTIONS__ requests to check what HTTP headers and methods are allowed by the server. [Read more about CORS](https://developer.mozilla.org/en-US/docs/Web/HTTP/Access_control_CORS).
 
-  The `.withCredentials()` method enables the ability to send cookies
-  from the origin, however only when `Access-Control-Allow-Origin` is _not_ a wildcard ("*"), and `Access-Control-Allow-Credentials` is "true".
+The `.withCredentials()` method enables the ability to send cookies from the origin, however only when `Access-Control-Allow-Origin` is _not_ a wildcard ("*"), and `Access-Control-Allow-Credentials` is "true".
 
     request
       .get('http://api.example.com:4001/')
@@ -548,13 +540,11 @@ An "error" event is also emitted, with you can listen for:
 
       });
 
-  Note that a 4xx or 5xx response with super agent **are** considered an error by default. For example if you get a 500 or 403 response, this status information will be available via `err.status`. Errors from such responses also contain an `err.response` field with all of the properties mentioned in "[Response properties](#response-properties)". The library behaves in this way to handle the common case of wanting success responses and treating HTTP error status codes as errors while still allowing for custom logic around specific error conditions.
+Note that a 4xx or 5xx response with super agent **are** considered an error by default. For example if you get a 500 or 403 response, this status information will be available via `err.status`. Errors from such responses also contain an `err.response` field with all of the properties mentioned in "[Response properties](#response-properties)". The library behaves in this way to handle the common case of wanting success responses and treating HTTP error status codes as errors while still allowing for custom logic around specific error conditions.
 
-  Network failures, timeouts, and other errors that produce no response will contain no `err.status` or `err.response` fields.
+Network failures, timeouts, and other errors that produce no response will contain no `err.status` or `err.response` fields.
 
-  If you wish to handle 404 or other HTTP error responses, you can query the `err.status` property.
-  When an HTTP error occurs (4xx or 5xx response) the `res.error` property is an `Error` object,
-  this allows you to perform checks such as:
+If you wish to handle 404 or other HTTP error responses, you can query the `err.status` property. When an HTTP error occurs (4xx or 5xx response) the `res.error` property is an `Error` object, this allows you to perform checks such as:
 
     if (err && err.status === 404) {
       alert('oh no ' + res.body.message);

--- a/docs/style.css
+++ b/docs/style.css
@@ -80,3 +80,8 @@ code .init { color: #2F6FAD }
 code .string { color: #5890AD }
 code .keyword { color: #8A6343 }
 code .number { color: #2F6FAD }
+
+/* override tocbot style to avoid vertical white line in table of content */
+.toc-link::before {
+  content: initial;
+}

--- a/docs/tail.html
+++ b/docs/tail.html
@@ -17,13 +17,20 @@
           .replace(/\b(function|new|throw|return|var|if|else)\b/gm, '<span class="keyword">$1</span>')
       }
     </script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/jqueryui/1.12.1/jquery-ui.min.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery.tocify/1.9.0/javascripts/jquery.tocify.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/tocbot/3.0.0/tocbot.js"></script>
     <script>
-	  $('#menu').tocify({
-	    selectors: 'h2',
-	    hashGenerator: 'pretty'
-	  });
+      // Only use tocbot for main docs, not test docs
+      if (document.querySelector('#superagent')) {
+        tocbot.init({
+          // Where to render the table of contents.
+          tocSelector: '#menu',
+          // Where to grab the headings to build the table of contents.
+          contentSelector: '#content',
+          // Which headings to grab inside of the contentSelector element.
+          headingSelector: 'h2',
+          smoothScroll: false
+        });
+      }
     </script>
   </body>
 </html>

--- a/docs/test.html
+++ b/docs/test.html
@@ -1,35 +1,65 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title>SuperAgent - Ajax with less suck</title>
+    <meta charset="utf8">
+    <title>SuperAgent — elegant API for AJAX in Node and browsers</title>
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/tocbot/3.0.0/tocbot.css">
     <link rel="stylesheet" href="style.css">
-    <script src="jquery.js"></script>
-    <script src="jquery-ui.min.js"></script>
-    <script src="highlight.js"></script>
-    <script src="jquery.tocify.min.js"></script>
-    <script>
-      $(function(){
-        $('#menu').tocify({
-          selectors: 'h2',
-          hashGenerator: 'pretty'
-        });
-      });
-    </script>
   </head>
   <body>
     <ul id="menu"></ul>
-    <div id="content">    <section class="suite">
+    <div id="content">
+    <section class="suite">
       <h1>request</h1>
       <dl>
+        <section class="suite">
+          <h1>res.statusCode</h1>
+          <dl>
+            <dt>should set statusCode</dt>
+            <dd><pre><code>request
+.get(uri + '/login', function(err, res){
+  try {
+  assert.strictEqual(res.statusCode, 200);
+  done();
+  } catch(e) { done(e); }
+});</code></pre></dd>
+          </dl>
+        </section>
+        <section class="suite">
+          <h1>should allow the send shorthand</h1>
+          <dl>
+            <dt>with callback in the method call</dt>
+            <dd><pre><code>request
+.get(uri + '/login', function(err, res) {
+    assert.equal(res.status, 200);
+    done();
+});</code></pre></dd>
+            <dt>with data in the method call</dt>
+            <dd><pre><code>request
+.post(uri + '/echo', { foo: 'bar' })
+.end(function(err, res) {
+  assert.equal('{&quot;foo&quot;:&quot;bar&quot;}', res.text);
+  done();
+});</code></pre></dd>
+            <dt>with callback and data in the method call</dt>
+            <dd><pre><code>request
+.post(uri + '/echo', { foo: 'bar' }, function(err, res) {
+  assert.equal('{&quot;foo&quot;:&quot;bar&quot;}', res.text);
+  done();
+});</code></pre></dd>
+          </dl>
+        </section>
         <section class="suite">
           <h1>with a callback</h1>
           <dl>
             <dt>should invoke .end()</dt>
             <dd><pre><code>request
 .get(uri + '/login', function(err, res){
+  try {
   assert.equal(res.status, 200);
   done();
-})</code></pre></dd>
+  } catch(e) { done(e); }
+});</code></pre></dd>
           </dl>
         </section>
         <section class="suite">
@@ -39,18 +69,71 @@
             <dd><pre><code>request
 .get(uri + '/login')
 .end(function(err, res){
+  try {
   assert.equal(res.status, 200);
   done();
+  } catch(e) { done(e); }
+});</code></pre></dd>
+            <dt>is optional with a promise</dt>
+            <dd><pre><code>if ('undefined' === typeof Promise) {
+  return;
+}
+return request.get(uri + '/login')
+.then(function(res) {
+    return res.status;
+})
+.then()
+.then(function(status) {
+    assert.equal(200, status, &quot;Real promises pass results through&quot;);
+});</code></pre></dd>
+            <dt>called only once with a promise</dt>
+            <dd><pre><code>if ('undefined' === typeof Promise) {
+  return;
+}
+var req = request.get(uri + '/unique');
+return Promise.all([req, req, req])
+.then(function(results){
+  results.forEach(function(item){
+    assert.equal(item.body, results[0].body, &quot;It should keep returning the same result after being called once&quot;);
+  });
 });</code></pre></dd>
           </dl>
         </section>
         <section class="suite">
           <h1>res.error</h1>
           <dl>
-            <dt>should should be an Error object</dt>
-            <dd><pre><code>request
+            <dt>ok</dt>
+            <dd><pre><code>var calledErrorEvent = false;
+var calledOKHandler = false;
+request
 .get(uri + '/error')
+.ok(function(res){
+  assert.strictEqual(500, res.status);
+  calledOKHandler = true;
+  return true;
+})
+.on('error', function(err){
+  calledErrorEvent = true;
+})
 .end(function(err, res){
+  try{
+    assert.ifError(err);
+    assert.strictEqual(res.status, 500);
+    assert(!calledErrorEvent);
+    assert(calledOKHandler);
+    done();
+  } catch(e) { done(e); }
+});</code></pre></dd>
+            <dt>should should be an Error object</dt>
+            <dd><pre><code>var calledErrorEvent = false;
+request
+.get(uri + '/error')
+.on('error', function(err){
+  assert.strictEqual(err.status, 500);
+  calledErrorEvent = true;
+})
+.end(function(err, res){
+  try {
   if (NODE) {
     res.error.message.should.equal('cannot GET /error (500)');
   }
@@ -60,7 +143,33 @@
   assert.strictEqual(res.error.status, 500);
   assert(err, 'should have an error for 500');
   assert.equal(err.message, 'Internal Server Error');
+  assert(calledErrorEvent);
   done();
+  } catch(e) { done(e); }
+});</code></pre></dd>
+            <dt>with .then() promise</dt>
+            <dd><pre><code>if ('undefined' === typeof Promise) {
+  return;
+}
+return request
+.get(uri + '/error')
+.then(function(){
+  assert.fail();
+}, function(err){
+  assert.equal(err.message, 'Internal Server Error');
+});</code></pre></dd>
+            <dt>with .ok() returning false</dt>
+            <dd><pre><code>if ('undefined' === typeof Promise) {
+  return;
+}
+return request
+.get(uri + '/echo')
+.ok(function() {return false;})
+.then(function(){
+  assert.fail();
+}, function(err){
+  assert.equal(200, err.response.status);
+  assert.equal(err.message, 'OK');
 });</code></pre></dd>
           </dl>
         </section>
@@ -71,9 +180,24 @@
             <dd><pre><code>request
 .get(uri + '/login')
 .end(function(err, res){
+  try {
   assert.equal('Express', res.header['x-powered-by']);
   done();
+  } catch(e) { done(e); }
 });</code></pre></dd>
+          </dl>
+        </section>
+        <section class="suite">
+          <h1>set headers</h1>
+          <dl>
+            <dt>should only set headers for ownProperties of header</dt>
+            <dd><pre><code>try {
+  request
+    .get(uri + '/echo')
+    .end(done);
+} catch (e) {
+  done(e)
+}</code></pre></dd>
           </dl>
         </section>
         <section class="suite">
@@ -83,8 +207,10 @@
             <dd><pre><code>request
 .get(uri + '/login')
 .end(function(err, res){
+  try {
   res.charset.should.equal('utf-8');
   done();
+  } catch(e) { done(e); }
 });</code></pre></dd>
           </dl>
         </section>
@@ -95,10 +221,12 @@
             <dd><pre><code>request
 .get(uri + '/login')
 .end(function(err, res){
+  try {
   assert(!err, 'should not have an error for success responses');
   assert.equal(200, res.status);
   assert.equal(2, res.statusType);
   done();
+  } catch(e) { done(e); }
 });</code></pre></dd>
           </dl>
         </section>
@@ -109,9 +237,11 @@
             <dd><pre><code>request
 .get(uri + '/login')
 .end(function(err, res){
+  try {
   res.type.should.equal('text/html');
   res.charset.should.equal('utf-8');
   done();
+  } catch(e) { done(e); }
 });</code></pre></dd>
           </dl>
         </section>
@@ -124,10 +254,12 @@
 .set('X-Foo', 'bar')
 .set('X-Bar', 'baz')
 .end(function(err, res){
+  try {
   assert.equal('bar', res.header['x-foo']);
   assert.equal('baz', res.header['x-bar']);
   done();
-})</code></pre></dd>
+  } catch(e) { done(e); }
+});</code></pre></dd>
           </dl>
         </section>
         <section class="suite">
@@ -138,10 +270,12 @@
 .post(uri + '/echo')
 .set({ 'X-Foo': 'bar', 'X-Bar': 'baz' })
 .end(function(err, res){
+  try {
   assert.equal('bar', res.header['x-foo']);
   assert.equal('baz', res.header['x-bar']);
   done();
-})</code></pre></dd>
+  } catch(e) { done(e); }
+});</code></pre></dd>
           </dl>
         </section>
         <section class="suite">
@@ -152,8 +286,10 @@
 .post(uri + '/echo')
 .type('text/x-foo')
 .end(function(err, res){
+  try {
   res.header['content-type'].should.equal('text/x-foo');
   done();
+  } catch(e) { done(e); }
 });</code></pre></dd>
             <dt>should map &quot;json&quot;</dt>
             <dd><pre><code>request
@@ -161,16 +297,20 @@
 .type('json')
 .send('{&quot;a&quot;: 1}')
 .end(function(err, res){
-  res.should.be.json;
+  try {
+  res.should.be.json();
   done();
+  } catch(e) { done(e); }
 });</code></pre></dd>
             <dt>should map &quot;html&quot;</dt>
             <dd><pre><code>request
 .post(uri + '/echo')
 .type('html')
 .end(function(err, res){
+  try {
   res.header['content-type'].should.equal('text/html');
   done();
+  } catch(e) { done(e); }
 });</code></pre></dd>
           </dl>
         </section>
@@ -182,32 +322,30 @@
 .get(uri + '/echo')
 .accept('text/x-foo')
 .end(function(err, res){
+  try {
    res.header['accept'].should.equal('text/x-foo');
    done();
+  } catch(e) { done(e); }
 });</code></pre></dd>
             <dt>should map &quot;json&quot;</dt>
             <dd><pre><code>request
 .get(uri + '/echo')
 .accept('json')
 .end(function(err, res){
+  try {
   res.header['accept'].should.equal('application/json');
   done();
-});</code></pre></dd>
-            <dt>should map &quot;xml&quot;</dt>
-            <dd><pre><code>request
-.get(uri + '/echo')
-.accept('xml')
-.end(function(err, res){
-  res.header['accept'].should.equal('application/xml');
-  done();
+  } catch(e) { done(e); }
 });</code></pre></dd>
             <dt>should map &quot;html&quot;</dt>
             <dd><pre><code>request
 .get(uri + '/echo')
 .accept('html')
 .end(function(err, res){
+  try {
   res.header['accept'].should.equal('text/html');
   done();
+  } catch(e) { done(e); }
 });</code></pre></dd>
           </dl>
         </section>
@@ -220,8 +358,10 @@
 .type('json')
 .send('{&quot;name&quot;:&quot;tobi&quot;}')
 .end(function(err, res){
+  try {
   res.text.should.equal('{&quot;name&quot;:&quot;tobi&quot;}');
   done();
+  } catch(e) { done(e); }
 });</code></pre></dd>
           </dl>
         </section>
@@ -233,9 +373,11 @@
 .post(uri + '/echo')
 .send({ name: 'tobi' })
 .end(function(err, res){
-  res.should.be.json
+  try {
+  res.should.be.json();
   res.text.should.equal('{&quot;name&quot;:&quot;tobi&quot;}');
   done();
+  } catch(e) { done(e); }
 });</code></pre></dd>
             <section class="suite">
               <h1>when called several times</h1>
@@ -246,13 +388,15 @@
 .send({ name: 'tobi' })
 .send({ age: 1 })
 .end(function(err, res){
-  res.should.be.json
+    try {
+  res.should.be.json();
   if (NODE) {
-    res.buffered.should.be.true;
+    res.buffered.should.be.true();
   }
   res.text.should.equal('{&quot;name&quot;:&quot;tobi&quot;,&quot;age&quot;:1}');
   done();
-});</code></pre></dd>
+  } catch(e) { done(e); }
+      });</code></pre></dd>
               </dl>
             </section>
           </dl>
@@ -265,9 +409,11 @@
 .post(uri + '/echo')
 .send({ name: 'tobi' })
 .end(function(err, res){
+  try {
   assert.equal(null, err);
   res.text.should.equal('{&quot;name&quot;:&quot;tobi&quot;}');
   done();
+  } catch(e) { done(e); }
 });</code></pre></dd>
             <dt>should emit request</dt>
             <dd><pre><code>var req = request.post(uri + '/echo');
@@ -291,7 +437,10 @@ req.end();</code></pre></dd>
           <h1>.then(fulfill, reject)</h1>
           <dl>
             <dt>should support successful fulfills with .then(fulfill)</dt>
-            <dd><pre><code>request
+            <dd><pre><code>if ('undefined' === typeof Promise) {
+  return done();
+}
+request
 .post(uri + '/echo')
 .send({ name: 'tobi' })
 .then(function(res) {
@@ -299,9 +448,28 @@ req.end();</code></pre></dd>
   done();
 })</code></pre></dd>
             <dt>should reject an error with .then(null, reject)</dt>
-            <dd><pre><code>request
+            <dd><pre><code>if ('undefined' === typeof Promise) {
+  return done();
+}
+request
 .get(uri + '/error')
 .then(null, function(err) {
+  assert.equal(err.status, 500);
+  assert.equal(err.response.text, 'boom');
+  done();
+})</code></pre></dd>
+          </dl>
+        </section>
+        <section class="suite">
+          <h1>.catch(reject)</h1>
+          <dl>
+            <dt>should reject an error with .catch(reject)</dt>
+            <dd><pre><code>if ('undefined' === typeof Promise) {
+  return done();
+}
+request
+.get(uri + '/error')
+.catch(function(err) {
   assert.equal(err.status, 500);
   assert.equal(err.response.text, 'boom');
   done();
@@ -315,14 +483,1529 @@ req.end();</code></pre></dd>
             <dd><pre><code>var req = request
 .get(uri + '/delay/3000')
 .end(function(err, res){
+  try {
   assert(false, 'should not complete the request');
+  } catch(e) { done(e); }
+    });
+req.on('error', function(error){
+  done(error);
 });
 req.on('abort', done);
 setTimeout(function() {
   req.abort();
+}, 500);</code></pre></dd>
+            <dt>should allow chaining .abort() several times</dt>
+            <dd><pre><code>var req = request
+.get(uri + '/delay/3000')
+.end(function(err, res){
+  try {
+  assert(false, 'should not complete the request');
+  } catch(e) { done(e); }
+});
+// This also verifies only a single 'done' event is emitted
+req.on('abort', done);
+setTimeout(function() {
+  req.abort().abort().abort();
 }, 1000);</code></pre></dd>
           </dl>
         </section>
+        <section class="suite">
+          <h1>req.toJSON()</h1>
+          <dl>
+            <dt>should describe the request</dt>
+            <dd><pre><code>var req = request
+.post(uri + '/echo')
+.send({ foo: 'baz' })
+.end(function(err, res){
+  try {
+  var json = req.toJSON();
+  assert.equal('POST', json.method);
+  assert(/\/echo$/.test(json.url));
+  assert.equal('baz', json.data.foo);
+  done();
+  } catch(e) { done(e); }
+});</code></pre></dd>
+          </dl>
+        </section>
+        <section class="suite">
+          <h1>req.options()</h1>
+          <dl>
+            <dt>should allow request body</dt>
+            <dd><pre><code>request.options(uri + '/options/echo/body')
+.send({ foo: 'baz' })
+.end(function(err, res){
+  try {
+  assert.equal(err, null);
+  assert.strictEqual(res.body.foo, 'baz');
+  done();
+  } catch(e) { done(e); }
+});</code></pre></dd>
+          </dl>
+        </section>
+        <section class="suite">
+          <h1>req.sortQuery()</h1>
+          <dl>
+            <dt>nop with no querystring</dt>
+            <dd><pre><code>request
+.get(uri + '/url')
+.sortQuery()
+.end(function(err, res){
+  try {
+  assert.equal(res.text, '/url')
+  done();
+  } catch(e) { done(e); }
+});</code></pre></dd>
+            <dt>should sort the request querystring</dt>
+            <dd><pre><code>request
+.get(uri + '/url')
+.query('search=Manny')
+.query('order=desc')
+.sortQuery()
+.end(function(err, res){
+  try {
+  assert.equal(res.text, '/url?order=desc&amp;search=Manny')
+  done();
+  } catch(e) { done(e); }
+});</code></pre></dd>
+            <dt>should allow disabling sorting</dt>
+            <dd><pre><code>request
+.get(uri + '/url')
+.query('search=Manny')
+.query('order=desc')
+.sortQuery() // take default of true
+.sortQuery(false) // override it in later call
+.end(function(err, res){
+  try {
+  assert.equal(res.text, '/url?search=Manny&amp;order=desc')
+  done();
+  } catch(e) { done(e); }
+});</code></pre></dd>
+            <dt>should sort the request querystring using customized function</dt>
+            <dd><pre><code>request
+.get(uri + '/url')
+.query('name=Nick')
+.query('search=Manny')
+.query('order=desc')
+.sortQuery(function(a, b){
+  return a.length - b.length;
+})
+.end(function(err, res){
+  try {
+  assert.equal(res.text, '/url?name=Nick&amp;order=desc&amp;search=Manny')
+  done();
+  } catch(e) { done(e); }
+});</code></pre></dd>
+          </dl>
+        </section>
+      </dl>
+    </section>
+    <section class="suite">
+      <h1>req.set(&quot;Content-Type&quot;, contentType)</h1>
+      <dl>
+        <dt>should work with just the contentType component</dt>
+        <dd><pre><code>request
+.post(uri + '/echo')
+.set('Content-Type', 'application/json')
+.send({ name: 'tobi' })
+.end(function(err, res){
+  assert(!err);
+  done();
+});</code></pre></dd>
+        <dt>should work with the charset component</dt>
+        <dd><pre><code>request
+.post(uri + '/echo')
+.set('Content-Type', 'application/json; charset=utf-8')
+.send({ name: 'tobi' })
+.end(function(err, res){
+  assert(!err);
+  done();
+});</code></pre></dd>
+      </dl>
+    </section>
+    <section class="suite">
+      <h1>req.send(Object) as &quot;form&quot;</h1>
+      <dl>
+        <section class="suite">
+          <h1>with req.type() set to form</h1>
+          <dl>
+            <dt>should send x-www-form-urlencoded data</dt>
+            <dd><pre><code>request
+.post(base + '/echo')
+.type('form')
+.send({ name: 'tobi' })
+.end(function(err, res){
+  res.header['content-type'].should.equal('application/x-www-form-urlencoded');
+  res.text.should.equal('name=tobi');
+  done();
+});</code></pre></dd>
+          </dl>
+        </section>
+        <section class="suite">
+          <h1>when called several times</h1>
+          <dl>
+            <dt>should merge the objects</dt>
+            <dd><pre><code>request
+.post(base + '/echo')
+.type('form')
+.send({ name: { first: 'tobi', last: 'holowaychuk' } })
+.send({ age: '1' })
+.end(function(err, res){
+  res.header['content-type'].should.equal('application/x-www-form-urlencoded');
+  res.text.should.equal('name%5Bfirst%5D=tobi&amp;name%5Blast%5D=holowaychuk&amp;age=1');
+  done();
+});</code></pre></dd>
+          </dl>
+        </section>
+      </dl>
+    </section>
+    <section class="suite">
+      <h1>req.attach</h1>
+      <dl>
+        <dt>ignores null file</dt>
+        <dd><pre><code>request
+  .post('/echo')
+  .attach('image', null)
+  .end(function(err, res){
+    done();
+  });</code></pre></dd>
+      </dl>
+    </section>
+    <section class="suite">
+      <h1>req.field</h1>
+      <dl>
+        <dt>allow bools</dt>
+        <dd><pre><code>if (!formDataSupported) {
+  return done();
+}
+request
+  .post(base + '/formecho')
+  .field('bools', true)
+  .field('strings', 'true')
+  .end(function(err, res){
+    assert.ifError(err);
+    assert.deepStrictEqual(res.body, {bools:'true', strings:'true'});
+    done();
+  });</code></pre></dd>
+        <dt>allow objects</dt>
+        <dd><pre><code>if (!formDataSupported) {
+  return done();
+}
+request
+  .post(base + '/formecho')
+  .field({bools: true, strings: 'true'})
+  .end(function(err, res){
+    assert.ifError(err);
+    assert.deepStrictEqual(res.body, {bools:'true', strings:'true'});
+    done();
+  });</code></pre></dd>
+        <dt>works with arrays in objects</dt>
+        <dd><pre><code>if (!formDataSupported) {
+  return done();
+}
+request
+  .post(base + '/formecho')
+  .field({numbers: [1,2,3]})
+  .end(function(err, res){
+    assert.ifError(err);
+    assert.deepStrictEqual(res.body, {numbers:['1','2','3']});
+    done();
+  });</code></pre></dd>
+        <dt>works with arrays</dt>
+        <dd><pre><code>if (!formDataSupported) {
+  return done();
+}
+request
+  .post(base + '/formecho')
+  .field('letters', ['a', 'b', 'c'])
+  .end(function(err, res){
+    assert.ifError(err);
+    assert.deepStrictEqual(res.body, {letters: ['a', 'b', 'c']});
+    done();
+  });</code></pre></dd>
+        <dt>throw when empty</dt>
+        <dd><pre><code>should.throws(function(){
+  request
+  .post(base + '/echo')
+  .field()
+}, /name/);
+should.throws(function(){
+  request
+  .post(base + '/echo')
+  .field('name')
+}, /val/);</code></pre></dd>
+      </dl>
+    </section>
+    <section class="suite">
+      <h1>req.send(Object) as &quot;json&quot;</h1>
+      <dl>
+        <dt>should default to json</dt>
+        <dd><pre><code>request
+.post(uri + '/echo')
+.send({ name: 'tobi' })
+.end(function(err, res){
+  res.should.be.json();
+  res.text.should.equal('{&quot;name&quot;:&quot;tobi&quot;}');
+  done();
+});</code></pre></dd>
+        <dt>should work with arrays</dt>
+        <dd><pre><code>request
+.post(uri + '/echo')
+.send([1,2,3])
+.end(function(err, res){
+  res.should.be.json();
+  res.text.should.equal('[1,2,3]');
+  done();
+});</code></pre></dd>
+        <dt>should work with value null</dt>
+        <dd><pre><code>request
+.post(uri + '/echo')
+.type('json')
+.send('null')
+.end(function(err, res){
+  res.should.be.json();
+  assert.strictEqual(res.body, null);
+  done();
+});</code></pre></dd>
+        <dt>should work with value false</dt>
+        <dd><pre><code>request
+.post(uri + '/echo')
+.type('json')
+.send('false')
+.end(function(err, res){
+  res.should.be.json();
+  res.body.should.equal(false);
+  done();
+});</code></pre></dd>
+        <dt>should work with value 0</dt>
+        <dd><pre><code>// fails in IE9
+   request
+   .post(uri + '/echo')
+   .type('json')
+   .send('0')
+   .end(function(err, res){
+     res.should.be.json();
+     res.body.should.equal(0);
+     done();
+   });</code></pre></dd>
+        <dt>should work with empty string value</dt>
+        <dd><pre><code>request
+.post(uri + '/echo')
+.type('json')
+.send('&quot;&quot;')
+.end(function(err, res){
+  res.should.be.json();
+  res.body.should.equal(&quot;&quot;);
+  done();
+});</code></pre></dd>
+        <dt>should work with GET</dt>
+        <dd><pre><code>request
+.get(uri + '/echo')
+.send({ tobi: 'ferret' })
+.end(function(err, res){
+  try {
+    res.should.be.json();
+    res.text.should.equal('{&quot;tobi&quot;:&quot;ferret&quot;}');
+    ({&quot;tobi&quot;:&quot;ferret&quot;}).should.eql(res.body);
+    done();
+  } catch(e) {done(e);}
+});</code></pre></dd>
+        <dt>should work with vendor MIME type</dt>
+        <dd><pre><code>request
+.post(uri + '/echo')
+.set('Content-Type', 'application/vnd.example+json')
+.send({ name: 'vendor' })
+.end(function(err, res){
+  res.text.should.equal('{&quot;name&quot;:&quot;vendor&quot;}');
+  ({&quot;name&quot;:&quot;vendor&quot;}).should.eql(res.body);
+  done();
+});</code></pre></dd>
+        <section class="suite">
+          <h1>when called several times</h1>
+          <dl>
+            <dt>should merge the objects</dt>
+            <dd><pre><code>request
+.post(uri + '/echo')
+.send({ name: 'tobi' })
+.send({ age: 1 })
+.end(function(err, res){
+  res.should.be.json();
+  res.text.should.equal('{&quot;name&quot;:&quot;tobi&quot;,&quot;age&quot;:1}');
+  ({&quot;name&quot;:&quot;tobi&quot;,&quot;age&quot;:1}).should.eql(res.body);
+  done();
+});</code></pre></dd>
+          </dl>
+        </section>
+      </dl>
+    </section>
+    <section class="suite">
+      <h1>res.body</h1>
+      <dl>
+        <section class="suite">
+          <h1>application/json</h1>
+          <dl>
+            <dt>should parse the body</dt>
+            <dd><pre><code>request
+.get(uri + '/json')
+.end(function(err, res){
+  res.text.should.equal('{&quot;name&quot;:&quot;manny&quot;}');
+  res.body.should.eql({ name: 'manny' });
+  done();
+});</code></pre></dd>
+          </dl>
+        </section>
+        <section class="suite">
+          <h1>HEAD requests</h1>
+          <dl>
+            <dt>should not throw a parse error</dt>
+            <dd><pre><code>request
+.head(uri + '/json')
+.end(function(err, res){
+  try {
+  assert.strictEqual(err, null);
+  assert.strictEqual(res.text, undefined)
+  assert.strictEqual(Object.keys(res.body).length, 0)
+  done();
+  } catch(e) {done(e);}
+});</code></pre></dd>
+          </dl>
+        </section>
+        <section class="suite">
+          <h1>Invalid JSON response</h1>
+          <dl>
+            <dt>should return the raw response</dt>
+            <dd><pre><code>request
+.get(uri + '/invalid-json')
+.end(function(err, res){
+  assert.deepEqual(err.rawResponse, &quot;)]}', {'header':{'code':200,'text':'OK','version':'1.0'},'data':'some data'}&quot;);
+  done();
+});</code></pre></dd>
+            <dt>should return the http status code</dt>
+            <dd><pre><code>request
+.get(uri + '/invalid-json-forbidden')
+.end(function(err, res){
+  assert.equal(err.statusCode, 403);
+  done();
+});</code></pre></dd>
+          </dl>
+        </section>
+        <section class="suite">
+          <h1>No content</h1>
+          <dl>
+            <dt>should not throw a parse error</dt>
+            <dd><pre><code>request
+.get(uri + '/no-content')
+.end(function(err, res){
+  try {
+  assert.strictEqual(err, null);
+  assert.strictEqual(res.text, '');
+  assert.strictEqual(Object.keys(res.body).length, 0);
+  done();
+  } catch(e) {done(e);}
+});</code></pre></dd>
+          </dl>
+        </section>
+        <section class="suite">
+          <h1>application/json+hal</h1>
+          <dl>
+            <dt>should parse the body</dt>
+            <dd><pre><code>request
+.get(uri + '/json-hal')
+.end(function(err, res){
+  if (err) return done(err);
+  res.text.should.equal('{&quot;name&quot;:&quot;hal 5000&quot;}');
+  res.body.should.eql({ name: 'hal 5000' });
+  done();
+});</code></pre></dd>
+          </dl>
+        </section>
+        <section class="suite">
+          <h1>vnd.collection+json</h1>
+          <dl>
+            <dt>should parse the body</dt>
+            <dd><pre><code>request
+.get(uri + '/collection-json')
+.end(function(err, res){
+  res.text.should.equal('{&quot;name&quot;:&quot;chewbacca&quot;}');
+  res.body.should.eql({ name: 'chewbacca' });
+  done();
+});</code></pre></dd>
+          </dl>
+        </section>
+      </dl>
+    </section>
+    <section class="suite">
+      <h1>request</h1>
+      <dl>
+        <section class="suite">
+          <h1>on redirect</h1>
+          <dl>
+            <dt>should retain header fields</dt>
+            <dd><pre><code>request
+.get(base + '/header')
+.set('X-Foo', 'bar')
+.end(function(err, res){
+  try {
+    assert(res.body);
+    res.body.should.have.property('x-foo', 'bar');
+    done();
+  } catch(err) {
+    done(err);
+  }
+});</code></pre></dd>
+            <dt>should preserve timeout across redirects</dt>
+            <dd><pre><code>request
+.get(base + '/movies/random')
+.timeout(250)
+.end(function(err, res){
+  try {
+    assert(err instanceof Error, 'expected an error');
+    err.should.have.property('timeout', 250);
+    done();
+  } catch(err) {
+    done(err);
+  }
+});</code></pre></dd>
+            <dt>should successfully redirect after retry on error</dt>
+            <dd><pre><code>var id = Math.random() * 1000000 * Date.now();
+request
+.get(base + '/error/redirect/' + id)
+.retry(2)
+.end(function(err, res){
+  assert(res.ok, 'response should be ok');
+  assert(res.text, 'first movie page');
+  done();
+});</code></pre></dd>
+            <dt>should preserve retries across redirects</dt>
+            <dd><pre><code>var id = Math.random() * 1000000 * Date.now();
+request
+.get(base + '/error/redirect-error' + id)
+.retry(2)
+.end(function(err, res){
+  assert(err, 'expected an error');
+  assert.equal(2, err.retries, 'expected an error with .retries');
+  assert.equal(500, err.status, 'expected an error status of 500');
+  done();
+});</code></pre></dd>
+          </dl>
+        </section>
+        <section class="suite">
+          <h1>on 303</h1>
+          <dl>
+            <dt>should redirect with same method</dt>
+            <dd><pre><code>request
+.put(base + '/redirect-303')
+.send({msg: &quot;hello&quot;})
+.redirects(1)
+.on('redirect', function(res) {
+  res.headers.location.should.equal('/reply-method')
+})
+.end(function(err, res){
+  if (err) {
+    done(err);
+    return;
+  }
+  res.text.should.equal('method=get');
+  done();
+})</code></pre></dd>
+          </dl>
+        </section>
+        <section class="suite">
+          <h1>on 307</h1>
+          <dl>
+            <dt>should redirect with same method</dt>
+            <dd><pre><code>if (isMSIE) return done(); // IE9 broken
+request
+.put(base + '/redirect-307')
+.send({msg: &quot;hello&quot;})
+.redirects(1)
+.on('redirect', function(res) {
+  res.headers.location.should.equal('/reply-method')
+})
+.end(function(err, res){
+  if (err) {
+    done(err);
+    return;
+  }
+  res.text.should.equal('method=put');
+  done();
+})</code></pre></dd>
+          </dl>
+        </section>
+        <section class="suite">
+          <h1>on 308</h1>
+          <dl>
+            <dt>should redirect with same method</dt>
+            <dd><pre><code>if (isMSIE) return done(); // IE9 broken
+request
+.put(base + '/redirect-308')
+.send({msg: &quot;hello&quot;})
+.redirects(1)
+.on('redirect', function(res) {
+  res.headers.location.should.equal('/reply-method')
+})
+.end(function(err, res){
+  if (err) {
+    done(err);
+    return;
+  }
+  res.text.should.equal('method=put');
+  done();
+})</code></pre></dd>
+          </dl>
+        </section>
+      </dl>
+    </section>
+    <section class="suite">
+      <h1>request</h1>
+      <dl>
+        <dt>Request inheritance</dt>
+        <dd><pre><code>assert(request.get(uri + '/') instanceof request.Request);</code></pre></dd>
+        <dt>request() simple GET without callback</dt>
+        <dd><pre><code>request('GET', 'test/test.request.js').end();
+next();</code></pre></dd>
+        <dt>request() simple GET</dt>
+        <dd><pre><code>request('GET', uri + '/ok').end(function(err, res){
+  try {
+  assert(res instanceof request.Response, 'respond with Response');
+  assert(res.ok, 'response should be ok');
+  assert(res.text, 'res.text');
+  next();
+  } catch(e) { next(e); }
+});</code></pre></dd>
+        <dt>request() simple HEAD</dt>
+        <dd><pre><code>request.head(uri + '/ok').end(function(err, res){
+  try {
+  assert(res instanceof request.Response, 'respond with Response');
+  assert(res.ok, 'response should be ok');
+  assert(!res.text, 'res.text');
+  next();
+  } catch(e) { next(e); }
+});</code></pre></dd>
+        <dt>request() GET 5xx</dt>
+        <dd><pre><code>request('GET', uri + '/error').end(function(err, res){
+  try {
+  assert(err);
+  assert.equal(err.message, 'Internal Server Error');
+  assert(!res.ok, 'response should not be ok');
+  assert(res.error, 'response should be an error');
+  assert(!res.clientError, 'response should not be a client error');
+  assert(res.serverError, 'response should be a server error');
+  next();
+  } catch(e) { next(e); }
+});</code></pre></dd>
+        <dt>request() GET 4xx</dt>
+        <dd><pre><code>request('GET', uri + '/notfound').end(function(err, res){
+  try {
+  assert(err);
+  assert.equal(err.message, 'Not Found');
+  assert(!res.ok, 'response should not be ok');
+  assert(res.error, 'response should be an error');
+  assert(res.clientError, 'response should be a client error');
+  assert(!res.serverError, 'response should not be a server error');
+  next();
+  } catch(e) { next(e); }
+});</code></pre></dd>
+        <dt>request() GET 404 Not Found</dt>
+        <dd><pre><code>request('GET', uri + '/notfound').end(function(err, res){
+  try {
+  assert(err);
+  assert(res.notFound, 'response should be .notFound');
+  next();
+  } catch(e) { next(e); }
+});</code></pre></dd>
+        <dt>request() GET 400 Bad Request</dt>
+        <dd><pre><code>request('GET', uri + '/bad-request').end(function(err, res){
+  try {
+  assert(err);
+  assert(res.badRequest, 'response should be .badRequest');
+  next();
+  } catch(e) { next(e); }
+});</code></pre></dd>
+        <dt>request() GET 401 Bad Request</dt>
+        <dd><pre><code>request('GET', uri + '/unauthorized').end(function(err, res){
+  try {
+  assert(err);
+  assert(res.unauthorized, 'response should be .unauthorized');
+  next();
+  } catch(e) { next(e); }
+});</code></pre></dd>
+        <dt>request() GET 406 Not Acceptable</dt>
+        <dd><pre><code>request('GET', uri + '/not-acceptable').end(function(err, res){
+  try {
+  assert(err);
+  assert(res.notAcceptable, 'response should be .notAcceptable');
+  next();
+  } catch(e) { next(e); }
+});</code></pre></dd>
+        <dt>request() GET 204 No Content</dt>
+        <dd><pre><code>request('GET', uri + '/no-content').end(function(err, res){
+  try {
+  assert.ifError(err);
+  assert(res.noContent, 'response should be .noContent');
+  next();
+  } catch(e) { next(e); }
+});</code></pre></dd>
+        <dt>request() DELETE 204 No Content</dt>
+        <dd><pre><code>request('DELETE', uri + '/no-content').end(function(err, res){
+  try {
+  assert.ifError(err);
+  assert(res.noContent, 'response should be .noContent');
+  next();
+  } catch(e) { next(e); }
+});</code></pre></dd>
+        <dt>request() header parsing</dt>
+        <dd><pre><code>request('GET', uri + '/notfound').end(function(err, res){
+  try {
+  assert(err);
+  assert.equal('text/html; charset=utf-8', res.header['content-type']);
+  assert.equal('Express', res.header['x-powered-by']);
+  next();
+  } catch(e) { next(e); }
+});</code></pre></dd>
+        <dt>request() .status</dt>
+        <dd><pre><code>request('GET', uri + '/notfound').end(function(err, res){
+  try {
+  assert(err);
+  assert.equal(404, res.status, 'response .status');
+  assert.equal(4, res.statusType, 'response .statusType');
+  next();
+  } catch(e) { next(e); }
+});</code></pre></dd>
+        <dt>get()</dt>
+        <dd><pre><code>request.get( uri + '/notfound').end(function(err, res){
+  try {
+  assert(err);
+  assert.equal(404, res.status, 'response .status');
+  assert.equal(4, res.statusType, 'response .statusType');
+  next();
+  } catch(e) { next(e); }
+});</code></pre></dd>
+        <dt>put()</dt>
+        <dd><pre><code>request.put(uri + '/user/12').end(function(err, res){
+  try {
+  assert.equal('updated', res.text, 'response text');
+  next();
+  } catch(e) { next(e); }
+});</code></pre></dd>
+        <dt>put().send()</dt>
+        <dd><pre><code>request.put(uri + '/user/13/body').send({user:&quot;new&quot;}).end(function(err, res){
+  try {
+  assert.equal('received new', res.text, 'response text');
+  next();
+  } catch(e) { next(e); }
+});</code></pre></dd>
+        <dt>post()</dt>
+        <dd><pre><code>request.post(uri + '/user').end(function(err, res){
+  try {
+  assert.equal('created', res.text, 'response text');
+  next();
+  } catch(e) { next(e); }
+});</code></pre></dd>
+        <dt>del()</dt>
+        <dd><pre><code>request.del(uri + '/user/12').end(function(err, res){
+  try {
+  assert.equal('deleted', res.text, 'response text');
+  next();
+  } catch(e) { next(e); }
+});</code></pre></dd>
+        <dt>delete()</dt>
+        <dd><pre><code>request.delete(uri + '/user/12').end(function(err, res){
+  try {
+  assert.equal('deleted', res.text, 'response text');
+  next();
+  } catch(e) { next(e); }
+});</code></pre></dd>
+        <dt>post() data</dt>
+        <dd><pre><code>request.post(uri + '/todo/item')
+.type('application/octet-stream')
+.send('tobi')
+.end(function(err, res){
+  try {
+  assert.equal('added &quot;tobi&quot;', res.text, 'response text');
+  next();
+  } catch(e) { next(e); }
+});</code></pre></dd>
+        <dt>request .type()</dt>
+        <dd><pre><code>request
+.post(uri + '/user/12/pet')
+.type('urlencoded')
+.send('pet=tobi')
+.end(function(err, res){
+  try {
+  assert.equal('added pet &quot;tobi&quot;', res.text, 'response text');
+  next();
+  } catch(e) { next(e); }
+});</code></pre></dd>
+        <dt>request .type() with alias</dt>
+        <dd><pre><code>request
+.post(uri + '/user/12/pet')
+.type('application/x-www-form-urlencoded')
+.send('pet=tobi')
+.end(function(err, res){
+  try {
+  assert.equal('added pet &quot;tobi&quot;', res.text, 'response text');
+  next();
+  } catch(e) { next(e); }
+});</code></pre></dd>
+        <dt>request .get() with no data or callback</dt>
+        <dd><pre><code>request.get(uri + '/echo-header/content-type');
+next();</code></pre></dd>
+        <dt>request .send() with no data only</dt>
+        <dd><pre><code>request.post(uri + '/user/5/pet').type('urlencoded').send('pet=tobi');
+next();</code></pre></dd>
+        <dt>request .send() with callback only</dt>
+        <dd><pre><code>request
+.get(uri + '/echo-header/accept')
+.set('Accept', 'foo/bar')
+.end(function(err, res){
+  try {
+  assert.equal('foo/bar', res.text);
+  next();
+  } catch(e) { next(e); }
+});</code></pre></dd>
+        <dt>request .accept() with json</dt>
+        <dd><pre><code>request
+.get(uri + '/echo-header/accept')
+.accept('json')
+.end(function(err, res){
+  try {
+  assert.equal('application/json', res.text);
+  next();
+  } catch(e) { next(e); }
+});</code></pre></dd>
+        <dt>request .accept() with application/json</dt>
+        <dd><pre><code>request
+.get(uri + '/echo-header/accept')
+.accept('application/json')
+.end(function(err, res){
+  try {
+  assert.equal('application/json', res.text);
+  next();
+  } catch(e) { next(e); }
+});</code></pre></dd>
+        <dt>request .accept() with application/xml</dt>
+        <dd><pre><code>request
+.get(uri + '/echo-header/accept')
+.accept('application/xml')
+.end(function(err, res){
+try {
+  assert.equal('application/xml', res.text);
+  next();
+  } catch(e) { next(e); }
+});</code></pre></dd>
+        <dt>request .end()</dt>
+        <dd><pre><code>request
+.get(uri + '/echo-header/content-type')
+.set('Content-Type', 'text/plain')
+.send('wahoo')
+.end(function(err, res){
+try {
+  assert.equal('text/plain', res.text);
+  next();
+  } catch(e) { next(e); }
+});</code></pre></dd>
+        <dt>request .send()</dt>
+        <dd><pre><code>request
+.get(uri + '/echo-header/content-type')
+.set('Content-Type', 'text/plain')
+.send('wahoo')
+.end(function(err, res){
+try {
+  assert.equal('text/plain', res.text);
+  next();
+  } catch(e) { next(e); }
+});</code></pre></dd>
+        <dt>request .set()</dt>
+        <dd><pre><code>request
+.get(uri + '/echo-header/content-type')
+.set('Content-Type', 'text/plain')
+.send('wahoo')
+.end(function(err, res){
+try {
+  assert.equal('text/plain', res.text);
+  next();
+  } catch(e) { next(e); }
+});</code></pre></dd>
+        <dt>request .set(object)</dt>
+        <dd><pre><code>request
+.get(uri + '/echo-header/content-type')
+.set({ 'Content-Type': 'text/plain' })
+.send('wahoo')
+.end(function(err, res){
+try {
+  assert.equal('text/plain', res.text);
+  next();
+  } catch(e) { next(e); }
+});</code></pre></dd>
+        <dt>POST urlencoded</dt>
+        <dd><pre><code>request
+.post(uri + '/pet')
+.type('urlencoded')
+.send({ name: 'Manny', species: 'cat' })
+.end(function(err, res){
+try {
+  assert.equal('added Manny the cat', res.text);
+  next();
+  } catch(e) { next(e); }
+});</code></pre></dd>
+        <dt>POST json</dt>
+        <dd><pre><code>request
+.post(uri + '/pet')
+.type('json')
+.send({ name: 'Manny', species: 'cat' })
+.end(function(err, res){
+try {
+  assert.equal('added Manny the cat', res.text);
+  next();
+  } catch(e) { next(e); }
+});</code></pre></dd>
+        <dt>POST json array</dt>
+        <dd><pre><code>request
+.post(uri + '/echo')
+.send([1,2,3])
+.end(function(err, res){
+try {
+  assert.equal('application/json', res.header['content-type'].split(';')[0]);
+  assert.equal('[1,2,3]', res.text);
+  next();
+  } catch(e) { next(e); }
+});</code></pre></dd>
+        <dt>POST json default</dt>
+        <dd><pre><code>request
+.post(uri + '/pet')
+.send({ name: 'Manny', species: 'cat' })
+.end(function(err, res){
+try {
+  assert.equal('added Manny the cat', res.text);
+  next();
+  } catch(e) { next(e); }
+});</code></pre></dd>
+        <dt>POST json contentType charset</dt>
+        <dd><pre><code>request
+.post(uri + '/echo')
+.set('Content-Type', 'application/json; charset=UTF-8')
+.send({ data: ['data1', 'data2'] })
+.end(function(err, res){
+try {
+  assert.equal('{&quot;data&quot;:[&quot;data1&quot;,&quot;data2&quot;]}', res.text);
+  next();
+  } catch(e) { next(e); }
+});</code></pre></dd>
+        <dt>POST json contentType vendor</dt>
+        <dd><pre><code>request
+.post(uri + '/echo')
+.set('Content-Type', 'application/vnd.example+json')
+.send({ data: ['data1', 'data2'] })
+.end(function(err, res){
+try {
+  assert.equal('{&quot;data&quot;:[&quot;data1&quot;,&quot;data2&quot;]}', res.text);
+  next();
+  } catch(e) { next(e); }
+});</code></pre></dd>
+        <dt>POST multiple .send() calls</dt>
+        <dd><pre><code>request
+.post(uri + '/pet')
+.send({ name: 'Manny' })
+.send({ species: 'cat' })
+.end(function(err, res){
+try {
+  assert.equal('added Manny the cat', res.text);
+  next();
+  } catch(e) { next(e); }
+});</code></pre></dd>
+        <dt>POST multiple .send() strings</dt>
+        <dd><pre><code>request
+.post(uri + '/echo')
+.send('user[name]=tj')
+.send('user[email]=tj@vision-media.ca')
+.end(function(err, res){
+try {
+  assert.equal('application/x-www-form-urlencoded', res.header['content-type'].split(';')[0]);
+  assert.equal(res.text, 'user[name]=tj&amp;user[email]=tj@vision-media.ca')
+  next();
+} catch(e) { next(e); }
+})</code></pre></dd>
+        <dt>POST with no data</dt>
+        <dd><pre><code>request
+  .post(uri + '/empty-body')
+  .send().end(function(err, res){
+  try {
+    assert.ifError(err);
+    assert(res.noContent, 'response should be .noContent');
+    next();
+  } catch(e) { next(e); }
+  });</code></pre></dd>
+        <dt>GET .type</dt>
+        <dd><pre><code>request
+.get(uri + '/pets')
+.end(function(err, res){
+try {
+  assert.equal('application/json', res.type);
+  next();
+  } catch(e) { next(e); }
+});</code></pre></dd>
+        <dt>GET Content-Type params</dt>
+        <dd><pre><code>request
+.get(uri + '/text')
+.end(function(err, res){
+  try {
+  assert.equal('utf-8', res.charset);
+  next();
+  } catch(e) { next(e); }
+});</code></pre></dd>
+        <dt>GET json</dt>
+        <dd><pre><code>request
+.get(uri + '/pets')
+.end(function(err, res){
+  try {
+  assert.deepEqual(res.body, ['tobi', 'loki', 'jane']);
+  next();
+  } catch(e) { next(e); }
+});</code></pre></dd>
+        <dt>GET x-www-form-urlencoded</dt>
+        <dd><pre><code>request
+.get(uri + '/foo')
+.end(function(err, res){
+  try {
+  assert.deepEqual(res.body, { foo: 'bar' });
+  next();
+  } catch(e) { next(e); }
+});</code></pre></dd>
+        <dt>GET shorthand</dt>
+        <dd><pre><code>request.get(uri + '/foo', function(err, res){
+  try {
+  assert.equal('foo=bar', res.text);
+  next();
+  } catch(e) { next(e); }
+});</code></pre></dd>
+        <dt>POST shorthand</dt>
+        <dd><pre><code>request.post(uri + '/user/0/pet', { pet: 'tobi' }, function(err, res){
+  try {
+  assert.equal('added pet &quot;tobi&quot;', res.text);
+  next();
+  } catch(e) { next(e); }
+});</code></pre></dd>
+        <dt>POST shorthand without callback</dt>
+        <dd><pre><code>request.post(uri + '/user/0/pet', { pet: 'tobi' }).end(function(err, res){
+  try {
+  assert.equal('added pet &quot;tobi&quot;', res.text);
+  next();
+  } catch(e) { next(e); }
+});</code></pre></dd>
+        <dt>GET querystring object with array</dt>
+        <dd><pre><code>request
+.get(uri + '/querystring')
+.query({ val: ['a', 'b', 'c'] })
+.end(function(err, res){
+  try {
+  assert.deepEqual(res.body, { val: ['a', 'b', 'c'] });
+  next();
+  } catch(e) { next(e); }
+});</code></pre></dd>
+        <dt>GET querystring object with array and primitives</dt>
+        <dd><pre><code>request
+.get(uri + '/querystring')
+.query({ array: ['a', 'b', 'c'], string: 'foo', number: 10 })
+.end(function(err, res){
+  try {
+  assert.deepEqual(res.body, { array: ['a', 'b', 'c'], string: 'foo', number: 10 });
+  next();
+  } catch(e) { next(e); }
+});</code></pre></dd>
+        <dt>GET querystring object with two arrays</dt>
+        <dd><pre><code>request
+.get(uri + '/querystring')
+.query({ array1: ['a', 'b', 'c'], array2: [1, 2, 3]})
+.end(function(err, res){
+  try {
+  assert.deepEqual(res.body, { array1: ['a', 'b', 'c'], array2: [1, 2, 3]});
+  next();
+  } catch(e) { next(e); }
+});</code></pre></dd>
+        <dt>GET querystring object</dt>
+        <dd><pre><code>request
+.get(uri + '/querystring')
+.query({ search: 'Manny' })
+.end(function(err, res){
+  try {
+  assert.deepEqual(res.body, { search: 'Manny' });
+  next();
+  } catch(e) { next(e); }
+});</code></pre></dd>
+        <dt>GET querystring append original</dt>
+        <dd><pre><code>request
+.get(uri + '/querystring?search=Manny')
+.query({ range: '1..5' })
+.end(function(err, res){
+  try {
+  assert.deepEqual(res.body, { search: 'Manny', range: '1..5' });
+  next();
+  } catch(e) { next(e); }
+});</code></pre></dd>
+        <dt>GET querystring multiple objects</dt>
+        <dd><pre><code>request
+.get(uri + '/querystring')
+.query({ search: 'Manny' })
+.query({ range: '1..5' })
+.query({ order: 'desc' })
+.end(function(err, res){
+  try {
+  assert.deepEqual(res.body, { search: 'Manny', range: '1..5', order: 'desc' });
+  next();
+  } catch(e) { next(e); }
+});</code></pre></dd>
+        <dt>GET querystring with strings</dt>
+        <dd><pre><code>request
+.get(uri + '/querystring')
+.query('search=Manny')
+.query('range=1..5')
+.query('order=desc')
+.end(function(err, res){
+  try {
+  assert.deepEqual(res.body, { search: 'Manny', range: '1..5', order: 'desc' });
+  next();
+  } catch(e) { next(e); }
+});</code></pre></dd>
+        <dt>GET querystring with strings and objects</dt>
+        <dd><pre><code>request
+.get(uri + '/querystring')
+.query('search=Manny')
+.query({ order: 'desc', range: '1..5' })
+.end(function(err, res){
+  try {
+  assert.deepEqual(res.body, { search: 'Manny', range: '1..5', order: 'desc' });
+  next();
+  } catch(e) { next(e); }
+});</code></pre></dd>
+        <dt>request(method, url)</dt>
+        <dd><pre><code>request('GET', uri + '/foo').end(function(err, res){
+  try {
+  assert.equal('bar', res.body.foo);
+  next();
+  } catch(e) { next(e); }
+});</code></pre></dd>
+        <dt>request(url)</dt>
+        <dd><pre><code>request(uri + '/foo').end(function(err, res){
+  try {
+  assert.equal('bar', res.body.foo);
+  next();
+  } catch(e) { next(e); }
+});</code></pre></dd>
+        <dt>request(url, fn)</dt>
+        <dd><pre><code>request(uri + '/foo', function(err, res){
+  try {
+  assert.equal('bar', res.body.foo);
+  next();
+  } catch(e) { next(e); }
+});</code></pre></dd>
+        <dt>req.timeout(ms)</dt>
+        <dd><pre><code>var req = request
+.get(uri + '/delay/3000')
+.timeout(1000)
+.end(function(err, res){
+  try {
+  assert(err, 'error missing');
+  assert.equal(1000, err.timeout, 'err.timeout missing');
+  assert.equal('Timeout of 1000ms exceeded', err.message, 'err.message incorrect');
+  assert.equal(null, res);
+  assert(req.timedout, true);
+  next();
+} catch(e) { next(e); }
+})</code></pre></dd>
+        <dt>req.timeout(ms) with redirect</dt>
+        <dd><pre><code>var req = request
+.get(uri + '/delay/const')
+.timeout(1000)
+.end(function(err, res) {
+  try {
+  assert(err, 'error missing');
+  assert.equal(1000, err.timeout, 'err.timeout missing');
+  assert.equal('Timeout of 1000ms exceeded', err.message, 'err.message incorrect');
+  assert.equal(null, res);
+  assert(req.timedout, true);
+  next();
+  } catch(e) { next(e); }
+});</code></pre></dd>
+        <dt>request event</dt>
+        <dd><pre><code>request
+.get(uri + '/foo')
+.on('request', function(req){
+  try {
+  assert.equal(uri + '/foo', req.url);
+  next();
+  } catch(e) { next(e); }
+})
+.end();</code></pre></dd>
+        <dt>response event</dt>
+        <dd><pre><code>request
+.get(uri + '/foo')
+.on('response', function(res){
+  try {
+  assert.equal('bar', res.body.foo);
+  next();
+  } catch(e) { next(e); }
+})
+.end();</code></pre></dd>
+        <dt>response should set statusCode</dt>
+        <dd><pre><code>request
+  .get(uri + '/ok', function(err, res){
+    try {
+    assert.strictEqual(res.statusCode, 200);
+    next();
+    } catch(e) { next(e); }
+  })</code></pre></dd>
+        <dt>req.toJSON()</dt>
+        <dd><pre><code>request
+.get(uri + '/ok')
+.end(function(err, res){
+  try {
+  var j = (res.request || res.req).toJSON();
+  ['url', 'method', 'data', 'headers'].forEach(function(prop){
+    assert(j.hasOwnProperty(prop));
+  });
+  next();
+  } catch(e) { next(e); }
+});</code></pre></dd>
+      </dl>
+    </section>
+    <section class="suite">
+      <h1>.retry(count)</h1>
+      <dl>
+        <dt>should not retry if passed &quot;0&quot;</dt>
+        <dd><pre><code>request
+.get(base + '/error')
+.retry(0)
+.end(function(err, res){
+  try {
+  assert(err, 'expected an error');
+  assert.equal(undefined, err.retries, 'expected an error without .retries');
+  assert.equal(500, err.status, 'expected an error status of 500');
+  done();
+  } catch(err) {
+    done(err);
+  }
+});</code></pre></dd>
+        <dt>should not retry if passed an invalid number</dt>
+        <dd><pre><code>request
+.get(base + '/error')
+.retry(-2)
+.end(function(err, res){
+  try {
+  assert(err, 'expected an error');
+  assert.equal(undefined, err.retries, 'expected an error without .retries');
+  assert.equal(500, err.status, 'expected an error status of 500');
+  done();
+  } catch(err) {
+    done(err);
+  }
+});</code></pre></dd>
+        <dt>should not retry if passed undefined</dt>
+        <dd><pre><code>request
+.get(base + '/error')
+.retry(undefined)
+.end(function(err, res){
+  try {
+  assert(err, 'expected an error');
+  assert.equal(undefined, err.retries, 'expected an error without .retries');
+  assert.equal(500, err.status, 'expected an error status of 500');
+  done();
+  } catch(err) {
+    done(err);
+  }
+});</code></pre></dd>
+        <dt>should handle server error after repeat attempt</dt>
+        <dd><pre><code>request
+.get(base + '/error')
+.retry(2)
+.end(function(err, res){
+  try {
+  assert(err, 'expected an error');
+  assert.equal(2, err.retries, 'expected an error with .retries');
+  assert.equal(500, err.status, 'expected an error status of 500');
+  done();
+  } catch(err) {
+    done(err);
+  }
+});</code></pre></dd>
+        <dt>should retry if passed nothing</dt>
+        <dd><pre><code>request
+.get(base + '/error')
+.retry()
+.end(function(err, res){
+  try {
+  assert(err, 'expected an error');
+  assert.equal(1, err.retries, 'expected an error with .retries');
+  assert.equal(500, err.status, 'expected an error status of 500');
+  done();
+  } catch(err) {
+    done(err);
+  }
+});</code></pre></dd>
+        <dt>should retry if passed &quot;true&quot;</dt>
+        <dd><pre><code>request
+.get(base + '/error')
+.retry(true)
+.end(function(err, res){
+  try {
+  assert(err, 'expected an error');
+  assert.equal(1, err.retries, 'expected an error with .retries');
+  assert.equal(500, err.status, 'expected an error status of 500');
+  done();
+  } catch(err) {
+    done(err);
+  }
+});</code></pre></dd>
+        <dt>should handle successful request after repeat attempt from server error</dt>
+        <dd><pre><code>request
+.get(base + '/error/ok/' + uniqid())
+.query({qs:'present'})
+.retry(2)
+.end(function(err, res){
+  try {
+  assert.ifError(err);
+  assert(res.ok, 'response should be ok');
+  assert(res.text, 'res.text');
+  done();
+  } catch(err) {
+    done(err);
+  }
+});</code></pre></dd>
+        <dt>should handle server timeout error after repeat attempt</dt>
+        <dd><pre><code>request
+.get(base + '/delay/400')
+.timeout(200)
+.retry(2)
+.end(function(err, res){
+  try {
+  assert(err, 'expected an error');
+  assert.equal(2, err.retries, 'expected an error with .retries');
+  assert.equal('number', typeof err.timeout, 'expected an error with .timeout');
+  assert.equal('ECONNABORTED', err.code, 'expected abort error code')
+  done();
+  } catch(err) {
+    done(err);
+  }
+});</code></pre></dd>
+        <dt>should handle successful request after repeat attempt from server timeout</dt>
+        <dd><pre><code>var url = '/delay/400/ok/' + uniqid() + '?built=in';
+request
+.get(base + url)
+.query(&quot;string=ified&quot;)
+.query({&quot;json&quot;:&quot;ed&quot;})
+.timeout(200)
+.retry(2)
+.end(function(err, res){
+  try {
+  assert.ifError(err);
+  assert(res.ok, 'response should be ok');
+  assert.equal(res.text, 'ok = ' + url + '&amp;string=ified&amp;json=ed');
+  done();
+  } catch(err) {
+    done(err);
+  }
+});</code></pre></dd>
+        <dt>should correctly abort a retry attempt</dt>
+        <dd><pre><code>var aborted = false;
+var req = request
+.get(base + '/delay/400')
+.timeout(200)
+.retry(2)
+.end(function(err, res){
+  try {
+    assert(false, 'should not complete the request');
+  } catch(e) { done(e); }
+});
+req.on('abort', function() {
+  aborted = true;
+});
+setTimeout(function() {
+  req.abort();
+  setTimeout(function() {
+    try {
+    assert(aborted, 'should be aborted');
+    done();
+    } catch(err) {
+      done(err);
+    }
+  }, 150)
+}, 150);</code></pre></dd>
+        <dt>should correctly retain header fields</dt>
+        <dd><pre><code>request
+.get(base + '/error/ok/' + uniqid())
+.query({qs:'present'})
+.retry(2)
+.set('X-Foo', 'bar')
+.end(function(err, res){
+  try {
+    assert.ifError(err);
+    assert(res.body);
+    res.body.should.have.property('x-foo', 'bar');
+    done();
+  } catch(err) {
+    done(err);
+  }
+});</code></pre></dd>
+        <dt>should not retry on 4xx responses</dt>
+        <dd><pre><code>request
+.get(base + '/bad-request')
+.retry(2)
+.end(function(err, res){
+  try {
+  assert(err, 'expected an error');
+  assert.equal(0, err.retries, 'expected an error with 0 .retries');
+  assert.equal(400, err.status, 'expected an error status of 400');
+  done();
+  } catch(err) {
+    done(err);
+  }
+});</code></pre></dd>
+      </dl>
+    </section>
+    <section class="suite">
+      <h1>.timeout(ms)</h1>
+      <dl>
+        <section class="suite">
+          <h1>when timeout is exceeded</h1>
+          <dl>
+            <dt>should error</dt>
+            <dd><pre><code>request
+.get(base + '/delay/500')
+.timeout(150)
+.end(function(err, res){
+  assert(err, 'expected an error');
+  assert.equal('number', typeof err.timeout, 'expected an error with .timeout');
+  assert.equal('ECONNABORTED', err.code, 'expected abort error code')
+  done();
+});</code></pre></dd>
+            <dt>should handle gzip timeout</dt>
+            <dd><pre><code>request
+.get(base + '/delay/zip')
+.timeout(150)
+.end(function(err, res){
+  assert(err, 'expected an error');
+  assert.equal('number', typeof err.timeout, 'expected an error with .timeout');
+  assert.equal('ECONNABORTED', err.code, 'expected abort error code')
+  done();
+});</code></pre></dd>
+            <dt>should handle buffer timeout</dt>
+            <dd><pre><code>request
+.get(base + '/delay/json')
+.buffer(true)
+.timeout(150)
+.end(function(err, res){
+  assert(err, 'expected an error');
+  assert.equal('number', typeof err.timeout, 'expected an error with .timeout');
+  assert.equal('ECONNABORTED', err.code, 'expected abort error code')
+  done();
+});</code></pre></dd>
+            <dt>should error on deadline</dt>
+            <dd><pre><code>request
+.get(base + '/delay/500')
+.timeout({deadline: 150})
+.end(function(err, res){
+  assert(err, 'expected an error');
+  assert.equal('number', typeof err.timeout, 'expected an error with .timeout');
+  assert.equal('ECONNABORTED', err.code, 'expected abort error code')
+  done();
+});</code></pre></dd>
+            <dt>should support setting individual options</dt>
+            <dd><pre><code>request
+.get(base + '/delay/500')
+.timeout({deadline: 10})
+.timeout({response: 99999})
+.end(function(err, res){
+  assert(err, 'expected an error');
+  assert.equal('ECONNABORTED', err.code, 'expected abort error code')
+  assert.equal('ETIME', err.errno);
+  done();
+});</code></pre></dd>
+            <dt>should error on response</dt>
+            <dd><pre><code>request
+.get(base + '/delay/500')
+.timeout({response: 150})
+.end(function(err, res){
+  assert(err, 'expected an error');
+  assert.equal('number', typeof err.timeout, 'expected an error with .timeout');
+  assert.equal('ECONNABORTED', err.code, 'expected abort error code')
+  assert.equal('ETIMEDOUT', err.errno);
+  done();
+});</code></pre></dd>
+            <dt>should accept slow body with fast response</dt>
+            <dd><pre><code>request
+  .get(base + '/delay/slowbody')
+  .timeout({response: 1000})
+  .on('progress', function(){
+    // This only makes the test faster without relying on arbitrary timeouts
+    request.get(base + '/delay/slowbody/finish').end();
+  })
+  .end(done);</code></pre></dd>
+          </dl>
+        </section>
+      </dl>
+    </section>
+    <section class="suite">
+      <h1>request</h1>
+      <dl>
+        <section class="suite">
+          <h1>use</h1>
+          <dl>
+            <dt>should use plugin success</dt>
+            <dd><pre><code>var now = '' + Date.now();
+function uuid(req){
+  req.set('X-UUID', now);
+  return req;
+}
+function prefix(req){
+  req.url = uri + req.url
+  return req;
+}
+request
+  .get('/echo')
+  .use(uuid)
+  .use(prefix)
+  .end(function(err, res){
+    assert.strictEqual(res.statusCode, 200);
+    assert.equal(res.get('X-UUID'), now);
+    done();
+  })</code></pre></dd>
+          </dl>
+        </section>
+      </dl>
+    </section>
+    <section class="suite">
+      <h1>subclass</h1>
+      <dl>
+        <dt>should be an instance of Request</dt>
+        <dd><pre><code>var req = request.get('/');
+assert(req instanceof request.Request);</code></pre></dd>
+        <dt>should use patched subclass</dt>
+        <dd><pre><code>assert(OriginalRequest);
+var constructorCalled, sendCalled;
+function NewRequest() {
+  constructorCalled = true;
+  OriginalRequest.apply(this, arguments);
+}
+NewRequest.prototype = Object.create(OriginalRequest.prototype);
+NewRequest.prototype.send = function() {
+  sendCalled = true;
+  return this;
+};
+request.Request = NewRequest;
+var req = request.get('/').send();
+assert(constructorCalled);
+assert(sendCalled);
+assert(req instanceof NewRequest);
+assert(req instanceof OriginalRequest);</code></pre></dd>
+        <dt>should use patched subclass in agent too</dt>
+        <dd><pre><code>if (!request.agent) return; // Node-only
+function NewRequest() {
+  OriginalRequest.apply(this, arguments);
+}
+NewRequest.prototype = Object.create(OriginalRequest.prototype);
+request.Request = NewRequest;
+var req = request.agent().del('/');
+assert(req instanceof NewRequest);
+assert(req instanceof OriginalRequest);</code></pre></dd>
       </dl>
     </section>
     <section class="suite">
@@ -332,18 +2015,16 @@ setTimeout(function() {
           <h1>persistent agent</h1>
           <dl>
             <dt>should gain a session on POST</dt>
-            <dd><pre><code>agent3
-  .post('http://localhost:4000/signin')
-  .end(function(err, res) {
-    should.not.exist(err);
+            <dd><pre><code>return agent3
+  .post(base + '/signin')
+  .then(function(res) {
     res.should.have.status(200);
     should.not.exist(res.headers['set-cookie']);
     res.text.should.containEql('dashboard');
-    done();
   });</code></pre></dd>
             <dt>should start with empty session (set cookies)</dt>
             <dd><pre><code>agent1
-  .get('http://localhost:4000/dashboard')
+  .get(base + '/dashboard')
   .end(function(err, res) {
     should.exist(err);
     res.should.have.status(401);
@@ -351,75 +2032,62 @@ setTimeout(function() {
     done();
   });</code></pre></dd>
             <dt>should gain a session (cookies already set)</dt>
-            <dd><pre><code>agent1
-  .post('http://localhost:4000/signin')
-  .end(function(err, res) {
-    should.not.exist(err);
+            <dd><pre><code>return agent1
+  .post(base + '/signin')
+  .then(function(res) {
     res.should.have.status(200);
     should.not.exist(res.headers['set-cookie']);
     res.text.should.containEql('dashboard');
-    done();
   });</code></pre></dd>
             <dt>should persist cookies across requests</dt>
-            <dd><pre><code>agent1
-  .get('http://localhost:4000/dashboard')
-  .end(function(err, res) {
-    should.not.exist(err);
+            <dd><pre><code>return agent1
+  .get(base + '/dashboard')
+  .then(function(res) {
     res.should.have.status(200);
-    done();
   });</code></pre></dd>
             <dt>should have the cookie set in the end callback</dt>
-            <dd><pre><code>agent4
-  .post('http://localhost:4000/setcookie')
-  .end(function(err, res) {
-    agent4
-      .get('http://localhost:4000/getcookie')
-      .end(function(err, res) {
-        should.not.exist(err);
-        res.should.have.status(200);
-        assert.strictEqual(res.text, 'jar');
-        done();
-      });
+            <dd><pre><code>return agent4
+  .post(base + '/setcookie')
+  .then(function() {
+    return agent4.get(base + '/getcookie')
+  })
+  .then(function(res) {
+    res.should.have.status(200);
+    assert.strictEqual(res.text, 'jar');
   });</code></pre></dd>
             <dt>should not share cookies</dt>
             <dd><pre><code>agent2
-  .get('http://localhost:4000/dashboard')
+  .get(base + '/dashboard')
   .end(function(err, res) {
     should.exist(err);
     res.should.have.status(401);
     done();
   });</code></pre></dd>
             <dt>should not lose cookies between agents</dt>
-            <dd><pre><code>agent1
-  .get('http://localhost:4000/dashboard')
-  .end(function(err, res) {
-    should.not.exist(err);
+            <dd><pre><code>return agent1
+  .get(base + '/dashboard')
+  .then(function(res) {
     res.should.have.status(200);
-    done();
   });</code></pre></dd>
             <dt>should be able to follow redirects</dt>
-            <dd><pre><code>agent1
-  .get('http://localhost:4000/')
-  .end(function(err, res) {
-    should.not.exist(err);
+            <dd><pre><code>return agent1
+  .get(base)
+  .then(function(res) {
     res.should.have.status(200);
     res.text.should.containEql('dashboard');
-    done();
   });</code></pre></dd>
             <dt>should be able to post redirects</dt>
-            <dd><pre><code>agent1
-  .post('http://localhost:4000/redirect')
+            <dd><pre><code>return agent1
+  .post(base + '/redirect')
   .send({ foo: 'bar', baz: 'blaaah' })
-  .end(function(err, res) {
-    should.not.exist(err);
+  .then(function(res) {
     res.should.have.status(200);
     res.text.should.containEql('simple');
-    res.redirects.should.eql(['http://localhost:4000/simple']);
-    done();
+    res.redirects.should.eql([base + '/simple']);
   });</code></pre></dd>
             <dt>should be able to limit redirects</dt>
             <dd><pre><code>agent1
-  .get('http://localhost:4000/')
+  .get(base)
   .redirects(0)
   .end(function(err, res) {
     should.exist(err);
@@ -429,17 +2097,15 @@ setTimeout(function() {
     done();
   });</code></pre></dd>
             <dt>should be able to create a new session (clear cookie)</dt>
-            <dd><pre><code>agent1
-  .post('http://localhost:4000/signout')
-  .end(function(err, res) {
-    should.not.exist(err);
+            <dd><pre><code>return agent1
+  .post(base + '/signout')
+  .then(function(res) {
     res.should.have.status(200);
     should.exist(res.headers['set-cookie']);
-    done();
   });</code></pre></dd>
             <dt>should regenerate with an empty session</dt>
             <dd><pre><code>agent1
-  .get('http://localhost:4000/dashboard')
+  .get(base + '/dashboard')
   .end(function(err, res) {
     should.exist(err);
     res.should.have.status(401);
@@ -457,8 +2123,11 @@ setTimeout(function() {
           <h1>when credentials are present in url</h1>
           <dl>
             <dt>should set Authorization</dt>
-            <dd><pre><code>request
-.get('http://tobi:learnboost@localhost:3010')
+            <dd><pre><code>var new_url = URL.parse(base);
+new_url.auth = 'tobi:learnboost';
+new_url.pathname = '/basic-auth';
+request
+.get(URL.format(new_url))
 .end(function(err, res){
   res.status.should.equal(200);
   done();
@@ -470,7 +2139,7 @@ setTimeout(function() {
           <dl>
             <dt>should set Authorization</dt>
             <dd><pre><code>request
-.get('http://localhost:3010')
+.get(base + '/basic-auth')
 .auth('tobi', 'learnboost')
 .end(function(err, res){
   res.status.should.equal(200);
@@ -483,7 +2152,7 @@ setTimeout(function() {
           <dl>
             <dt>should set authorization</dt>
             <dd><pre><code>request
-.get('http://localhost:3010/again')
+.get(base + '/basic-auth/again')
 .auth('tobi')
 .end(function(err, res){
   res.status.should.eql(200);
@@ -496,13 +2165,25 @@ setTimeout(function() {
     <section class="suite">
       <h1>[node] request</h1>
       <dl>
+        <dt>should send body with .get().send()</dt>
+        <dd><pre><code>request
+.get(base + '/echo')
+.set('Content-Type', 'text/plain')
+.send('wahoo')
+.end(function(err, res){
+try {
+  assert.equal('wahoo', res.text);
+  next();
+  } catch(e) { next(e); }
+});</code></pre></dd>
         <section class="suite">
-          <h1>res.statusCode</h1>
+          <h1>with an url</h1>
           <dl>
-            <dt>should set statusCode</dt>
+            <dt>should preserve the encoding of the url</dt>
             <dd><pre><code>request
-.get('http://localhost:5000/login', function(err, res){
-  assert.strictEqual(res.statusCode, 200);
+.get(base + '/url?a=(b%29')
+.end(function(err, res){
+  assert.equal('/url?a=(b%29', res.text);
   done();
 })</code></pre></dd>
           </dl>
@@ -511,11 +2192,10 @@ setTimeout(function() {
           <h1>with an object</h1>
           <dl>
             <dt>should format the url</dt>
-            <dd><pre><code>request
-.get(url.parse('http://localhost:5000/login'))
-.end(function(err, res){
+            <dd><pre><code>return request
+.get(url.parse(base + '/login'))
+.then(function(res){
   assert(res.ok);
-  done();
 })</code></pre></dd>
           </dl>
         </section>
@@ -523,68 +2203,26 @@ setTimeout(function() {
           <h1>without a schema</h1>
           <dl>
             <dt>should default to http</dt>
-            <dd><pre><code>request
+            <dd><pre><code>return request
 .get('localhost:5000/login')
-.end(function(err, res){
+.then(function(res){
   assert.equal(res.status, 200);
-  done();
 })</code></pre></dd>
-          </dl>
-        </section>
-        <section class="suite">
-          <h1>req.toJSON()</h1>
-          <dl>
-            <dt>should describe the request</dt>
-            <dd><pre><code>request
-.post(':5000/echo')
-.send({ foo: 'baz' })
-.end(function(err, res){
-  var obj = res.request.toJSON();
-  assert.equal('POST', obj.method);
-  assert.equal(':5000/echo', obj.url);
-  assert.equal('baz', obj.data.foo);
-  done();
-});</code></pre></dd>
-          </dl>
-        </section>
-        <section class="suite">
-          <h1>should allow the send shorthand</h1>
-          <dl>
-            <dt>with callback in the method call</dt>
-            <dd><pre><code>request
-.get('http://localhost:5000/login', function(err, res) {
-    assert.equal(res.status, 200);
-    done();
-});</code></pre></dd>
-            <dt>with data in the method call</dt>
-            <dd><pre><code>request
-.post('http://localhost:5000/echo', { foo: 'bar' })
-.end(function(err, res) {
-  assert.equal('{&quot;foo&quot;:&quot;bar&quot;}', res.text);
-  done();
-});</code></pre></dd>
-            <dt>with callback and data in the method call</dt>
-            <dd><pre><code>request
-.post('http://localhost:5000/echo', { foo: 'bar' }, function(err, res) {
-  assert.equal('{&quot;foo&quot;:&quot;bar&quot;}', res.text);
-  done();
-});</code></pre></dd>
           </dl>
         </section>
         <section class="suite">
           <h1>res.toJSON()</h1>
           <dl>
             <dt>should describe the response</dt>
-            <dd><pre><code>request
-.post('http://localhost:5000/echo')
+            <dd><pre><code>return request
+.post(base + '/echo')
 .send({ foo: 'baz' })
-.end(function(err, res){
+.then(function(res){
   var obj = res.toJSON();
   assert.equal('object', typeof obj.header);
   assert.equal('object', typeof obj.req);
   assert.equal(200, obj.status);
   assert.equal('{&quot;foo&quot;:&quot;baz&quot;}', obj.text);
-  done();
 });</code></pre></dd>
           </dl>
         </section>
@@ -592,15 +2230,14 @@ setTimeout(function() {
           <h1>res.links</h1>
           <dl>
             <dt>should default to an empty object</dt>
-            <dd><pre><code>request
-.get('http://localhost:5000/login')
-.end(function(err, res){
+            <dd><pre><code>return request
+.get(base + '/login')
+.then(function(res){
   res.links.should.eql({});
-  done();
 })</code></pre></dd>
             <dt>should parse the Link header field</dt>
             <dd><pre><code>request
-.get('http://localhost:5000/links')
+.get(base + '/links')
 .end(function(err, res){
   res.links.next.should.equal('https://api.github.com/repos/visionmedia/mocha/issues?page=2');
   done();
@@ -612,7 +2249,7 @@ setTimeout(function() {
           <dl>
             <dt>should remove the header field</dt>
             <dd><pre><code>request
-.post('http://localhost:5000/echo')
+.post(base + '/echo')
 .unset('User-Agent')
 .end(function(err, res){
   assert.equal(void 0, res.header['user-agent']);
@@ -621,13 +2258,27 @@ setTimeout(function() {
           </dl>
         </section>
         <section class="suite">
+          <h1>case-insensitive</h1>
+          <dl>
+            <dt>should set/get header fields case-insensitively</dt>
+            <dd><pre><code>var r = request.post(base + '/echo');
+r.set('MiXeD', 'helloes');
+assert.strictEqual(r.get('mixed'), 'helloes');</code></pre></dd>
+            <dt>should unset header fields case-insensitively</dt>
+            <dd><pre><code>var r = request.post(base + '/echo');
+r.set('MiXeD', 'helloes');
+r.unset('MIXED');
+assert.strictEqual(r.get('mixed'), undefined);</code></pre></dd>
+          </dl>
+        </section>
+        <section class="suite">
           <h1>req.write(str)</h1>
           <dl>
             <dt>should write the given data</dt>
-            <dd><pre><code>var req = request.post('http://localhost:5000/echo');
+            <dd><pre><code>var req = request.post(base + '/echo');
 req.set('Content-Type', 'application/json');
-req.write('{&quot;name&quot;').should.be.a.boolean;
-req.write(':&quot;tobi&quot;}').should.be.a.boolean;
+assert.equal('boolean', typeof req.write('{&quot;name&quot;'));
+assert.equal('boolean', typeof req.write(':&quot;tobi&quot;}'));
 req.end(function(err, res){
   res.text.should.equal('{&quot;name&quot;:&quot;tobi&quot;}');
   done();
@@ -649,7 +2300,7 @@ stream.end = function(){
   done();
 };
 request
-.post('http://localhost:5000/echo')
+.post(base + '/echo')
 .send('{&quot;name&quot;:&quot;tobi&quot;}')
 .pipe(stream);</code></pre></dd>
           </dl>
@@ -659,7 +2310,7 @@ request
           <dl>
             <dt>should enable buffering</dt>
             <dd><pre><code>request
-.get('http://localhost:5000/custom')
+.get(base + '/custom')
 .buffer()
 .end(function(err, res){
   assert.equal(null, err);
@@ -674,7 +2325,7 @@ request
           <dl>
             <dt>should disable buffering</dt>
             <dd><pre><code>request
-.post('http://localhost:5000/echo')
+.post(base + '/echo')
 .type('application/x-dog')
 .send('hello this is dog')
 .buffer(false)
@@ -693,10 +2344,23 @@ request
           </dl>
         </section>
         <section class="suite">
+          <h1>.withCredentials()</h1>
+          <dl>
+            <dt>should not throw an error when using the client-side &quot;withCredentials&quot; method</dt>
+            <dd><pre><code>request
+.get(base + '/custom')
+.withCredentials()
+.end(function(err, res){
+  assert.equal(null, err);
+  done();
+});</code></pre></dd>
+          </dl>
+        </section>
+        <section class="suite">
           <h1>.agent()</h1>
           <dl>
             <dt>should return the defaut agent</dt>
-            <dd><pre><code>var req = request.post('http://localhost:5000/echo');
+            <dd><pre><code>var req = request.post(base + '/echo');
 req.agent().should.equal(false);
 done();</code></pre></dd>
           </dl>
@@ -705,7 +2369,7 @@ done();</code></pre></dd>
           <h1>.agent(undefined)</h1>
           <dl>
             <dt>should set an agent to undefined and ensure it is chainable</dt>
-            <dd><pre><code>var req = request.get('http://localhost:5000/echo');
+            <dd><pre><code>var req = request.get(base + '/echo');
 var ret = req.agent(undefined);
 ret.should.equal(req);
 assert.strictEqual(req.agent(), undefined);
@@ -717,7 +2381,7 @@ done();</code></pre></dd>
           <dl>
             <dt>should set passed agent</dt>
             <dd><pre><code>var http = require('http');
-var req = request.get('http://localhost:5000/echo');
+var req = request.get(base + '/echo');
 var agent = new http.Agent();
 var ret = req.agent(agent);
 ret.should.equal(req);
@@ -730,7 +2394,7 @@ done();</code></pre></dd>
           <dl>
             <dt>should disable buffering</dt>
             <dd><pre><code>request
-.post('http://localhost:5000/echo')
+.post(base + '/echo')
 .type('application/x-dog')
 .send('hello this is dog')
 .end(function(err, res){
@@ -756,7 +2420,7 @@ done();</code></pre></dd>
 var img = fs.readFileSync(__dirname + '/fixtures/test.png');
 img = decoder.write(img);
 request
-.post('http://localhost:5000/echo')
+.post(base + '/echo')
 .type('application/x-image')
 .send(img)
 .buffer(false)
@@ -769,7 +2433,7 @@ request
             <dt>should be set to the length of a buffer object</dt>
             <dd><pre><code>var img = fs.readFileSync(__dirname + '/fixtures/test.png');
 request
-.post('http://localhost:5000/echo')
+.post(base + '/echo')
 .type('application/x-image')
 .send(img)
 .buffer(true)
@@ -784,33 +2448,8 @@ request
       </dl>
     </section>
     <section class="suite">
-      <h1>req.set(&quot;Content-Type&quot;, contentType)</h1>
-      <dl>
-        <dt>should work with just the contentType component</dt>
-        <dd><pre><code>request
-.post('http://localhost:3005/echo')
-.set('Content-Type', 'application/json')
-.send({ name: 'tobi' })
-.end(function(err, res){
-  assert(!err);
-  done();
-});</code></pre></dd>
-        <dt>should work with the charset component</dt>
-        <dd><pre><code>request
-.post('http://localhost:3005/echo')
-.set('Content-Type', 'application/json; charset=utf-8')
-.send({ name: 'tobi' })
-.end(function(err, res){
-  assert(!err);
-  done();
-});</code></pre></dd>
-      </dl>
-    </section>
-    <section class="suite">
       <h1>exports</h1>
       <dl>
-        <dt>should expose Part</dt>
-        <dd><pre><code>request.Part.should.be.a.function;</code></pre></dd>
         <dt>should expose .protocols</dt>
         <dd><pre><code>Object.keys(request.protocols)
   .should.eql(['http:', 'https:']);</code></pre></dd>
@@ -819,7 +2458,7 @@ request
   .should.eql(['application/x-www-form-urlencoded', 'application/json']);</code></pre></dd>
         <dt>should expose .parse</dt>
         <dd><pre><code>Object.keys(request.parse)
-  .should.eql(['application/x-www-form-urlencoded', 'application/json', 'text', 'image']);</code></pre></dd>
+  .should.eql(['application/x-www-form-urlencoded', 'application/json', 'text', 'application/octet-stream', 'image']);</code></pre></dd>
       </dl>
     </section>
     <section class="suite">
@@ -830,7 +2469,7 @@ request
           <dl>
             <dt>should set res.error and res.clientError</dt>
             <dd><pre><code>request
-.get('http://localhost:3004/notfound')
+.get(base + '/notfound')
 .end(function(err, res){
   assert(err);
   assert(!res.ok, 'response should not be ok');
@@ -846,7 +2485,7 @@ request
           <dl>
             <dt>should set res.error and res.serverError</dt>
             <dd><pre><code>request
-.get('http://localhost:3004/error')
+.get(base + '/error')
 .end(function(err, res){
   assert(err);
   assert(!res.ok, 'response should not be ok');
@@ -863,7 +2502,7 @@ request
           <dl>
             <dt>should res.notFound</dt>
             <dd><pre><code>request
-.get('http://localhost:3004/notfound')
+.get(base + '/notfound')
 .end(function(err, res){
   assert(err);
   assert(res.notFound, 'response should be .notFound');
@@ -876,7 +2515,7 @@ request
           <dl>
             <dt>should set req.badRequest</dt>
             <dd><pre><code>request
-.get('http://localhost:3004/bad-request')
+.get(base + '/bad-request')
 .end(function(err, res){
   assert(err);
   assert(res.badRequest, 'response should be .badRequest');
@@ -889,7 +2528,7 @@ request
           <dl>
             <dt>should set res.unauthorized</dt>
             <dd><pre><code>request
-.get('http://localhost:3004/unauthorized')
+.get(base + '/unauthorized')
 .end(function(err, res){
   assert(err);
   assert(res.unauthorized, 'response should be .unauthorized');
@@ -902,7 +2541,7 @@ request
           <dl>
             <dt>should set res.notAcceptable</dt>
             <dd><pre><code>request
-.get('http://localhost:3004/not-acceptable')
+.get(base + '/not-acceptable')
 .end(function(err, res){
   assert(err);
   assert(res.notAcceptable, 'response should be .notAcceptable');
@@ -915,7 +2554,7 @@ request
           <dl>
             <dt>should set res.noContent</dt>
             <dd><pre><code>request
-.get('http://localhost:3004/no-content')
+.get(base + '/no-content')
 .end(function(err, res){
   assert(!err);
   assert(res.noContent, 'response should be .noContent');
@@ -926,39 +2565,15 @@ request
       </dl>
     </section>
     <section class="suite">
-      <h1>req.send(Object) as &quot;form&quot;</h1>
+      <h1>Merging objects</h1>
       <dl>
-        <section class="suite">
-          <h1>with req.type() set to form</h1>
-          <dl>
-            <dt>should send x-www-form-urlencoded data</dt>
-            <dd><pre><code>request
-.post('http://localhost:3002/echo')
-.type('form')
-.send({ name: 'tobi' })
-.end(function(err, res){
-  res.header['content-type'].should.equal('application/x-www-form-urlencoded');
-  res.text.should.equal('name=tobi');
-  done();
+        <dt>Don't mix Buffer and JSON</dt>
+        <dd><pre><code>assert.throws(function(){
+  request
+    .post('/echo')
+    .send(new Buffer(&quot;Change this to Buffer.from in April 2017&quot;))
+    .send({allowed:false})
 });</code></pre></dd>
-          </dl>
-        </section>
-        <section class="suite">
-          <h1>when called several times</h1>
-          <dl>
-            <dt>should merge the objects</dt>
-            <dd><pre><code>request
-.post('http://localhost:3002/echo')
-.type('form')
-.send({ name: { first: 'tobi', last: 'holowaychuk' } })
-.send({ age: '1' })
-.end(function(err, res){
-  res.header['content-type'].should.equal('application/x-www-form-urlencoded');
-  res.text.should.equal('name%5Bfirst%5D=tobi&amp;name%5Blast%5D=holowaychuk&amp;age=1');
-  done();
-});</code></pre></dd>
-          </dl>
-        </section>
       </dl>
     </section>
     <section class="suite">
@@ -966,7 +2581,7 @@ request
       <dl>
         <dt>should default to &quot;form&quot;</dt>
         <dd><pre><code>request
-.post('http://localhost:3002/echo')
+.post(base + '/echo')
 .send('user[name]=tj')
 .send('user[email]=tj@vision-media.ca')
 .end(function(err, res){
@@ -984,7 +2599,7 @@ request
           <dl>
             <dt>should parse the body</dt>
             <dd><pre><code>request
-.get('http://localhost:3002/form-data')
+.get(base + '/form-data')
 .end(function(err, res){
   res.text.should.equal('pet[name]=manny');
   res.body.should.eql({ pet: { name: 'manny' }});
@@ -998,37 +2613,107 @@ request
       <h1>https</h1>
       <dl>
         <section class="suite">
-          <h1>request</h1>
+          <h1>certificate authority</h1>
           <dl>
-            <dt>should give a good response</dt>
-            <dd><pre><code>request
-.get('https://localhost:8443/')
-.ca(cert)
+            <section class="suite">
+              <h1>request</h1>
+              <dl>
+                <dt>should give a good response</dt>
+                <dd><pre><code>request
+.get(testEndpoint)
+.ca(ca)
 .end(function(err, res){
   assert(res.ok);
   assert.strictEqual('Safe and secure!', res.text);
   done();
-});</code></pre></dd>
-          </dl>
-        </section>
-        <section class="suite">
-          <h1>.agent</h1>
-          <dl>
-            <dt>should be able to make multiple requests without redefining the certificate</dt>
-            <dd><pre><code>var agent = request.agent({ca: cert});
+})</code></pre></dd>
+              </dl>
+            </section>
+            <section class="suite">
+              <h1>.agent</h1>
+              <dl>
+                <dt>should be able to make multiple requests without redefining the certificate</dt>
+                <dd><pre><code>var agent = request.agent({ca: ca});
 agent
-.get('https://localhost:8443/')
+.get(testEndpoint)
 .end(function(err, res){
   assert(res.ok);
   assert.strictEqual('Safe and secure!', res.text);
   agent
-  .get(url.parse('https://localhost:8443/'))
+  .get(url.parse(testEndpoint))
   .end(function(err, res){
     assert(res.ok);
     assert.strictEqual('Safe and secure!', res.text);
     done();
-  });
-});</code></pre></dd>
+  })
+})</code></pre></dd>
+              </dl>
+            </section>
+          </dl>
+        </section>
+        <section class="suite">
+          <h1>client certificates</h1>
+          <dl>
+            <section class="suite">
+              <h1>request</h1>
+              <dl>
+                <dt>should give a good response with client certificates and CA</dt>
+                <dd><pre><code>request
+.get(testEndpoint)
+.ca(ca)
+.key(key)
+.cert(cert)
+.end(function(err, res){
+  assert(res.ok);
+  assert.strictEqual('Safe and secure!', res.text);
+  done();
+})</code></pre></dd>
+                <dt>should give a good response with client pfx</dt>
+                <dd><pre><code>request
+.get(testEndpoint)
+.pfx(pfx)
+.end(function(err, res){
+  assert(res.ok);
+  assert.strictEqual('Safe and secure!', res.text);
+  done();
+})</code></pre></dd>
+              </dl>
+            </section>
+            <section class="suite">
+              <h1>.agent</h1>
+              <dl>
+                <dt>should be able to make multiple requests without redefining the certificates</dt>
+                <dd><pre><code>var agent = request.agent({ca: ca, key: key, cert: cert});
+agent
+.get(testEndpoint)
+.end(function(err, res){
+  assert(res.ok);
+  assert.strictEqual('Safe and secure!', res.text);
+  agent
+  .get(url.parse(testEndpoint))
+  .end(function(err, res){
+    assert(res.ok);
+    assert.strictEqual('Safe and secure!', res.text);
+    done();
+  })
+})</code></pre></dd>
+                <dt>should be able to make multiple requests without redefining pfx</dt>
+                <dd><pre><code>var agent = request.agent({pfx: pfx});
+agent
+.get(testEndpoint)
+.end(function(err, res){
+  assert(res.ok);
+  assert.strictEqual('Safe and secure!', res.text);
+  agent
+  .get(url.parse(testEndpoint))
+  .end(function(err, res){
+    assert(res.ok);
+    assert.strictEqual('Safe and secure!', res.text);
+    done();
+  })
+})</code></pre></dd>
+              </dl>
+            </section>
           </dl>
         </section>
       </dl>
@@ -1041,11 +2726,43 @@ agent
           <dl>
             <dt>should parse the body</dt>
             <dd><pre><code>request
-.get('http://localhost:3011/image')
+.get(base + '/image')
 .end(function(err, res){
+  res.type.should.equal('image/png');
+  Buffer.isBuffer(res.body).should.be.true();
   (res.body.length - img.length).should.equal(0);
   done();
 });</code></pre></dd>
+          </dl>
+        </section>
+        <section class="suite">
+          <h1>application/octet-stream</h1>
+          <dl>
+            <dt>should parse the body</dt>
+            <dd><pre><code>request
+.get(base + '/image-as-octets')
+.buffer(true) // that's tech debt :(
+.end(function(err, res){
+  res.type.should.equal('application/octet-stream');
+  Buffer.isBuffer(res.body).should.be.true();
+  (res.body.length - img.length).should.equal(0);
+  done();
+});</code></pre></dd>
+          </dl>
+        </section>
+        <section class="suite">
+          <h1>application/octet-stream</h1>
+          <dl>
+            <dt>should parse the body (using responseType)</dt>
+            <dd><pre><code>request
+    .get(base + '/image-as-octets')
+    .responseType('blob')
+    .end(function(err, res){
+        res.type.should.equal('application/octet-stream');
+        Buffer.isBuffer(res.body).should.be.true();
+        (res.body.length - img.length).should.equal(0);
+        done();
+    });</code></pre></dd>
           </dl>
         </section>
       </dl>
@@ -1055,19 +2772,47 @@ agent
       <dl>
         <dt>should deflate the content</dt>
         <dd><pre><code>request
-  .get('http://localhost:3080')
-  .end(function(err, res){
+  .get(base)
+  .end(function(err, res) {
     res.should.have.status(200);
     res.text.should.equal(subject);
     res.headers['content-length'].should.be.below(subject.length);
     done();
   });</code></pre></dd>
+        <dt>should ignore trailing junk</dt>
+        <dd><pre><code>request
+  .get(base + '/junk')
+  .end(function(err, res) {
+    res.should.have.status(200);
+    res.text.should.equal(subject);
+    done();
+  });</code></pre></dd>
+        <dt>should ignore missing data</dt>
+        <dd><pre><code>request
+  .get(base + '/chopped')
+  .end(function(err, res) {
+    assert.equal(undefined, err);
+    res.should.have.status(200);
+    res.text.should.startWith(subject);
+    done();
+  });</code></pre></dd>
         <dt>should handle corrupted responses</dt>
         <dd><pre><code>request
-  .get('http://localhost:3080/corrupt')
-  .end(function(err, res){
+  .get(base + '/corrupt')
+  .end(function(err, res) {
     assert(err, 'missing error');
     assert(!res, 'response should not be defined');
+    done();
+  });</code></pre></dd>
+        <dt>should handle no content with gzip header</dt>
+        <dd><pre><code>request
+  .get(base + '/nocontent')
+  .end(function(err, res) {
+    assert.ifError(err);
+    assert(res);
+    res.should.have.status(204);
+    res.text.should.equal('');
+    res.headers.should.not.have.property('content-length');
     done();
   });</code></pre></dd>
         <section class="suite">
@@ -1075,11 +2820,11 @@ agent
           <dl>
             <dt>should emit buffers</dt>
             <dd><pre><code>request
-  .get('http://localhost:3080/binary')
-  .end(function(err, res){
+  .get(base + '/binary')
+  .end(function(err, res) {
     res.should.have.status(200);
     res.headers['content-length'].should.be.below(subject.length);
-    res.on('data', function(chunk){
+    res.on('data', function(chunk) {
       chunk.should.have.length(subject.length);
     });
     res.on('end', done);
@@ -1089,213 +2834,105 @@ agent
       </dl>
     </section>
     <section class="suite">
-      <h1>req.send(Object) as &quot;json&quot;</h1>
-      <dl>
-        <dt>should default to json</dt>
-        <dd><pre><code>request
-.post('http://localhost:3005/echo')
-.send({ name: 'tobi' })
-.end(function(err, res){
-  res.should.be.json
-  res.text.should.equal('{&quot;name&quot;:&quot;tobi&quot;}');
-  done();
-});</code></pre></dd>
-        <dt>should work with arrays</dt>
-        <dd><pre><code>request
-.post('http://localhost:3005/echo')
-.send([1,2,3])
-.end(function(err, res){
-  res.should.be.json
-  res.text.should.equal('[1,2,3]');
-  done();
-});</code></pre></dd>
-        <dt>should work with value null</dt>
-        <dd><pre><code>request
-.post('http://localhost:3005/echo')
-.type('json')
-.send('null')
-.end(function(err, res){
-  res.should.be.json
-  assert.strictEqual(res.body, null);
-  done();
-});</code></pre></dd>
-        <dt>should work with value false</dt>
-        <dd><pre><code>request
-.post('http://localhost:3005/echo')
-.type('json')
-.send('false')
-.end(function(err, res){
-  res.should.be.json
-  res.body.should.equal(false);
-  done();
-});</code></pre></dd>
-        <dt>should work with value 0</dt>
-        <dd><pre><code>request
-.post('http://localhost:3005/echo')
-.type('json')
-.send('0')
-.end(function(err, res){
-  res.should.be.json
-  res.body.should.equal(0);
-  done();
-});</code></pre></dd>
-        <dt>should work with empty string value</dt>
-        <dd><pre><code>request
-.post('http://localhost:3005/echo')
-.type('json')
-.send('&quot;&quot;')
-.end(function(err, res){
-  res.should.be.json
-  res.body.should.equal(&quot;&quot;);
-  done();
-});</code></pre></dd>
-        <dt>should work with GET</dt>
-        <dd><pre><code>request
-.get('http://localhost:3005/echo')
-.send({ tobi: 'ferret' })
-.end(function(err, res){
-  res.should.be.json
-  res.text.should.equal('{&quot;tobi&quot;:&quot;ferret&quot;}');
-  done();
-});</code></pre></dd>
-        <dt>should work with vendor MIME type</dt>
-        <dd><pre><code>request
-.post('http://localhost:3005/echo')
-.set('Content-Type', 'application/vnd.example+json')
-.send({ name: 'vendor' })
-.end(function(err, res){
-  res.text.should.equal('{&quot;name&quot;:&quot;vendor&quot;}');
-  done();
-});</code></pre></dd>
-        <section class="suite">
-          <h1>when called several times</h1>
-          <dl>
-            <dt>should merge the objects</dt>
-            <dd><pre><code>request
-.post('http://localhost:3005/echo')
-.send({ name: 'tobi' })
-.send({ age: 1 })
-.end(function(err, res){
-  res.should.be.json
-  res.text.should.equal('{&quot;name&quot;:&quot;tobi&quot;,&quot;age&quot;:1}');
-  done();
-});</code></pre></dd>
-          </dl>
-        </section>
-      </dl>
-    </section>
-    <section class="suite">
-      <h1>res.body</h1>
+      <h1>Reques</h1>
       <dl>
         <section class="suite">
-          <h1>application/json</h1>
+          <h1>#field(name, value)</h1>
           <dl>
-            <dt>should parse the body</dt>
-            <dd><pre><code>request
-.get('http://localhost:3005/json')
-.end(function(err, res){
-  res.text.should.equal('{&quot;name&quot;:&quot;manny&quot;}');
-  res.body.should.eql({ name: 'manny' });
-  done();
+            <dt>should set a multipart field value</dt>
+            <dd><pre><code>var req = request.post(base + '/echo');
+req.field('user[name]', 'tobi');
+req.field('user[age]', '2');
+req.field('user[species]', 'ferret');
+return req.then(function(res){
+  res.body['user[name]'].should.equal('tobi');
+  res.body['user[age]'].should.equal('2');
+  res.body['user[species]'].should.equal('ferret');
+});</code></pre></dd>
+            <dt>should work with file attachments</dt>
+            <dd><pre><code>var req = request.post(base + '/echo');
+req.field('name', 'Tobi');
+req.attach('document', 'test/node/fixtures/user.html');
+req.field('species', 'ferret');
+return req.then(function(res){
+  res.body.name.should.equal('Tobi');
+  res.body.species.should.equal('ferret');
+  var html = res.files.document;
+  html.name.should.equal('user.html');
+  html.type.should.equal('text/html');
+  read(html.path).should.equal('&lt;h1&gt;name&lt;/h1&gt;');
 });</code></pre></dd>
           </dl>
         </section>
         <section class="suite">
-          <h1>HEAD requests</h1>
+          <h1>#attach(name, path)</h1>
           <dl>
-            <dt>should not throw a parse error</dt>
-            <dd><pre><code>request
-.head('http://localhost:3005/json')
-.end(function(err, res){
-  assert.strictEqual(err, null);
-  assert.strictEqual(res.text, undefined)
-  assert.strictEqual(Object.keys(res.body).length, 0)
-  done();
+            <dt>should attach a file</dt>
+            <dd><pre><code>var req = request.post(base + '/echo');
+req.attach('one', 'test/node/fixtures/user.html');
+req.attach('two', 'test/node/fixtures/user.json');
+req.attach('three', 'test/node/fixtures/user.txt');
+return req.then(function(res){
+  var html = res.files.one;
+  var json = res.files.two
+  var text = res.files.three;
+  html.name.should.equal('user.html');
+  html.type.should.equal('text/html');
+  read(html.path).should.equal('&lt;h1&gt;name&lt;/h1&gt;');
+  json.name.should.equal('user.json');
+  json.type.should.equal('application/json');
+  read(json.path).should.equal('{&quot;name&quot;:&quot;tobi&quot;}');
+  text.name.should.equal('user.txt');
+  text.type.should.equal('text/plain');
+  read(text.path).should.equal('Tobi');
 });</code></pre></dd>
-          </dl>
-        </section>
-        <section class="suite">
-          <h1>Invalid JSON response</h1>
-          <dl>
-            <dt>should return the raw response</dt>
-            <dd><pre><code>request
-.get('http://localhost:3005/invalid-json')
-.end(function(err, res){
-  assert.deepEqual(err.rawResponse, &quot;)]}', {'header':{'code':200,'text':'OK','version':'1.0'},'data':'some data'}&quot;);
+            <section class="suite">
+              <h1>when a file does not exist</h1>
+              <dl>
+                <dt>should emit an error</dt>
+                <dd><pre><code>var req = request.post(base + '/echo');
+req.attach('name', 'foo');
+req.attach('name2', 'bar');
+req.attach('name3', 'baz');
+req.on('error', function(err){
+  err.message.should.containEql('ENOENT');
+  err.path.should.equal('foo');
   done();
-});</code></pre></dd>
-          </dl>
-        </section>
-        <section class="suite">
-          <h1>No content</h1>
-          <dl>
-            <dt>should not throw a parse error</dt>
-            <dd><pre><code>request
-.get('http://localhost:3005/no-content')
-.end(function(err, res){
-  assert.strictEqual(err, null);
-  assert.strictEqual(res.text, '');
-  assert.strictEqual(Object.keys(res.body).length, 0);
-  done();
-});</code></pre></dd>
-          </dl>
-        </section>
-        <section class="suite">
-          <h1>application/json+hal</h1>
-          <dl>
-            <dt>should parse the body</dt>
-            <dd><pre><code>request
-.get('http://localhost:3005/json-hal')
-.end(function(err, res){
+});
+req.end(function(err, res){
   if (err) return done(err);
-  res.text.should.equal('{&quot;name&quot;:&quot;hal 5000&quot;}');
-  res.body.should.eql({ name: 'hal 5000' });
-  done();
+  assert(0, 'end() was called');
 });</code></pre></dd>
+              </dl>
+            </section>
           </dl>
         </section>
-        <section class="suite">
-          <h1>vnd.collection+json</h1>
-          <dl>
-            <dt>should parse the body</dt>
-            <dd><pre><code>request
-.get('http://localhost:3005/collection-json')
-.end(function(err, res){
-  res.text.should.equal('{&quot;name&quot;:&quot;chewbacca&quot;}');
-  res.body.should.eql({ name: 'chewbacca' });
-  done();
-});</code></pre></dd>
-          </dl>
-        </section>
-      </dl>
-    </section>
-    <section class="suite">
-      <h1>Request</h1>
-      <dl>
         <section class="suite">
           <h1>#attach(name, path, filename)</h1>
           <dl>
             <dt>should use the custom filename</dt>
-            <dd><pre><code>request
-.post(':3005/echo')
+            <dd><pre><code>return request
+.post(base + '/echo')
 .attach('document', 'test/node/fixtures/user.html', 'doc.html')
-.end(function(err, res){
-  if (err) return done(err);
+.then(function(res){
   var html = res.files.document;
   html.name.should.equal('doc.html');
   html.type.should.equal('text/html');
   read(html.path).should.equal('&lt;h1&gt;name&lt;/h1&gt;');
-  done();
-})</code></pre></dd>
+});</code></pre></dd>
             <dt>should fire progress event</dt>
             <dd><pre><code>var loaded = 0;
 var total = 0;
+var uploadEventWasFired = false;
 request
-.post(':3005/echo')
+.post(base + '/echo')
 .attach('document', 'test/node/fixtures/user.html')
 .on('progress', function (event) {
   total = event.total;
   loaded = event.loaded;
+  if (event.direction === 'upload') {
+    uploadEventWasFired = true;
+  }
 })
 .end(function(err, res){
   if (err) return done(err);
@@ -1303,10 +2940,54 @@ request
   html.name.should.equal('user.html');
   html.type.should.equal('text/html');
   read(html.path).should.equal('&lt;h1&gt;name&lt;/h1&gt;');
-  total.should.equal(221);
-  loaded.should.equal(221);
+  total.should.equal(223);
+  loaded.should.equal(223);
+  uploadEventWasFired.should.equal(true);
   done();
 })</code></pre></dd>
+            <dt>filesystem errors should be caught</dt>
+            <dd><pre><code>request
+    .post(base + '/echo')
+    .attach('filedata', 'test/node/fixtures/non-existent-file.ext')
+    .on('error', function(err) {
+      err.code.should.equal('ENOENT')
+      err.path.should.equal('test/node/fixtures/non-existent-file.ext')
+      done()
+    })
+    .end(function (err, res) {
+      done(new Error(&quot;Request should have been aborted earlier!&quot;))
+    })</code></pre></dd>
+          </dl>
+        </section>
+        <section class="suite">
+          <h1>#field(name, val)</h1>
+          <dl>
+            <dt>should set a multipart field value</dt>
+            <dd><pre><code>request.post(base + '/echo')
+.field('first-name', 'foo')
+.field('last-name', 'bar')
+.end(function(err, res) {
+  if(err) done(err);
+  res.should.be.ok();
+  res.body['first-name'].should.equal('foo');
+  res.body['last-name'].should.equal('bar');
+  done();
+});</code></pre></dd>
+          </dl>
+        </section>
+        <section class="suite">
+          <h1>#field(object)</h1>
+          <dl>
+            <dt>should set multiple multipart fields</dt>
+            <dd><pre><code>request.post(base + '/echo')
+.field({ 'first-name': 'foo', 'last-name': 'bar' })
+.end(function(err, res) {
+  if(err) done(err);
+  res.should.be.ok();
+  res.body['first-name'].should.equal('foo');
+  res.body['last-name'].should.equal('bar');
+  done();
+});</code></pre></dd>
           </dl>
         </section>
       </dl>
@@ -1331,7 +3012,7 @@ request
           <dl>
             <dt>should start with 200</dt>
             <dd><pre><code>request
-.get('http://localhost:3008/')
+.get(base + '/if-mod')
 .end(function(err, res){
   res.should.have.status(200)
   res.text.should.match(/^\d+$/);
@@ -1340,7 +3021,7 @@ request
 });</code></pre></dd>
             <dt>should then be 304</dt>
             <dd><pre><code>request
-.get('http://localhost:3008/')
+.get(base + '/if-mod')
 .set('If-Modified-Since', new Date(ts).toUTCString())
 .end(function(err, res){
   res.should.have.status(304)
@@ -1356,7 +3037,7 @@ request
       <dl>
         <dt>should take precedence over default parsers</dt>
         <dd><pre><code>request
-.get('http://localhost:3033/manny')
+.get(base + '/manny')
 .parse(request.parse['application/json'])
 .end(function(err, res){
   assert(res.ok);
@@ -1365,20 +3046,19 @@ request
   done();
 });</code></pre></dd>
         <dt>should be the only parser</dt>
-        <dd><pre><code>request
-.get('http://localhost:3033/image')
+        <dd><pre><code>return request
+.get(base + '/image')
 .parse(function(res, fn) {
   res.on('data', function() {});
 })
-.end(function(err, res){
+.then(function(res){
   assert(res.ok);
   assert.strictEqual(res.text, undefined);
   res.body.should.eql({});
-  done();
 });</code></pre></dd>
         <dt>should emit error if parser throws</dt>
         <dd><pre><code>request
-.get('http://localhost:3033/manny')
+.get(base + '/manny')
 .parse(function() {
   throw new Error('I am broken');
 })
@@ -1389,7 +3069,7 @@ request
 .end();</code></pre></dd>
         <dt>should emit error if parser returns an error</dt>
         <dd><pre><code>request
-.get('http://localhost:3033/manny')
+.get(base + '/manny')
 .parse(function(res, fn) {
   fn(new Error('I am broken'));
 })
@@ -1400,49 +3080,49 @@ request
 .end()</code></pre></dd>
         <dt>should not emit error on chunked json</dt>
         <dd><pre><code>request
-.get('http://localhost:3033/chunked-json')
+.get(base + '/chunked-json')
 .end(function(err){
   assert(!err);
   done();
 });</code></pre></dd>
         <dt>should not emit error on aborted chunked json</dt>
         <dd><pre><code>var req = request
-.get('http://localhost:3033/chunked-json')
+.get(base + '/chunked-json')
 .end(function(err){
-  assert(!err);
+  assert.ifError(err);
   done();
 });
 setTimeout(function(){req.abort()},50);</code></pre></dd>
+        <dt>should not reject promise on aborted chunked json</dt>
+        <dd><pre><code>var req = request.get(base + '/chunked-json')
+setTimeout(function(){req.abort()},50);
+return req;</code></pre></dd>
       </dl>
     </section>
     <section class="suite">
       <h1>pipe on redirect</h1>
       <dl>
         <dt>should follow Location</dt>
-        <dd><pre><code>var stream = fs.createWriteStream('test/node/fixtures/pipe.txt');
+        <dd><pre><code>var stream = fs.createWriteStream(destPath);
 var redirects = [];
 var req = request
-  .get('http://localhost:3012/')
+  .get(base)
   .on('redirect', function (res) {
     redirects.push(res.headers.location);
   })
-  .on('end', function () {
-    var arr = [];
-    arr.push('/movies');
-    arr.push('/movies/all');
-    arr.push('/movies/all/0');
-    redirects.should.eql(arr);
-    fs.readFileSync('test/node/fixtures/pipe.txt', 'utf8').should.eql('first movie page');
-    done();
-  });
-  req.pipe(stream);</code></pre></dd>
+stream.on('finish', function () {
+  redirects.should.eql(['/movies', '/movies/all', '/movies/all/0']);
+  fs.readFileSync(destPath, 'utf8').should.eql('first movie page');
+  done();
+});
+req.pipe(stream);</code></pre></dd>
       </dl>
     </section>
     <section class="suite">
       <h1>request pipe</h1>
       <dl>
         <dt>should act as a writable stream</dt>
-        <dd><pre><code>var req = request.post('http://localhost:3020');
+        <dd><pre><code>var req = request.post(base);
 var stream = fs.createReadStream('test/node/fixtures/user.json');
 req.type('json');
 req.on('response', function(res){
@@ -1451,11 +3131,17 @@ req.on('response', function(res){
 });
 stream.pipe(req);</code></pre></dd>
         <dt>should act as a readable stream</dt>
-        <dd><pre><code>var stream = fs.createWriteStream('test/node/fixtures/tmp.json');
-var req = request.get('http://localhost:3025');
+        <dd><pre><code>var stream = fs.createWriteStream(destPath);
+var responseCalled = false;
+var req = request.get(base);
 req.type('json');
-req.on('end', function(){
-  JSON.parse(fs.readFileSync('test/node/fixtures/tmp.json', 'utf8')).should.eql({ name: 'tobi' });
+req.on('response', function(res){
+  res.should.have.status(200);
+  responseCalled = true;
+});
+stream.on('finish', function(){
+  JSON.parse(fs.readFileSync(destPath, 'utf8')).should.eql({ name: 'tobi' });
+  responseCalled.should.be.true();
   done();
 });
 req.pipe(stream);</code></pre></dd>
@@ -1464,20 +3150,9 @@ req.pipe(stream);</code></pre></dd>
     <section class="suite">
       <h1>req.query(String)</h1>
       <dl>
-        <dt>should supply uri malformed error to the callback</dt>
-        <dd><pre><code>request
-.get('http://localhost:3006')
-.query('name=toby')
-.query('a=\uD800')
-.query({ b: '\uD800' })
-.end(function(err, res){
-  assert(err instanceof Error);
-  assert.equal('URIError', err.name);
-  done();
-});</code></pre></dd>
         <dt>should support passing in a string</dt>
         <dd><pre><code>request
-.del('http://localhost:3006')
+.del(base)
 .query('name=t%F6bi')
 .end(function(err, res){
   res.body.should.eql({ name: 't%F6bi' });
@@ -1485,7 +3160,7 @@ req.pipe(stream);</code></pre></dd>
 });</code></pre></dd>
         <dt>should work with url query-string and string for query</dt>
         <dd><pre><code>request
-.del('http://localhost:3006/?name=tobi')
+.del(base + '/?name=tobi')
 .query('age=2%20')
 .end(function(err, res){
   res.body.should.eql({ name: 'tobi', age: '2 ' });
@@ -1493,7 +3168,7 @@ req.pipe(stream);</code></pre></dd>
 });</code></pre></dd>
         <dt>should support compound elements in a string</dt>
         <dd><pre><code>request
-  .del('http://localhost:3006/')
+  .del(base)
   .query('name=t%F6bi&amp;age=2')
   .end(function(err, res){
     res.body.should.eql({ name: 't%F6bi', age: '2' });
@@ -1501,7 +3176,7 @@ req.pipe(stream);</code></pre></dd>
   });</code></pre></dd>
         <dt>should work when called multiple times with a string</dt>
         <dd><pre><code>request
-.del('http://localhost:3006/')
+.del(base)
 .query('name=t%F6bi')
 .query('age=2%F6')
 .end(function(err, res){
@@ -1510,7 +3185,7 @@ req.pipe(stream);</code></pre></dd>
 });</code></pre></dd>
         <dt>should work with normal `query` object and query string</dt>
         <dd><pre><code>request
-.del('http://localhost:3006/')
+.del(base)
 .query('name=t%F6bi')
 .query({ age: '2' })
 .end(function(err, res){
@@ -1524,7 +3199,7 @@ req.pipe(stream);</code></pre></dd>
       <dl>
         <dt>should construct the query-string</dt>
         <dd><pre><code>request
-.del('http://localhost:3006/')
+.del(base)
 .query({ name: 'tobi' })
 .query({ order: 'asc' })
 .query({ limit: ['1', '2'] })
@@ -1535,7 +3210,7 @@ req.pipe(stream);</code></pre></dd>
         <dt>should not error on dates</dt>
         <dd><pre><code>var date = new Date(0);
 request
-.del('http://localhost:3006/')
+.del(base)
 .query({ at: date })
 .end(function(err, res){
   assert.equal(date.toISOString(), res.body.at);
@@ -1543,7 +3218,7 @@ request
 });</code></pre></dd>
         <dt>should work after setting header fields</dt>
         <dd><pre><code>request
-.del('http://localhost:3006/')
+.del(base)
 .set('Foo', 'bar')
 .set('Bar', 'baz')
 .query({ name: 'tobi' })
@@ -1555,7 +3230,7 @@ request
 });</code></pre></dd>
         <dt>should append to the original query-string</dt>
         <dd><pre><code>request
-.del('http://localhost:3006/?name=tobi')
+.del(base + '/?name=tobi')
 .query({ order: 'asc' })
 .end(function(err, res) {
   res.body.should.eql({ name: 'tobi', order: 'asc' });
@@ -1563,11 +3238,27 @@ request
 });</code></pre></dd>
         <dt>should retain the original query-string</dt>
         <dd><pre><code>request
-.del('http://localhost:3006/?name=tobi')
+.del(base + '/?name=tobi')
 .end(function(err, res) {
   res.body.should.eql({ name: 'tobi' });
   done();
 });</code></pre></dd>
+        <dt>should keep only keys with null querystring values</dt>
+        <dd><pre><code>request
+.del(base + '/url')
+.query({ nil: null })
+.end(function(err, res) {
+  res.text.should.equal('/url?nil');
+  done();
+});</code></pre></dd>
+        <dt>query-string should be sent on pipe</dt>
+        <dd><pre><code>var req = request.put(base + '/?name=tobi');
+var stream = fs.createReadStream('test/node/fixtures/user.json');
+req.on('response', function(res){
+  res.body.should.eql({ name: 'tobi' });
+  done();
+});
+stream.pipe(req);</code></pre></dd>
       </dl>
     </section>
     <section class="suite">
@@ -1578,10 +3269,10 @@ request
           <dl>
             <dt>should follow Location with a GET request</dt>
             <dd><pre><code>var req = request
-  .get('http://localhost:3210/test-301')
+  .get(base + '/test-301')
   .redirects(1)
   .end(function(err, res){
-    req.req._headers.host.should.eql('localhost:3211');
+    req.req._headers.host.should.eql('localhost:' + server2.address().port);
     res.status.should.eql(200);
     res.text.should.eql('GET');
     done();
@@ -1593,10 +3284,10 @@ request
           <dl>
             <dt>should follow Location with a GET request</dt>
             <dd><pre><code>var req = request
-  .get('http://localhost:3210/test-302')
+  .get(base + '/test-302')
   .redirects(1)
   .end(function(err, res){
-    req.req._headers.host.should.eql('localhost:3211');
+    req.req._headers.host.should.eql('localhost:' + server2.address().port + '');
     res.status.should.eql(200);
     res.text.should.eql('GET');
     done();
@@ -1608,10 +3299,10 @@ request
           <dl>
             <dt>should follow Location with a GET request</dt>
             <dd><pre><code>var req = request
-  .get('http://localhost:3210/test-303')
+  .get(base + '/test-303')
   .redirects(1)
   .end(function(err, res){
-    req.req._headers.host.should.eql('localhost:3211');
+    req.req._headers.host.should.eql('localhost:' + server2.address().port + '');
     res.status.should.eql(200);
     res.text.should.eql('GET');
     done();
@@ -1623,10 +3314,10 @@ request
           <dl>
             <dt>should follow Location with a GET request</dt>
             <dd><pre><code>var req = request
-  .get('http://localhost:3210/test-307')
+  .get(base + '/test-307')
   .redirects(1)
   .end(function(err, res){
-    req.req._headers.host.should.eql('localhost:3211');
+    req.req._headers.host.should.eql('localhost:' + server2.address().port + '');
     res.status.should.eql(200);
     res.text.should.eql('GET');
     done();
@@ -1638,10 +3329,10 @@ request
           <dl>
             <dt>should follow Location with a GET request</dt>
             <dd><pre><code>var req = request
-  .get('http://localhost:3210/test-308')
+  .get(base + '/test-308')
   .redirects(1)
   .end(function(err, res){
-    req.req._headers.host.should.eql('localhost:3211');
+    req.req._headers.host.should.eql('localhost:' + server2.address().port + '');
     res.status.should.eql(200);
     res.text.should.eql('GET');
     done();
@@ -1658,10 +3349,10 @@ request
           <dl>
             <dt>should follow Location with a GET request</dt>
             <dd><pre><code>var req = request
-  .post('http://localhost:3210/test-301')
+  .post(base + '/test-301')
   .redirects(1)
   .end(function(err, res){
-    req.req._headers.host.should.eql('localhost:3211');
+    req.req._headers.host.should.eql('localhost:' + server2.address().port + '');
     res.status.should.eql(200);
     res.text.should.eql('GET');
     done();
@@ -1673,10 +3364,10 @@ request
           <dl>
             <dt>should follow Location with a GET request</dt>
             <dd><pre><code>var req = request
-  .post('http://localhost:3210/test-302')
+  .post(base + '/test-302')
   .redirects(1)
   .end(function(err, res){
-    req.req._headers.host.should.eql('localhost:3211');
+    req.req._headers.host.should.eql('localhost:' + server2.address().port + '');
     res.status.should.eql(200);
     res.text.should.eql('GET');
     done();
@@ -1688,10 +3379,10 @@ request
           <dl>
             <dt>should follow Location with a GET request</dt>
             <dd><pre><code>var req = request
-  .post('http://localhost:3210/test-303')
+  .post(base + '/test-303')
   .redirects(1)
   .end(function(err, res){
-    req.req._headers.host.should.eql('localhost:3211');
+    req.req._headers.host.should.eql('localhost:' + server2.address().port + '');
     res.status.should.eql(200);
     res.text.should.eql('GET');
     done();
@@ -1703,10 +3394,10 @@ request
           <dl>
             <dt>should follow Location with a POST request</dt>
             <dd><pre><code>var req = request
-  .post('http://localhost:3210/test-307')
+  .post(base + '/test-307')
   .redirects(1)
   .end(function(err, res){
-    req.req._headers.host.should.eql('localhost:3211');
+    req.req._headers.host.should.eql('localhost:' + server2.address().port + '');
     res.status.should.eql(200);
     res.text.should.eql('POST');
     done();
@@ -1718,10 +3409,10 @@ request
           <dl>
             <dt>should follow Location with a POST request</dt>
             <dd><pre><code>var req = request
-  .post('http://localhost:3210/test-308')
+  .post(base + '/test-308')
   .redirects(1)
   .end(function(err, res){
-    req.req._headers.host.should.eql('localhost:3211');
+    req.req._headers.host.should.eql('localhost:' + server2.address().port + '');
     res.status.should.eql(200);
     res.text.should.eql('POST');
     done();
@@ -1739,85 +3430,125 @@ request
             <dt>should follow Location</dt>
             <dd><pre><code>var redirects = [];
 request
-.get('http://localhost:3003/')
+.get(base)
 .on('redirect', function(res){
   redirects.push(res.headers.location);
 })
 .end(function(err, res){
-  var arr = [];
-  arr.push('/movies');
-  arr.push('/movies/all');
-  arr.push('/movies/all/0');
-  redirects.should.eql(arr);
-  res.text.should.equal('first movie page');
-  done();
+  try {
+    var arr = [];
+    arr.push('/movies');
+    arr.push('/movies/all');
+    arr.push('/movies/all/0');
+    redirects.should.eql(arr);
+    res.text.should.equal('first movie page');
+    done();
+  } catch(err) {
+    done(err);
+  }
 });</code></pre></dd>
-            <dt>should retain header fields</dt>
-            <dd><pre><code>request
-.get('http://localhost:3003/header')
-.set('X-Foo', 'bar')
+            <dt>should not follow on HEAD by default</dt>
+            <dd><pre><code>var redirects = [];
+request.head(base)
+.on('redirect', function(res){
+  redirects.push(res.headers.location);
+})
 .end(function(err, res){
-  res.body.should.have.property('x-foo', 'bar');
-  done();
+  try {
+    redirects.should.eql([]);
+    res.status.should.equal(302);
+    done();
+  } catch(err) {
+    done(err);
+  }
+});</code></pre></dd>
+            <dt>should follow on HEAD when redirects are set</dt>
+            <dd><pre><code>var redirects = [];
+request.head(base)
+.redirects(10)
+.on('redirect', function(res){
+  redirects.push(res.headers.location);
+})
+.end(function(err, res){
+  try {
+    var arr = [];
+    arr.push('/movies');
+    arr.push('/movies/all');
+    arr.push('/movies/all/0');
+    redirects.should.eql(arr);
+    assert(!res.text);
+    done();
+  } catch(err) {
+    done(err);
+  }
 });</code></pre></dd>
             <dt>should remove Content-* fields</dt>
             <dd><pre><code>request
-.post('http://localhost:3003/header')
+.post(base + '/header')
 .type('txt')
 .set('X-Foo', 'bar')
 .set('X-Bar', 'baz')
 .send('hey')
 .end(function(err, res){
-  res.body.should.have.property('x-foo', 'bar');
-  res.body.should.have.property('x-bar', 'baz');
-  res.body.should.not.have.property('content-type');
-  res.body.should.not.have.property('content-length');
-  res.body.should.not.have.property('transfer-encoding');
-  done();
+  try {
+    assert(res.body);
+    res.body.should.have.property('x-foo', 'bar');
+    res.body.should.have.property('x-bar', 'baz');
+    res.body.should.not.have.property('content-type');
+    res.body.should.not.have.property('content-length');
+    res.body.should.not.have.property('transfer-encoding');
+    done();
+  } catch(err) {
+    done(err);
+  }
 });</code></pre></dd>
             <dt>should retain cookies</dt>
             <dd><pre><code>request
-.get('http://localhost:3003/header')
+.get(base + '/header')
 .set('Cookie', 'foo=bar;')
 .end(function(err, res){
-  res.body.should.have.property('cookie', 'foo=bar;');
-  done();
-});</code></pre></dd>
-            <dt>should preserve timeout across redirects</dt>
-            <dd><pre><code>request
-.get('http://localhost:3003/movies/random')
-.timeout(250)
-.end(function(err, res){
-  assert(err instanceof Error, 'expected an error');
-  err.should.have.property('timeout', 250);
-  done();
+  try {
+    assert(res.body);
+    res.body.should.have.property('cookie', 'foo=bar;');
+    done();
+  } catch(err) {
+    done(err);
+  }
 });</code></pre></dd>
             <dt>should not resend query parameters</dt>
             <dd><pre><code>var redirects = [];
 var query = [];
 request
-.get('http://localhost:3003/?foo=bar')
+.get(base + '/?foo=bar')
 .on('redirect', function(res){
   query.push(res.headers.query);
   redirects.push(res.headers.location);
 })
 .end(function(err, res){
-  var arr = [];
-  arr.push('/movies');
-  arr.push('/movies/all');
-  arr.push('/movies/all/0');
-  redirects.should.eql(arr);
-  res.text.should.equal('first movie page');
-  query.should.eql(['{&quot;foo&quot;:&quot;bar&quot;}', '{}', '{}']);
-  res.headers.query.should.eql('{}');
-  done();
+  try {
+    var arr = [];
+    arr.push('/movies');
+    arr.push('/movies/all');
+    arr.push('/movies/all/0');
+    redirects.should.eql(arr);
+    res.text.should.equal('first movie page');
+    query.should.eql(['{&quot;foo&quot;:&quot;bar&quot;}', '{}', '{}']);
+    res.headers.query.should.eql('{}');
+    done();
+  } catch(err) {
+    done(err);
+  }
 });</code></pre></dd>
             <dt>should handle no location header</dt>
             <dd><pre><code>request
-.get('http://localhost:3003/bad-redirect')
+.get(base + '/bad-redirect')
 .end(function(err, res){
-  err.message.should.equal('No location header for redirect');
-  done();
+  try {
+    err.message.should.equal('No location header for redirect');
+    done();
+  } catch(err) {
+    done(err);
+  }
 });</code></pre></dd>
             <section class="suite">
               <h1>when relative</h1>
@@ -1825,28 +3556,34 @@ request
                 <dt>should redirect to a sibling path</dt>
                 <dd><pre><code>var redirects = [];
 request
-.get('http://localhost:3003/relative')
+.get(base + '/relative')
 .on('redirect', function(res){
   redirects.push(res.headers.location);
 })
 .end(function(err, res){
-  var arr = [];
-  redirects.should.eql(['tobi']);
-  res.text.should.equal('tobi');
-  done();
+  try {
+    redirects.should.eql(['tobi']);
+    res.text.should.equal('tobi');
+    done();
+  } catch(err) {
+    done(err);
+  }
 });</code></pre></dd>
                 <dt>should redirect to a parent path</dt>
                 <dd><pre><code>var redirects = [];
 request
-.get('http://localhost:3003/relative/sub')
+.get(base + '/relative/sub')
 .on('redirect', function(res){
   redirects.push(res.headers.location);
 })
 .end(function(err, res){
-  var arr = [];
-  redirects.should.eql(['../tobi']);
-  res.text.should.equal('tobi');
-  done();
+  try {
+    redirects.should.eql(['../tobi']);
+    res.text.should.equal('tobi');
+    done();
+  } catch(err) {
+    done(err);
+  }
 });</code></pre></dd>
               </dl>
             </section>
@@ -1858,19 +3595,23 @@ request
             <dt>should alter the default number of redirects to follow</dt>
             <dd><pre><code>var redirects = [];
 request
-.get('http://localhost:3003/')
+.get(base)
 .redirects(2)
 .on('redirect', function(res){
   redirects.push(res.headers.location);
 })
 .end(function(err, res){
-  var arr = [];
-  assert(res.redirect, 'res.redirect');
-  arr.push('/movies');
-  arr.push('/movies/all');
-  redirects.should.eql(arr);
-  res.text.should.match(/Moved Temporarily|Found/);
-  done();
+  try {
+    var arr = [];
+    assert(res.redirect, 'res.redirect');
+    arr.push('/movies');
+    arr.push('/movies/all');
+    redirects.should.eql(arr);
+    res.text.should.match(/Moved Temporarily|Found/);
+    done();
+  } catch(err) {
+    done(err);
+  }
 });</code></pre></dd>
           </dl>
         </section>
@@ -1880,70 +3621,49 @@ request
             <dt>should redirect as GET</dt>
             <dd><pre><code>var redirects = [];
 request
-.post('http://localhost:3003/movie')
+.post(base + '/movie')
 .send({ name: 'Tobi' })
 .redirects(2)
 .on('redirect', function(res){
   redirects.push(res.headers.location);
 })
 .end(function(err, res){
-  var arr = [];
-  arr.push('/movies/all/0');
-  redirects.should.eql(arr);
-  res.text.should.equal('first movie page');
-  done();
+  try {
+    var arr = [];
+    arr.push('/movies/all/0');
+    redirects.should.eql(arr);
+    res.text.should.equal('first movie page');
+    done();
+  } catch(err) {
+    done(err);
+  }
 });</code></pre></dd>
           </dl>
         </section>
         <section class="suite">
-          <h1>on 303</h1>
+          <h1>on POST using multipart/form-data</h1>
           <dl>
-            <dt>should redirect with same method</dt>
-            <dd><pre><code>request
-.put('http://localhost:3003/redirect-303')
-.send({msg: &quot;hello&quot;})
-.redirects(1)
-.on('redirect', function(res) {
-  res.headers.location.should.equal('/reply-method')
+            <dt>should redirect as GET</dt>
+            <dd><pre><code>var redirects = [];
+request
+.post(base + '/movie')
+.type('form')
+.field('name', 'Tobi')
+.redirects(2)
+.on('redirect', function(res){
+  redirects.push(res.headers.location);
 })
 .end(function(err, res){
-  res.text.should.equal('method=get');
-  done();
-})</code></pre></dd>
-          </dl>
-        </section>
-        <section class="suite">
-          <h1>on 307</h1>
-          <dl>
-            <dt>should redirect with same method</dt>
-            <dd><pre><code>request
-.put('http://localhost:3003/redirect-307')
-.send({msg: &quot;hello&quot;})
-.redirects(1)
-.on('redirect', function(res) {
-  res.headers.location.should.equal('/reply-method')
-})
-.end(function(err, res){
-  res.text.should.equal('method=put');
-  done();
-})</code></pre></dd>
-          </dl>
-        </section>
-        <section class="suite">
-          <h1>on 308</h1>
-          <dl>
-            <dt>should redirect with same method</dt>
-            <dd><pre><code>request
-.put('http://localhost:3003/redirect-308')
-.send({msg: &quot;hello&quot;})
-.redirects(1)
-.on('redirect', function(res) {
-  res.headers.location.should.equal('/reply-method')
-})
-.end(function(err, res){
-  res.text.should.equal('method=put');
-  done();
-})</code></pre></dd>
+  try {
+    var arr = [];
+    arr.push('/movies/all/0');
+    redirects.should.eql(arr);
+    res.text.should.equal('first movie page');
+    done();
+  } catch(err) {
+    done(err);
+  }
+});</code></pre></dd>
           </dl>
         </section>
       </dl>
@@ -1953,7 +3673,7 @@ request
       <dl>
         <dt>should act as a readable stream</dt>
         <dd><pre><code>var req = request
-  .get('http://localhost:3025')
+  .get(base)
   .buffer(false);
 req.end(function(err,res){
   if (err) return done(err);
@@ -1976,31 +3696,11 @@ req.end(function(err,res){
       </dl>
     </section>
     <section class="suite">
-      <h1>.timeout(ms)</h1>
-      <dl>
-        <section class="suite">
-          <h1>when timeout is exceeded</h1>
-          <dl>
-            <dt>should error</dt>
-            <dd><pre><code>request
-.get('http://localhost:3009/500')
-.timeout(150)
-.end(function(err, res){
-  assert(err, 'expected an error');
-  assert.equal('number', typeof err.timeout, 'expected an error with .timeout');
-  assert.equal('ECONNABORTED', err.code, 'expected abort error code')
-  done();
-});</code></pre></dd>
-          </dl>
-        </section>
-      </dl>
-    </section>
-    <section class="suite">
       <h1>res.toError()</h1>
       <dl>
         <dt>should return an Error</dt>
         <dd><pre><code>request
-.get('http://localhost:' + server.address().port)
+.get(base)
 .end(function(err, res){
   var err = res.toError();
   assert.equal(err.status, 400);
@@ -2013,34 +3713,85 @@ req.end(function(err,res){
       </dl>
     </section>
     <section class="suite">
+      <h1>[unix-sockets] http</h1>
+      <dl>
+        <section class="suite">
+          <h1>request</h1>
+          <dl>
+            <dt>path: / (root)</dt>
+            <dd><pre><code>request
+  .get(base + '/')
+  .end(function(err, res) {
+    assert(res.ok);
+    assert.strictEqual('root ok!', res.text);
+    done();
+  });</code></pre></dd>
+            <dt>path: /request/path</dt>
+            <dd><pre><code>request
+  .get(base + '/request/path')
+  .end(function(err, res) {
+    assert(res.ok);
+    assert.strictEqual('request path ok!', res.text);
+    done();
+  });</code></pre></dd>
+          </dl>
+        </section>
+      </dl>
+    </section>
+    <section class="suite">
+      <h1>[unix-sockets] https</h1>
+      <dl>
+        <section class="suite">
+          <h1>request</h1>
+          <dl>
+            <dt>path: / (root)</dt>
+            <dd><pre><code>request
+  .get(base + '/')
+  .ca(cert)
+  .end(function(err, res) {
+    assert(res.ok);
+    assert.strictEqual('root ok!', res.text);
+    done();
+  });</code></pre></dd>
+            <dt>path: /request/path</dt>
+            <dd><pre><code>request
+  .get(base + '/request/path')
+  .ca(cert)
+  .end(function(err, res) {
+    assert(res.ok);
+    assert.strictEqual('request path ok!', res.text);
+    done();
+  });</code></pre></dd>
+          </dl>
+        </section>
+      </dl>
+    </section>
+    <section class="suite">
       <h1>req.get()</h1>
       <dl>
         <dt>should set a default user-agent</dt>
-        <dd><pre><code>request
-.get('http://localhost:3345/ua')
-.end(function(err, res){
+        <dd><pre><code>return request
+.get(base + '/ua')
+.then(function(res){
   assert(res.headers);
   assert(res.headers['user-agent']);
-  assert(/^node-superagent\/\d+\.\d+\.\d+$/.test(res.headers['user-agent']));
-  done();
+  assert(/^node-superagent\/\d+\.\d+\.\d+(?:-[a-z]+\.\d+|$)/.test(res.headers['user-agent']));
 });</code></pre></dd>
         <dt>should be able to override user-agent</dt>
-        <dd><pre><code>request
-.get('http://localhost:3345/ua')
+        <dd><pre><code>return request
+.get(base + '/ua')
 .set('User-Agent', 'foo/bar')
-.end(function(err, res){
+.then(function(res){
   assert(res.headers);
   assert.equal(res.headers['user-agent'], 'foo/bar');
-  done();
 });</code></pre></dd>
         <dt>should be able to wipe user-agent</dt>
-        <dd><pre><code>request
-.get('http://localhost:3345/ua')
+        <dd><pre><code>return request
+.get(base + '/ua')
 .unset('User-Agent')
-.end(function(err, res){
+.then(function(res){
   assert(res.headers);
   assert.equal(res.headers['user-agent'], void 0);
-  done();
 });</code></pre></dd>
       </dl>
     </section>
@@ -2078,5 +3829,37 @@ ret.last.should.equal('https://api.github.com/repos/visionmedia/mocha/issues?pag
     </section>
     </div>
     <a href="http://github.com/visionmedia/superagent"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_white_ffffff.png" alt="Fork me on GitHub"></a>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.2.1/jquery.min.js"></script>
+    <script>
+      $('code').each(function(){
+        $(this).html(highlight($(this).text()));
+      });
+
+      function highlight(js) {
+        return js
+          .replace(/</g, '&lt;')
+          .replace(/>/g, '&gt;')
+          .replace(/('.*?')/gm, '<span class="string">$1</span>')
+          .replace(/(\d+\.\d+)/gm, '<span class="number">$1</span>')
+          .replace(/(\d+)/gm, '<span class="number">$1</span>')
+          .replace(/\bnew *(\w+)/gm, '<span class="keyword">new</span> <span class="init">$1</span>')
+          .replace(/\b(function|new|throw|return|var|if|else)\b/gm, '<span class="keyword">$1</span>')
+      }
+    </script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/tocbot/3.0.0/tocbot.js"></script>
+    <script>
+      // Only use tocbot for main docs, not test docs
+      if (document.querySelector('#superagent')) {
+        tocbot.init({
+          // Where to render the table of contents.
+          tocSelector: '#menu',
+          // Where to grab the headings to build the table of contents.
+          contentSelector: '#content',
+          // Which headings to grab inside of the contentSelector element.
+          headingSelector: 'h2',
+          smoothScroll: false
+        });
+      }
+    </script>
   </body>
 </html>


### PR DESCRIPTION
Github pages now supports serving the static site from the master branch `docs` directory. The `gh-pages` branch was confusing because the only things we used from there were the docs but there was also a ton of ancient code in there. With this change, we should be able to go into the github settings and configure our github pages site to be based off master branch `docs/index.html`. Then we can delete the `gh-pages` branch which should simplify things.

I also switched our table of contents generator to an actively-maintained, 0-dependency alternative.