### PR TITLE
Fix handling of FormData errors

### DIFF
--- a/lib/node/index.js
+++ b/lib/node/index.js
@@ -264,7 +264,13 @@ Request.prototype._getFormData = function() {
   if (!this._formData) {
     this._formData = new FormData();
     this._formData.on('error', err => {
-      this.emit('error', err);
+      debug('FormData error', err);
+      if (this.called) {
+        // The request has already finished and the callback was called.
+        // Silently ignore the error.
+        return;
+      }
+      this.callback(err);
       this.abort();
     });
   }

--- a/lib/request-base.js
+++ b/lib/request-base.js
@@ -242,7 +242,6 @@ RequestBase.prototype.then = function then(resolve, reject) {
       console.warn("Warning: superagent request was sent twice, because both .end() and .then() were called. Never call .end() if you use promises");
     }
     this._fullfilledPromise = new Promise((innerResolve, innerReject) => {
-      self.on('error', innerReject);
       self.on('abort', () => {
         const err = new Error('Aborted');
         err.code = "ABORTED";


### PR DESCRIPTION
This patch is fixing regression introduced by https://github.com/visionmedia/superagent/commit/6670a0fb708fef3d8e09538ee8af6c73f682f346, see https://github.com/visionmedia/superagent/issues/1466 for detailed discussion.

/cc @kornelski  @lapo-luchini

I have verified the fix by running the following test manually. ~~Please advise me how to capture these test cases in your automated test suite.~~

The first two use cases are already captured in the existing test suite, so I updated the existing tests to match the new behavior. Then I added two new tests to verify what happens when two errors are triggered by a single request (the last case below).

```js
// remote host is listening, attaching a missing file
// PROMISE VARIANT
require('.').post('http://example.com/does-not-exist')
.field({a:1,b:2})
.attach('c', 'does-not-exists.txt')
//.on('error', e => console.log('ERR', e.message))
.then(ok => console.log('THEN'))
.catch(e => console.log('CATCH', e.message));

// remote host is listening, attaching a missing file
// CALLBACK VARIANT
require('.').post('http://example.com/does-not-exist')
  .field({a:1,b:2})
  .attach('c', 'does-not-exists.txt')
  //.on('error', e => console.log('ERR', e.message))
  .end((err, res) => {
    if (err) console.log('CATCH', err && err.message);
    else console.log('THEN');
  });

// remote host is not listening
// two errors are triggered: cannot read the file, cannot connect to 127.0.0.1:80
require('.').post('http://127.0.0.1/test')
.field({a:1,b:2})
.attach('c', 'does-not-exists.txt')
//.on('error', e => console.log('ERR', e.message))
.then(ok => console.log('THEN'))
.catch(e => console.log('CATCH', e.message));
```