### PR TITLE
chore: fix typo in readme

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -2,7 +2,7 @@
 
 [![Sauce Test Status](https://saucelabs.com/browser-matrix/shtylman-superagent.svg)](https://saucelabs.com/u/shtylman-superagent)
 
-SuperAgent is a small progressive __client-side__ and __Node.js__ HTTP request library, sporting many high-level HTTP client features. View the [docs](https://visionmedia.github.io/superagent/).
+SuperAgent is a small progressive __client-side__ and __Node.js__ HTTP request library, supporting many high-level HTTP client features. View the [docs](https://visionmedia.github.io/superagent/).
 
 ![super agent](http://f.cl.ly/items/3d282n3A0h0Z0K2w0q2a/Screenshot.png)
 


### PR DESCRIPTION
Replaced `sporting` with `supporting`.