### PR TITLE
Use `res.getHeaders()` to avoid deprecation warning

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,7 @@ test-node:
 	@NODE_ENV=test ./node_modules/.bin/mocha \
 		--require should \
 		--trace-warnings \
+		--throw-deprecation \
 		--reporter $(REPORTER) \
 		--timeout 5000 \
 		$(NODETESTS)
@@ -18,6 +19,7 @@ test-node-http2:
 	@NODE_ENV=test HTTP2_TEST=1 node ./node_modules/.bin/mocha \
 		--require should \
 		--trace-warnings \
+		--throw-deprecation \
 		--reporter $(REPORTER) \
 		--timeout 5000 \
 		$(NODETESTS)

--- a/src/node/index.js
+++ b/src/node/index.js
@@ -506,7 +506,7 @@ Request.prototype._redirect = function(res) {
   if (res.statusCode === 301 || res.statusCode === 302) {
     // strip Content-* related fields
     // in case of POST etc
-    headers = utils.cleanHeader(this.req._headers, changesOrigin);
+    headers = utils.cleanHeader(headers, changesOrigin);
 
     // force GET
     this.method = this.method === 'HEAD' ? 'HEAD' : 'GET';
@@ -519,7 +519,7 @@ Request.prototype._redirect = function(res) {
   if (res.statusCode === 303) {
     // strip Content-* related fields
     // in case of POST etc
-    headers = utils.cleanHeader(this.req._headers, changesOrigin);
+    headers = utils.cleanHeader(headers, changesOrigin);
 
     // force method
     this.method = 'GET';

--- a/src/node/index.js
+++ b/src/node/index.js
@@ -498,7 +498,7 @@ Request.prototype._redirect = function(res) {
   // this is required for Node v0.10+
   res.resume();
 
-  let headers = this.req._headers;
+  let headers = this.req.getHeaders ? this.req.getHeaders() : this.req._headers;
 
   const changesOrigin = parse(url).host !== parse(this.url).host;
 


### PR DESCRIPTION
See #1502