### PR TITLE
There is a bug in JSON parsing

### DIFF
--- a/lib/node/parsers/json.js
+++ b/lib/node/parsers/json.js
@@ -8,7 +8,7 @@ module.exports = function parseJSON(res, fn){
   });
   res.on('end', () => {
     try {
-      var body = res.text && JSON.parse(res.text);
+      var body = res.text.trim() && JSON.parse(res.text.trim());
     } catch (e) {
       var err = e;
       // issue #675: return the raw response if the response parsing fails


### PR DESCRIPTION
I am using a WordPress API module in NodeJS ( https://github.com/WP-API/node-wpapi )
When I make API requests ; it gets the json data , but causes an error .
When I open the stacktrace :

{ SyntaxError: Unexpected token ﻿ in JSON at position 0 at JSON.parse (<anonymous>) at IncomingMessage.res.on (C:\cde\fn\notification-stream\node_modules\superagent\lib\node\parsers\json.js:11:35) at IncomingMessage.emit (events.js:187:15) at endReadableNT (_stream_readable.js:1092:12) at process._tickCallback (internal/process/next_tick.js:63:19)

When I examine the file superagent/lib/node/parsers/json.js , I found a bug in how it parses JSON .


I added the .trim() to ensure that there is no space in the string just before it is parsed