### PR TITLE
Do not parse json-seq as json

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -243,7 +243,9 @@ function parseHeader(str) {
  */
 
 function isJSON(mime) {
-  return /[\/+]json\b/.test(mime);
+  // should match /json or +json
+  // but not /json-seq
+  return /[\/+]json($|[^-\w])/.test(mime);
 }
 
 /**

--- a/lib/node/index.js
+++ b/lib/node/index.js
@@ -1064,7 +1064,9 @@ function isImageOrVideo(mime) {
  */
 
 function isJSON(mime) {
-  return /[\/+]json\b/.test(mime);
+  // should match /json or +json
+  // but not /json-seq
+  return /[\/+]json($|[^-\w])/.test(mime);
 }
 
 /**

--- a/test/request.js
+++ b/test/request.js
@@ -518,6 +518,19 @@ it('GET json', function(next){
   });
 });
 
+it('GET json-seq', function(next){
+  request
+  .get(uri + '/json-seq')
+  .buffer()
+  .end(function(err, res){
+    try{
+    assert.ifError(err);
+    assert.deepEqual(res.text, '\x1e{"id":1}\n\x1e{"id":2}\n');
+    next();
+    } catch(e) { next(e); }
+  });
+});
+
 it('GET x-www-form-urlencoded', function(next){
   request
   .get(uri + '/foo')

--- a/test/support/server.js
+++ b/test/support/server.js
@@ -248,6 +248,10 @@ app.get('/pets', function(req, res){
   res.send(['tobi', 'loki', 'jane']);
 });
 
+app.get('/json-seq', function(req, res){
+  res.set('content-type', 'application/json-seq').send('\x1e{"id":1}\n\x1e{"id":2}\n');
+});
+
 app.get('/invalid-json', function(req, res) {
   res.set('content-type', 'application/json');
   // sample invalid json taken from https://github.com/swagger-api/swagger-ui/issues/1354


### PR DESCRIPTION
There's an odd mimetype `json-seq` which is a delimited series of JSON
objects (see [RFC 7464](https://tools.ietf.org/html/rfc7464)).

This format is not parseable JSON, so `isJSON('application/json-seq')`
should return `false`.