### PR TITLE
Catch and pass along errors in ok callback

### DIFF
--- a/lib/node/index.js
+++ b/lib/node/index.js
@@ -671,16 +671,20 @@ Request.prototype.callback = function(err, res){
   this.called = true;
 
   if (!err) {
-    if (this._isResponseOK(res)) {
-      return fn(err, res);
-    }
+    try {
+      if (this._isResponseOK(res)) {
+        return fn(err, res);
+      }
 
-    var msg = 'Unsuccessful HTTP response';
-    if (res) {
-      msg = http.STATUS_CODES[res.status] || msg;
+      var msg = 'Unsuccessful HTTP response';
+      if (res) {
+        msg = http.STATUS_CODES[res.status] || msg;
+      }
+      err = new Error(msg);
+      err.status = res ? res.status : undefined;
+    } catch (new_err) {
+      err = new_err;
     }
-    err = new Error(msg);
-    err.status = res ? res.status : undefined;
   }
 
   err.response = res;

--- a/test/basic.js
+++ b/test/basic.js
@@ -182,6 +182,22 @@ describe('request', function(){
         assert.equal(err.message, 'OK');
       });
     })
+
+    it('with .ok() throwing an Error', function(){
+      if ('undefined' === typeof Promise) {
+        return;
+      }
+
+      return request
+      .get(uri + '/echo')
+      .ok(function() {throw new Error('boom');})
+      .then(function(){
+        assert.fail();
+      }, function(err){
+        assert.equal(200, err.response.status);
+        assert.equal(err.message, 'boom');
+      });
+    })
   })
 
   describe('res.header', function(){


### PR DESCRIPTION
This patch wraps `_isResponseOk` in a try/catch block and passes along the caught error. The client version of superagent already appears to be doing this properly.

Fixes #1247 