### PR TITLE
Allow default buffer settings based on response-type.

### DIFF
--- a/lib/node/index.js
+++ b/lib/node/index.js
@@ -852,7 +852,7 @@ Request.prototype._end = function() {
       unzip(req, res);
     }
 
-    if (buffer === undefined && exports.buffer[mime] !== undefined){
+    if (buffer === undefined && mime in exports.buffer){
       buffer = !!exports.buffer[mime];
     }
 

--- a/lib/node/index.js
+++ b/lib/node/index.js
@@ -108,6 +108,15 @@ exports.serialize = {
 
 exports.parse = require('./parsers');
 
+
+/**
+ * Default buffering map. Can be used to set certain
+ * response types to buffer/not buffer.
+ *
+ *     superagent.buffer['application/xml'] = true;
+ */
+exports.buffer = {};
+
 /**
  * Initialize internal header tracking properties on a request instance.
  *
@@ -841,6 +850,10 @@ Request.prototype._end = function() {
     // zlib support
     if (this._shouldUnzip(res)) {
       unzip(req, res);
+    }
+
+    if (buffer === undefined && exports.buffer[mime] !== undefined){
+      buffer = !!exports.buffer[mime];
     }
 
     if (!parser) {

--- a/test/node/buffers.js
+++ b/test/node/buffers.js
@@ -1,0 +1,117 @@
+"use strict";
+const assert = require("assert");
+const request = require("../../");
+const setup = require("../support/setup");
+const base = setup.uri;
+
+describe("req.buffer['someMimeType']", () => {
+
+    it('should respect that agent.buffer(true) takes precedent', () => {
+        const agent = request.agent();
+        agent.buffer(true);
+        const type = 'application/somerandomtype';
+        const send = 'somerandomtext';
+        request.buffer[type] = false;
+        agent
+            .post(`${base}/echo`)
+            .type(type)
+            .send(send)
+            .end((err, res) => {
+                delete request.buffer[type];
+                assert.equal(null, err);
+                assert.equal(res.type, type);
+                assert.equal(send, res.text);
+                assert(res.buffered);
+                done();
+            })
+    });
+
+    it('should respect that agent.buffer(false) takes precedent', () => {
+        const agent = request.agent();
+        agent.buffer(false);
+        const type = 'application/barrr';
+        const send = 'some random text2';
+        request.buffer[type] = true;
+        agent
+            .post(`${base}/echo`)
+            .type(type)
+            .send(send)
+            .end((err, res) => {
+                delete request.buffer[type];
+                assert.equal(null, err);
+                assert.equal(null, res.text);
+                assert.equal(res.type, type);
+                assert(!res.buffered);
+                res.body.should.eql({});
+                let buf = "";
+                res.setEncoding("utf8");
+                res.on("data", chunk => {
+                    buf += chunk;
+                });
+                res.on("end", () => {
+                    buf.should.equal(send);
+                    done();
+                });
+            });
+    });
+
+    it("should disable buffering for that mimetype when false", done => {
+        const type = 'application/bar';
+        const send = 'some random text';
+        request.buffer[type] = false;
+        request
+            .post(`${base}/echo`)
+            .type(type)
+            .send(send)
+            .end((err, res) => {
+                delete request.buffer[type];
+                assert.equal(null, err);
+                assert.equal(null, res.text);
+                assert.equal(res.type, type);
+                assert(!res.buffered);
+                res.body.should.eql({});
+                let buf = "";
+                res.setEncoding("utf8");
+                res.on("data", chunk => {
+                    buf += chunk;
+                });
+                res.on("end", () => {
+                    buf.should.equal(send);
+                    done();
+                });
+            });
+    });
+    it('should enable buffering for that mimetype when true', done => {
+        const type = 'application/baz';
+        const send = 'woooo';
+        request.buffer[type] = true;
+        request
+            .post(`${base}/echo`)
+            .type(type)
+            .send(send)
+            .end((err, res) => {
+                delete request.buffer[type];
+                assert.equal(null, err);
+                assert.equal(res.type, type);
+                assert.equal(send, res.text);
+                assert(res.buffered);
+                done();
+            })
+    });
+    it('should fallback to default handling for that mimetype when undefined', done => {
+        const type = 'application/bazzz';
+        const send = 'woooooo';
+        request
+            .post(`${base}/echo`)
+            .type(type)
+            .send(send)
+            .end((err, res) => {
+                assert.equal(null, err);
+                assert.equal(null, res.text);
+                assert.equal(res.type, type);
+                assert(!res.buffered);
+                res.body.should.eql({});
+                done();
+            })
+    })
+});

--- a/test/node/exports.js
+++ b/test/node/exports.js
@@ -23,4 +23,8 @@ describe("exports", () => {
       "image",
     ]);
   });
+
+  it("should export .buffer", () => {
+    Object.keys(request.buffer).should.eql([]);
+  });
 });


### PR DESCRIPTION
I often use superagent to make requests to API's returning XML responses. In order to parse the response body, I need to call the buffer() method everytime, which gets tedious. 

I added a buffer field on the superagent object so that you can define certain response-types to be buffered or not buffered by default. I don't believe that it is a breaking change, and I think it might be useful to both me and other users of superagent.