### PR TITLE
fix: unify "undefined" password treatment for auth()

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -553,7 +553,7 @@ Request.prototype.accept = function(type) {
  */
 
 Request.prototype.auth = function(user, pass, options) {
-  if (arguments.length === 1) pass = '';
+  if (pass === undefined) pass = '';
   if (typeof pass === 'object' && pass !== null) {
     // pass is optional and can be replaced with options
     options = pass;

--- a/src/node/index.js
+++ b/src/node/index.js
@@ -571,7 +571,7 @@ Request.prototype._redirect = function(res) {
  */
 
 Request.prototype.auth = function(user, pass, options) {
-  if (arguments.length === 1) pass = '';
+  if (pass === undefined) pass = '';
   if (typeof pass === 'object' && pass !== null) {
     // pass is optional and can be replaced with options
     options = pass;

--- a/test/node/basic-auth.js
+++ b/test/node/basic-auth.js
@@ -32,14 +32,16 @@ describe('Basic auth', () => {
   });
 
   describe('req.auth(user + ":" + pass)', () => {
-    it('should set authorization', done => {
-      request
-        .get(`${base}/basic-auth/again`)
-        .auth('tobi')
-        .end((err, res) => {
-          res.status.should.eql(200);
-          done();
-        });
-    });
+    it('should set authorization', () =>
+      Promise.all([
+        request
+          .get(`${base}/basic-auth/again`)
+          .auth('tobi')
+          .then(res => res.status.should.eql(200)),
+        request
+          .get(`${base}/basic-auth/again`)
+          .auth('tobi', undefined)
+          .then(res => res.status.should.eql(200))
+      ]));
   });
 });


### PR DESCRIPTION
Using `.auth('tobi')` gives different results than `.auth('tobi', undefined)`. This happens, because in the first case `pass` is [replaced with an empty string based on the args count](https://github.com/visionmedia/superagent/blob/master/src/node/index.js#L574), whilst not being replaced in the second case, [gets stringified](https://github.com/visionmedia/superagent/blob/master/src/request-base.js#L463) to the `'undefined'` string.

Not sure if this is an intended behavior, but imho it's misleading, because in both cases the `pass` is `undefined`. The only difference, is that in the first case it's implicit and explicit in the second one.

This PR unifies treatment of the `undefined` `pass`.