### PR TITLE
fix: omit queries that are set to undefined

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -125,21 +125,23 @@ function serialize(obj) {
  */
 
 function pushEncodedKeyValuePair(pairs, key, val) {
-  if (val !== null) {
-    if (Array.isArray(val)) {
-      val.forEach(v => {
-        pushEncodedKeyValuePair(pairs, key, v);
-      });
-    } else if (isObject(val)) {
-      for (const subkey in val) {
-        if (Object.prototype.hasOwnProperty.call(val, subkey))
-          pushEncodedKeyValuePair(pairs, `${key}[${subkey}]`, val[subkey]);
-      }
-    } else {
-      pairs.push(encodeURIComponent(key) + '=' + encodeURIComponent(val));
-    }
-  } else if (val === null) {
+  if (val === undefined) return;
+  if (val === null) {
     pairs.push(encodeURIComponent(key));
+    return;
+  }
+
+  if (Array.isArray(val)) {
+    val.forEach(v => {
+      pushEncodedKeyValuePair(pairs, key, v);
+    });
+  } else if (isObject(val)) {
+    for (const subkey in val) {
+      if (Object.prototype.hasOwnProperty.call(val, subkey))
+        pushEncodedKeyValuePair(pairs, `${key}[${subkey}]`, val[subkey]);
+    }
+  } else {
+    pairs.push(encodeURIComponent(key) + '=' + encodeURIComponent(val));
   }
 }
 


### PR DESCRIPTION
Fixes #1481.

It seems we already have a [test case](https://github.com/visionmedia/superagent/blob/47f1d2829e5dfd4855a8fac5da388d6ed1067b86/test/client/serialize.js#L32) for this. However I didn't found how to run it.