### PR TITLE
fix req.serialize in node

### DIFF
--- a/lib/node/index.js
+++ b/lib/node/index.js
@@ -875,7 +875,7 @@ Request.prototype._end = function() {
       let contentType = req.getHeader('Content-Type');
       // Parse out just the content type from the header (ignore the charset)
       if (contentType) contentType = contentType.split(';')[0];
-      let serialize = exports.serialize[contentType];
+      let serialize = this._serializer || exports.serialize[contentType];
       if (!serialize && isJSON(contentType)) {
         serialize = exports.serialize['application/json'];
       }

--- a/test/node/serialize.js
+++ b/test/node/serialize.js
@@ -1,0 +1,21 @@
+"use strict";
+
+const request = require("../support/client");
+const setup = require("../support/setup");
+const base = setup.uri;
+const assert = require("assert");
+
+describe("req.serialize(fn)", () => {
+  it("should take precedence over default parsers", done => {
+    request
+      .post(`${base}/echo`)
+      .send({foo:123})
+      .serialize(data => '{"bar":456}')
+      .end((err, res) => {
+        assert.ifError(err);
+        assert.equal('{"bar":456}', res.text);
+        assert.equal(456, res.body.bar);
+        done();
+      });
+  });
+});


### PR DESCRIPTION
`request.serialize(fn)` is not working in Node.  This patch uses user specified `_serializer` in case it exists.

Fixes #1141 