### PR TITLE
Update dependency 'cookiejar' to version 2.1.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "dependencies": {
     "component-emitter": "^1.2.0",
-    "cookiejar": "^2.1.0",
+    "cookiejar": "^2.1.2",
     "debug": "^3.1.0",
     "extend": "^3.0.0",
     "form-data": "^2.3.2",


### PR DESCRIPTION
This fixes an issue seen sometimes when using superagent in node.js. The an error is thrown when an agent is used and the server send invalid `Set-Cookie` headers. The package [x-ray](https://github.com/matthewmueller/x-ray), which relies on [x-ray-crawler](https://github.com/lapwinglabs/x-ray-crawler), which relies on superagent, has an example of this problem seen here: https://github.com/matthewmueller/x-ray/issues/234.