### PR TITLE
Adding link to new cheerio plugin

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -67,6 +67,7 @@ Existing plugins:
  * [superagent-throttle](https://github.com/leviwheatcroft/superagent-throttle) - queues and intelligently throttles requests
  * [superagent-charset](https://github.com/magicdawn/superagent-charset) - add charset support for node's SuperAgent
  * [superagent-verbose-errors](https://github.com/jcoreio/superagent-verbose-errors) - include response body in error messages for failed requests
+ * [superagent-cheerio](https://github.com/mmmmmrob/superagent-cheerio) - include cheerio as `res.$` on html responses
 
 Please prefix your plugin with `superagent-*` so that it can easily be found by others.
 


### PR DESCRIPTION
Simple plugin that adds cheerio to html responses, useful when testing server-side rendering with supertest.