### PR TITLE
[node] Emit progress event while uploading Buffer via send method

### DIFF
--- a/lib/node/index.js
+++ b/lib/node/index.js
@@ -978,7 +978,7 @@ Request.prototype._end = function() {
     const remainder = totalLength % chunkSize;
     const cutoff = totalLength - remainder;
 
-    for (let i = 0 ; i < cutoff ; i += chunkSize) {
+    for (let i = 0; i < cutoff; i += chunkSize) {
       const chunk = buffer.slice(i, i + chunkSize);
       chunking.push(chunk);
     }
@@ -1016,9 +1016,7 @@ Request.prototype._end = function() {
       formData.pipe(getProgressMonitor()).pipe(req);
     });
   } else if (Buffer.isBuffer(data)) {
-    bufferToChunks(data)
-      .pipe(getProgressMonitor())
-      .pipe(req);
+    bufferToChunks(data).pipe(getProgressMonitor()).pipe(req);
   } else {
     req.end(data);
   }

--- a/lib/node/index.js
+++ b/lib/node/index.js
@@ -952,6 +952,47 @@ Request.prototype._end = function() {
 
   this.emit('request', this);
 
+  const getProgressMonitor = () => {
+    const lengthComputable = true;
+    const total = req.getHeader('Content-Length');
+    let loaded = 0;
+
+    const progress = new Stream.Transform();
+    progress._transform = (chunk, encoding, cb) => {
+      loaded += chunk.length;
+      this.emit('progress', {
+        direction: 'upload',
+        lengthComputable,
+        loaded,
+        total,
+      });
+      cb(null, chunk);
+    };
+    return progress;
+  };
+
+  const bufferToChunks = (buffer) => {
+    const chunkSize = 16 * 1024; // default highWaterMark value
+    const chunking = new Stream.Readable();
+    const totalLength = buffer.length;
+    const remainder = totalLength % chunkSize;
+    const cutoff = totalLength - remainder;
+
+    for (let i = 0 ; i < cutoff ; i += chunkSize) {
+      const chunk = buffer.slice(i, i + chunkSize);
+      chunking.push(chunk);
+    }
+
+    if (remainder > 0) {
+      const remainderBuffer = buffer.slice(-remainder);
+      chunking.push(remainderBuffer);
+    }
+
+    chunking.push(null); // no more data
+
+    return chunking;
+  }
+
   // if a FormData instance got created, then we send that as the request body
   const formData = this._formData;
   if (formData) {
@@ -971,27 +1012,13 @@ Request.prototype._end = function() {
       if ('number' == typeof length) {
         req.setHeader('Content-Length', length);
       }
-
-      const getProgressMonitor = () => {
-        const lengthComputable = true;
-        const total = req.getHeader('Content-Length');
-        let loaded = 0;
-
-        const progress = new Stream.Transform();
-        progress._transform = (chunk, encoding, cb) => {
-          loaded += chunk.length;
-          this.emit('progress', {
-            direction: 'upload',
-            lengthComputable,
-            loaded,
-            total,
-          });
-          cb(null, chunk);
-        };
-        return progress;
-      };
+      
       formData.pipe(getProgressMonitor()).pipe(req);
     });
+  } else if (Buffer.isBuffer(data)) {
+    bufferToChunks(data)
+      .pipe(getProgressMonitor())
+      .pipe(req);
   } else {
     req.end(data);
   }


### PR DESCRIPTION
Hi!

Superagent is awesome and it allows to upload node Buffers like this `req.send(buffer)...` - this is exactly what we need. Unfortunately, `.on('progress', ...)` does not work in this case, this PR solves the problem.

Please let me know if you have any questions/considerations or see any issues.



  
  