### PR TITLE
Access cookie in headers correctly

### DIFF
--- a/lib/node/index.js
+++ b/lib/node/index.js
@@ -695,10 +695,10 @@ Request.prototype.request = function(){
 
   // add cookies
   if (this.cookies) {
-    if(this.header.hasOwnProperty('cookie')) {
+    if(this._header.hasOwnProperty('cookie')) {
       // merge
       const tmpJar = new CookieJar.CookieJar();
-      tmpJar.setCookies(this.header.cookie.split(';'));
+      tmpJar.setCookies(this._header.cookie.split(';'));
       tmpJar.setCookies(this.cookies.split(';'));
       req.setHeader('Cookie',tmpJar.getCookies(CookieJar.CookieAccessInfo.All).toValueString());
     } else {

--- a/test/node/redirects.js
+++ b/test/node/redirects.js
@@ -44,6 +44,28 @@ describe("request", () => {
       });
     })
 
+    it("should have previously set cookie for subsquent requests when agent is used", done => {
+      const agent = request.agent();
+      agent
+      .get(`${base}/set-cookie`)
+      .end((err) => {
+        assert.ifError(err);
+        agent
+        .get(`${base}/show-cookies`)
+        .set({'Cookie': 'orig=1'})
+        .end((err, res) => {
+          try {
+            assert.ifError(err);
+            assert(/orig=1/.test(res.text), "orig=1/.test");
+            assert(/persist=123/.test(res.text), "persist=123");
+            done();
+          } catch(err) {
+            done(err);
+          }
+        });
+      });
+    })
+
     it("should follow Location", done => {
       const redirects = [];
 

--- a/test/support/server.js
+++ b/test/support/server.js
@@ -351,10 +351,15 @@ app.options('/options/echo/body', bodyParser.json(), (req, res) => {
 app.get('/cookie-redirect', (req, res) => {
   res.set("Set-Cookie", "replaced=yes");
   res.append("Set-Cookie", "from-redir=1", true);
-  res.redirect(303, '/cookie-redirect-2');
+  res.redirect(303, '/show-cookies');
 });
 
-app.get('/cookie-redirect-2', (req, res) => {
+app.get('/set-cookie', (req, res) => {
+  res.cookie('persist', '123');
+  res.send('ok');
+});
+
+app.get('/show-cookies', (req, res) => {
   res.set('content-type', 'text/plain');
   res.send(req.headers.cookie);
 });


### PR DESCRIPTION
Cookies laid in a previous request were not being merged with a new request due to the header being `Cookie` rather than `cookie`. This uses the internal `_headers` object where keys are coerced to be lowercase to fix this.