### PR TITLE
Documented FormData support in .send()

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -178,6 +178,12 @@ SuperAgent formats are extensible, however by default "json" and "form" are supp
         .send({ name: 'tj' })
         .send({ pet: 'tobi' })
         .end(callback)
+        
+Sending a [`FormData`](https://developer.mozilla.org/en-US/docs/Web/API/FormData/FormData) object is also supported. The following example will __POST__ the content of the HTML form identified by id="myForm":
+
+      request.post('/user')
+        .send(new FormData(document.getElementById('myForm')))
+        .end(callback)
 
 ## Setting the `Content-Type`
 


### PR DESCRIPTION
I wanted to use superagent to send an HTML form, because of some `<input type="file">` fields. Browser support section in the master branch's README hints that `FormData` is somehow supported, but I couldn't find any mentions of it in the documentation website. After blindly trying using `.field()` and `.append()`, I found out that it works with `.send()`.