### PR TITLE
return immediately from .end if request is already aborted (pre-flight abort)

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -662,6 +662,10 @@ Request.prototype._isHost = function _isHost(obj) {
  */
 
 Request.prototype.end = function(fn){
+  if (this._aborted) {
+    return this;
+  }
+  
   if (this._endCalled) {
     console.warn("Warning: .end() was called twice. This is not supported in superagent");
   }


### PR DESCRIPTION
Hello, I've noticed that if I do the following:

```js
const myRequest = request.get("/whatever");
const myPromise = Promise.resolve(myRequest);
myRequest.abort();
```

...the request is executed anyway, seemingly because the standard `Promise.resolve` calls `.then` on the provided argument asynchronously. (observed today in Chrome 64.0.3282.119)

This PR theoretically solves this for both Promises and traditional `.end` by ignoring `.end` calls if `this._aborted` is already `true` at call time.

This may have undesired effects; for example, the promise created above when `req.then` is called is never resolved nor rejected, though I believe this is currently the case if any in-flight request is aborted.

Just curious whether pre-flight abort is a case y'all would be willing to support. I would be willing to address further concerns + add tests if it is something you would accept.

Thanks!