### PR TITLE
feat: Leave backticks unencoded in query strings where possible

### DIFF
--- a/lib/node/index.js
+++ b/lib/node/index.js
@@ -597,9 +597,30 @@ Request.prototype.request = function(){
   let url = this.url;
   const retries = this._retries;
 
+  // Capture backticks as-is from the final query string built above.
+  // Note: this'll only find backticks entered in req.query(String)
+  // calls, because qs.stringify unconditionally encodes backticks.
+  let queryStringBackticks;
+  if(url.indexOf('`') > -1) {
+    const queryStartIndex = url.indexOf("?");
+
+    if(queryStartIndex !== -1) {
+      const queryString = url.substr(queryStartIndex + 1);
+      queryStringBackticks = queryString.match(/`|\%60/g);
+    }
+  }
+
   // default to http://
   if (0 != url.indexOf('http')) url = `http://${url}`;
   url = parse(url);
+
+  // See https://github.com/visionmedia/superagent/issues/1367
+  if(queryStringBackticks) {
+    let i = 0;
+    url.query = url.query.replace(/\%60/g, () => queryStringBackticks[i++]);
+    url.search = '?' + url.query;
+    url.path = url.pathname + url.search;
+  }
 
   // support unix sockets
   if (/^https?\+unix:/.test(url.protocol) === true) {
@@ -1030,7 +1051,7 @@ Request.prototype._end = function() {
       if ('number' == typeof length) {
         req.setHeader('Content-Length', length);
       }
-      
+
       formData.pipe(getProgressMonitor()).pipe(req);
     });
   } else if (Buffer.isBuffer(data)) {

--- a/test/client/serialize.js
+++ b/test/client/serialize.js
@@ -30,6 +30,7 @@ describe('request.serializeObject()', function(){
     serialize({ name: 'tj', age: 24 }, 'name=tj&age=24');
     serialize({ name: '&tj&' }, 'name=%26tj%26');
     serialize({ '&name&': 'tj' }, '%26name%26=tj');
+    serialize({ hello: "`test`" }, "hello=%60test%60");
   });
 });
 
@@ -40,6 +41,7 @@ describe('request.parseString()', function(){
     parse('redirect=/&ok', { redirect: '/', ok: '' });
     parse('%26name=tj', { '&name': 'tj' });
     parse('name=tj%26', { name: 'tj&' });
+    parse("%60", { "`": "" });
   });
 });
 


### PR DESCRIPTION
Addresses #1367 as discussed. See the commit message for details.  I’m not that familiar with the superagent code base (especially around how code is shared between the Node and browser versions), so please let me know if you think this is missing anything. 

This PR leaves the behavior of `req.query(Object)` the same as it is now. I also worked up a [slightly different version](https://github.com/ethanresnick/superagent/commit/d4380735898076914e52887379b393aba0fa1167) that changes `req.query(Object)` to not encode any backticks provided in a key/value of the object. That approach has some pros and cons (also discussed in the commit message), but you can check out the code for it if you're curious. I think I slightly prefer this version, but I could probably go either way. 