### PR TITLE
Fix for error in subsequent require() calls

### DIFF
--- a/lib/node/index.js
+++ b/lib/node/index.js
@@ -70,7 +70,7 @@ exports.Response = Response;
 
 mime.define({
   'application/x-www-form-urlencoded': ['form', 'urlencoded', 'form-data']
-});
+}, true);
 
 /**
  * Protocol map.


### PR DESCRIPTION
Superagent has recently been upgraded to use version 2.0.3 of mime.

However, between version 1.4.1 and 2.0.3 of mime an earlier warning has been upgraded to an error when defining the same mime types twice .

See https://github.com/visionmedia/superagent/issues/1288 for a longer explanation