### PR TITLE
Consolidate auth args handling in node/browser

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -518,21 +518,14 @@ Request.prototype.auth = function(user, pass, options){
     }
   }
 
-  switch (options.type) {
-    case 'basic':
-      this.set('Authorization', 'Basic ' + btoa(user + ':' + pass));
-    break;
+  var encoder = function(string) {
+    if ('function' === typeof btoa) {
+      return btoa(string);
+    }
+    throw new Error('Cannot use basic auth, btoa is not a function');
+  };
 
-    case 'auto':
-      this.username = user;
-      this.password = pass;
-    break;
-
-    case 'bearer': // usage would be .auth(accessToken, { type: 'bearer' })
-      this.set('Authorization', 'Bearer ' + user);
-    break;
-  }
-  return this;
+  return this._auth(user, pass, options, encoder);
 };
 
 /**

--- a/lib/client.js
+++ b/lib/client.js
@@ -507,8 +507,10 @@ Request.prototype.accept = function(type){
  */
 
 Request.prototype.auth = function(user, pass, options){
-  if (typeof pass === 'object' && pass !== null) { // pass is optional and can substitute for options
+  if (1 === arguments.length) pass = '';
+  if (typeof pass === 'object' && pass !== null) { // pass is optional and can be replaced with options
     options = pass;
+    pass = '';
   }
   if (!options) {
     options = {

--- a/lib/node/index.js
+++ b/lib/node/index.js
@@ -485,15 +485,12 @@ Request.prototype.auth = function(user, pass, options){
   if (!options) {
     options = { type: 'basic' };
   }
-  switch (options.type) {
-    case 'bearer':
-      return this.set('Authorization', 'Bearer ' + user);
 
-    default: // 'basic'
-      if (!~user.indexOf(':')) user = user + ':';
-      var str = new Buffer(user + pass).toString('base64');
-      return this.set('Authorization', 'Basic ' + str);
-  }
+  var encoder = function(string) {
+    return new Buffer(string).toString('base64');
+  };
+
+  return this._auth(user, pass, options, encoder);
 };
 
 /**

--- a/lib/node/index.js
+++ b/lib/node/index.js
@@ -478,7 +478,10 @@ Request.prototype._redirect = function(res){
 
 Request.prototype.auth = function(user, pass, options){
   if (1 === arguments.length) pass = '';
-  if (2 === arguments.length && typeof pass === 'object') options = pass;
+  if (typeof pass === 'object' && pass !== null) { // pass is optional and can be replaced with options
+    options = pass;
+    pass = '';
+  }
   if (!options) {
     options = { type: 'basic' };
   }

--- a/lib/node/index.js
+++ b/lib/node/index.js
@@ -641,6 +641,9 @@ Request.prototype.request = function(){
     var auth = url.auth.split(':');
     this.auth(auth[0], auth[1]);
   }
+  if (this.username && this.password) {
+    this.auth(this.username, this.password);
+  }
 
   // add cookies
   if (this.cookies) req.setHeader('Cookie', this.cookies);

--- a/lib/request-base.js
+++ b/lib/request-base.js
@@ -382,6 +382,24 @@ RequestBase.prototype.abort = function(){
   return this;
 };
 
+RequestBase.prototype._auth = function(user, pass, options, base64Encoder) {
+  switch (options.type) {
+    case 'basic':
+      this.set('Authorization', 'Basic ' + base64Encoder(user + ':' + pass));
+      break;
+
+    case 'auto':
+      this.username = user;
+      this.password = pass;
+      break;
+
+    case 'bearer': // usage would be .auth(accessToken, { type: 'bearer' })
+      this.set('Authorization', 'Bearer ' + user);
+      break;
+  }
+  return this;
+};
+
 /**
  * Enable transmission of cookies with x-domain requests.
  *

--- a/test/client/request.js
+++ b/test/client/request.js
@@ -180,6 +180,47 @@ it('auth type "auto"', function(next){
   });
 });
 
+it('auth type "basic" cannot be used if btoa is not defined', function (next) {
+  window.btoa = undefined;
+
+  assert.throws(
+    function () {
+      request
+        .post('/auth')
+        .auth('foo', 'bar', { type: 'basic' });
+    },
+    Error
+  );
+
+  next();
+});
+
+it('basic auth without pass but with options should set authentication', function(next){
+  window.btoa = window.btoa || require('Base64').btoa;
+
+  request
+    .post('/auth/again')
+    .auth('foo', {type: 'basic'})
+    .end(function(err, res){
+      assert.equal('foo', res.body.user);
+      assert.equal('', res.body.pass);
+      next();
+    });
+});
+
+it('basic auth without pass should set authentication', function(next){
+  window.btoa = window.btoa || require('Base64').btoa;
+
+  request
+    .post('/auth/again')
+    .auth('foo')
+    .end(function(err, res){
+      assert.equal('foo', res.body.user);
+      assert.equal('', res.body.pass);
+      next();
+    });
+});
+
 it('progress event listener on xhr object registered when some on the request', function(){
   var req = request
   .get('/foo')

--- a/test/node/basic-auth.js
+++ b/test/node/basic-auth.js
@@ -31,6 +31,18 @@ describe('Basic auth', function(){
     })
   })
 
+  describe('req.auth(user, pass) including options', function(){
+    it('should set Authorization', function(done){
+      request
+        .get(base + '/basic-auth')
+        .auth('tobi', 'learnboost', { type: 'auto' })
+        .end(function(err, res){
+          res.status.should.equal(200);
+          done();
+        });
+    })
+  })
+
   describe('req.auth(user + ":" + pass)', function(){
     it('should set authorization', function(done){
       request
@@ -40,6 +52,18 @@ describe('Basic auth', function(){
         res.status.should.eql(200);
         done();
       });
+    })
+  })
+
+  describe('req.auth(user + ":" + pass) including options', function(){
+    it('should set authorization', function(done){
+      request
+        .get(base + '/basic-auth/again')
+        .auth('tobi', { type: 'basic' })
+        .end(function(err, res){
+          res.status.should.eql(200);
+          done();
+        });
     })
   })
 })

--- a/test/support/server.js
+++ b/test/support/server.js
@@ -277,6 +277,16 @@ app.post('/auth', basicAuth('foo', 'bar'), function(req, res) {
   res.send({ user : user, pass : pass });
 });
 
+app.post('/auth/again', basicAuth('foo', ''), function(req, res) {
+  var auth = req.headers.authorization,
+    parts = auth.split(' '),
+    credentials = new Buffer(parts[1], 'base64').toString().split(':'),
+    user = credentials[0],
+    pass = credentials[1];
+
+  res.send({ user : user, pass : pass });
+});
+
 app.get('/error', function(req, res){
   res.status(500).send('boom');
 });


### PR DESCRIPTION
As described in #796, `auth` arguments handling was quite different in the code running on a browser and Node, which could lead to inconsistent results between both platforms.

This PR tries to bring them into an equal state, and also updates the test cases to cover the same situations in both platforms.

Fixes #796