### PR TITLE
keep upload alive for large files or slow connections

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -709,6 +709,14 @@ Request.prototype._end = function() {
 
   // progress
   const handleProgress = (direction, e) => {
+    // reset 'deadline' timer if still sending data
+    if (self._timer) {
+      clearTimeout(self._timer);
+    }
+    // reset 'timeout' timer if still sending data
+    if (self._responseTimeoutTimer) {
+      clearTimeout(self._responseTimeoutTimer);
+    }
     if (e.total > 0) {
       e.percent = e.loaded / e.total * 100;
     }


### PR DESCRIPTION
Addresses issue #1374

Keeps upload alive for very large files or slow connections, resets deadline/timeout timers while data is still being sent over the wire.

I have tested the fix with network throttling using Chrome DevTools, also tested on a real project. However I cannot find a way to create a unit test that has slow upload with progress updates simulated.