### PR TITLE
Don't pop last array element when parsing a header.

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -220,11 +220,12 @@ function parseHeader(str) {
   var field;
   var val;
 
-  lines.pop(); // trailing CRLF
-
   for (var i = 0, len = lines.length; i < len; ++i) {
     line = lines[i];
     index = line.indexOf(':');
+    if (index === -1) { // could be empty line, just skip it
+      continue;
+    }
     field = line.slice(0, index).toLowerCase();
     val = trim(line.slice(index + 1));
     fields[field] = val;


### PR DESCRIPTION
`xhr.getAllResponseHeaders()` may actually return a header string without trailing `\r\n`.

Fixes #1295.