### PR TITLE
Invalid redirect in pipe

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ coverage
 .nyc_output
 lib
 dist
+*.swp

--- a/src/node/index.js
+++ b/src/node/index.js
@@ -423,9 +423,10 @@ Request.prototype.pipe = function(stream, options) {
 Request.prototype._pipeContinue = function(stream, options) {
   this.req.once('response', res => {
     // redirect
-    const redirect = isRedirect(res.statusCode);
-    if (redirect && this._redirects++ !== this._maxRedirects) {
-      return this._redirect(res)._pipeContinue(stream, options);
+    if (isRedirect(res.statusCode) && this._redirects++ != this._maxRedirects) {
+      return this._redirect(res) === this
+        ? this._pipeContinue(stream, options)
+        : void 0;
     }
 
     this.res = res;

--- a/src/node/index.js
+++ b/src/node/index.js
@@ -423,10 +423,13 @@ Request.prototype.pipe = function(stream, options) {
 Request.prototype._pipeContinue = function(stream, options) {
   this.req.once('response', res => {
     // redirect
-    if (isRedirect(res.statusCode) && this._redirects++ != this._maxRedirects) {
+    if (
+      isRedirect(res.statusCode) &&
+      this._redirects++ !== this._maxRedirects
+    ) {
       return this._redirect(res) === this
         ? this._pipeContinue(stream, options)
-        : void 0;
+        : undefined;
     }
 
     this.res = res;

--- a/test/node/pipe.js
+++ b/test/node/pipe.js
@@ -17,8 +17,16 @@ app.get('/', (req, res) => {
   fs.createReadStream('test/node/fixtures/user.json').pipe(res);
 });
 
-app.post('/', (req, res) => {
-  if (process.env.HTTP2_TEST) {
+app.get("/redirect", (req, res) => {
+  res.set('Location', '/').sendStatus(302);
+});
+
+app.get("/badRedirectNoLocation", (req, res) => {
+  res.set('Location', '').sendStatus(302);
+});
+
+app.post("/", (req, res) => {
+  if (process.env.HTTP2_TEST){
     // body-parser does not support http2 yet.
     // This section can be remove after body-parser supporting http2.
     res.set('content-type', 'application/json');
@@ -89,6 +97,51 @@ describe('request pipe', () => {
         name: 'tobi'
       });
       responseCalled.should.be.true();
+      done();
+    });
+    req.pipe(stream);
+  });
+
+  it("should follow redirects", done => {
+    const stream = fs.createWriteStream(destPath);
+
+    let responseCalled = false;
+    const req = request.get(base + '/redirect');
+    req.type("json");
+
+    req.on("response", res => {
+      res.status.should.eql(200);
+      responseCalled = true;
+    });
+    stream.on("finish", () => {
+      JSON.parse(fs.readFileSync(destPath, "utf8")).should.eql({
+        name: "tobi",
+      });
+      responseCalled.should.be.true();
+      done();
+    });
+    req.pipe(stream);
+  });
+
+  it("should not throw on bad redirects", done => {
+    const stream = fs.createWriteStream(destPath);
+
+    let responseCalled = false;
+    let errorCalled = false;
+    const req = request.get(base + '/badRedirectNoLocation');
+    req.type("json");
+
+    req.on("response", res => {
+      responseCalled = true;
+    });
+    req.on("error", err => {
+      err.message.should.eql("No location header for redirect");
+      errorCalled = true;
+      stream.end();
+    });
+    stream.on("finish", () => {
+      responseCalled.should.be.false();
+      errorCalled.should.be.true();
       done();
     });
     req.pipe(stream);

--- a/test/node/pipe.js
+++ b/test/node/pipe.js
@@ -17,16 +17,16 @@ app.get('/', (req, res) => {
   fs.createReadStream('test/node/fixtures/user.json').pipe(res);
 });
 
-app.get("/redirect", (req, res) => {
+app.get('/redirect', (req, res) => {
   res.set('Location', '/').sendStatus(302);
 });
 
-app.get("/badRedirectNoLocation", (req, res) => {
+app.get('/badRedirectNoLocation', (req, res) => {
   res.set('Location', '').sendStatus(302);
 });
 
-app.post("/", (req, res) => {
-  if (process.env.HTTP2_TEST){
+app.post('/', (req, res) => {
+  if (process.env.HTTP2_TEST) {
     // body-parser does not support http2 yet.
     // This section can be remove after body-parser supporting http2.
     res.set('content-type', 'application/json');
@@ -102,20 +102,20 @@ describe('request pipe', () => {
     req.pipe(stream);
   });
 
-  it("should follow redirects", done => {
+  it('should follow redirects', done => {
     const stream = fs.createWriteStream(destPath);
 
     let responseCalled = false;
     const req = request.get(base + '/redirect');
-    req.type("json");
+    req.type('json');
 
-    req.on("response", res => {
+    req.on('response', res => {
       res.status.should.eql(200);
       responseCalled = true;
     });
-    stream.on("finish", () => {
-      JSON.parse(fs.readFileSync(destPath, "utf8")).should.eql({
-        name: "tobi",
+    stream.on('finish', () => {
+      JSON.parse(fs.readFileSync(destPath, 'utf8')).should.eql({
+        name: 'tobi'
       });
       responseCalled.should.be.true();
       done();
@@ -123,23 +123,23 @@ describe('request pipe', () => {
     req.pipe(stream);
   });
 
-  it("should not throw on bad redirects", done => {
+  it('should not throw on bad redirects', done => {
     const stream = fs.createWriteStream(destPath);
 
     let responseCalled = false;
     let errorCalled = false;
     const req = request.get(base + '/badRedirectNoLocation');
-    req.type("json");
+    req.type('json');
 
-    req.on("response", res => {
+    req.on('response', res => {
       responseCalled = true;
     });
-    req.on("error", err => {
-      err.message.should.eql("No location header for redirect");
+    req.on('error', err => {
+      err.message.should.eql('No location header for redirect');
       errorCalled = true;
       stream.end();
     });
-    stream.on("finish", () => {
+    stream.on('finish', () => {
       responseCalled.should.be.false();
       errorCalled.should.be.true();
       done();


### PR DESCRIPTION
There is a bug in redirects during a pipe. If the request responds with a redirect status, but an empty Location header then superagent will throw `Uncaught TypeError: Cannot read property '_pipeContinue' of undefined`.

To reproduce you can checkout my tests (without the patch) and run them. You will see:
```bash
 330 passing (8s)                               
  5 pending                                
  1 failing                                      
                                             
  1) request pipe should not throw on bad redirects:          
     Uncaught TypeError: Cannot read property '_pipeContinue' of undefined
      at ClientRequest.req.once.res (lib/node/index.js:414:33)
      at HTTPParser.parserOnIncomingClient [as onIncoming] (_http_client.js:543:21)
      at HTTPParser.parserOnHeadersComplete (_http_common.js:112:17)
      at Socket.socketOnData (_http_client.js:440:20)
      at addChunk (_stream_readable.js:263:12)
      at readableAddChunk (_stream_readable.js:250:11)
      at Socket.Readable.push (_stream_readable.js:208:10)
      at TCP.onread (net.js:597:20)  
```

or you can reproduce with by hand with something like:

```
http.createServer((req, res) => {
  res.setHeader('Location', '');
  res.statusCode = 302;
  res.end();
}).listen(8000);

require('superagent').get('localhost:8000/').pipe(require('fs').createWriteStream('./temp'));

```