### PR TITLE
Resolve IE issue that cannot understand arrow function

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -48,7 +48,7 @@ exports.Request = Request;
  * Determine XHR.
  */
 
-request.getXHR = () => {
+request.getXHR = function() {
   if (root.XMLHttpRequest
       && (!root.location || 'file:' != root.location.protocol
           || !root.ActiveXObject)) {
@@ -723,7 +723,7 @@ Request.prototype._end = function() {
 
     if (e.total > 0) {
       e.percent = e.loaded / e.total * 100;
-      
+
       if(e.percent === 100) {
          clearTimeout(self._uploadTimeoutTimer);
       }


### PR DESCRIPTION
![screenshot 2019-03-05 at 11 31 22 am](https://user-images.githubusercontent.com/156895/53779196-403e7980-3f3a-11e9-92e6-fee3d61007a7.png)

- IE 11 cannot understand arrow function