### PR TITLE
Trim response text before parsing as JSON.

### DIFF
--- a/lib/node/parsers/json.js
+++ b/lib/node/parsers/json.js
@@ -8,7 +8,7 @@ module.exports = function parseJSON(res, fn){
   });
   res.on('end', () => {
     try {
-      var body = res.text && JSON.parse(res.text);
+      var body = res.text && JSON.parse(res.text.trim());
     } catch (e) {
       var err = e;
       // issue #675: return the raw response if the response parsing fails


### PR DESCRIPTION
Hello,

One of our internal APIs adds whitespace before returning a JSON list. (i.e. `' ["foo", "bar"]'`). I've been able to make it work by copying your JSON parser and trimming the response text.

I thought that perhaps this tweak could benefit others as well, so I made this pull request. Hope it's okay. :)

Cheers,
John