### PR TITLE
Document that 3xx status codes are errors

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -556,7 +556,7 @@ An "error" event is also emitted, with you can listen for:
 
       });
 
-Note that **superagent considers 3xx, 4xx and 5xx status codes errors by default**. For example if you get a 500 or 403 response, this status information will be available via `err.status`. Errors from such responses also contain an `err.response` field with all of the properties mentioned in "[Response properties](#response-properties)". The library behaves in this way to handle the common case of wanting success responses and treating HTTP error status codes as errors while still allowing for custom logic around specific error conditions.
+Note that **superagent considers 4xx and 5xx responses (as well as unhandled 3xx responses) errors by default**. For example, if you get a `304 Not modified`, `403 Forbidden` or `500 Internal server error` response, this status information will be available via `err.status`. Errors from such responses also contain an `err.response` field with all of the properties mentioned in "[Response properties](#response-properties)". The library behaves in this way to handle the common case of wanting success responses and treating HTTP error status codes as errors while still allowing for custom logic around specific error conditions.
 
 Network failures, timeouts, and other errors that produce no response will contain no `err.status` or `err.response` fields.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -556,7 +556,7 @@ An "error" event is also emitted, with you can listen for:
 
       });
 
-Note that a 4xx or 5xx response with super agent **are** considered an error by default. For example if you get a 500 or 403 response, this status information will be available via `err.status`. Errors from such responses also contain an `err.response` field with all of the properties mentioned in "[Response properties](#response-properties)". The library behaves in this way to handle the common case of wanting success responses and treating HTTP error status codes as errors while still allowing for custom logic around specific error conditions.
+Note that **superagent considers 3xx, 4xx and 5xx status codes errors by default**. For example if you get a 500 or 403 response, this status information will be available via `err.status`. Errors from such responses also contain an `err.response` field with all of the properties mentioned in "[Response properties](#response-properties)". The library behaves in this way to handle the common case of wanting success responses and treating HTTP error status codes as errors while still allowing for custom logic around specific error conditions.
 
 Network failures, timeouts, and other errors that produce no response will contain no `err.status` or `err.response` fields.
 


### PR DESCRIPTION
According to the discussion in #283 as well as [the code in the latest release](https://github.com/visionmedia/superagent/blob/v3.7.0/lib/request-base.js#L230), 3xx responses are considered errors by default.

This PR increases clarity about this point in the docs.