### PR TITLE
Fix spelling mistake in the docs

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -19,7 +19,7 @@ Works with [browserify](https://github.com/substack/node-browserify) and should 
 ```js
 request
   .post('/api/pet')
-  .send({ name: 'Manny', species: 'cat' })
+  .send({ name: 'Manny', species: 'cat' }) // sends a JSON post body
   .set('X-API-Key', 'foobar')
   .set('Accept', 'application/json')
   .end(function(err, res){

--- a/docs/index.md
+++ b/docs/index.md
@@ -150,7 +150,7 @@ A typical JSON __POST__ request might look a little like the following, where we
         .send('{"name":"tj","pet":"tobi"}')
         .end(callback)
 
-Since JSON is undoubtably the most common, it's the _default_! The following example is equivalent to the previous.
+Since JSON is undoubtedly the most common, it's the _default_! The following example is equivalent to the previous.
 
       request.post('/user')
         .send({ name: 'tj', pet: 'tobi' })


### PR DESCRIPTION
Also clarify in the docs that the default example sends a JSON upload,
not a form-urlencoded upload.