### PR TITLE
Feature disable tls certs

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -302,6 +302,7 @@ In Node.js SuperAgent supports methods to configure HTTPS requests:
 - `.cert()`: Set the client certificate chain(s)
 - `.key()`: Set the client private key(s)
 - `.pfx()`: Set the client PFX or PKCS12 encoded private key and certificate chain
+- `.disableTLSCerts()`: Does not reject expired or invalid TLS certs. Sets internally `rejectUnauthorized=true`. *Be warned, this method allows MITM attacks.*
 
 For more information, see Node.js [https.request docs](https://nodejs.org/api/https.html#https_https_request_options_callback).
 

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "zuul": "^3.12.0"
   },
   "engines": {
-    "node": ">= 6.4.0"
+    "node": ">= 7.0.0"
   },
   "homepage": "https://github.com/visionmedia/superagent",
   "husky": {

--- a/src/agent-base.js
+++ b/src/agent-base.js
@@ -23,7 +23,8 @@ function Agent() {
   'ca',
   'key',
   'pfx',
-  'cert'
+  'cert',
+  'disableTLSCerts'
 ].forEach(fn => {
   // Default setting for all requests from this agent
   Agent.prototype[fn] = function(...args) {

--- a/src/node/agent.js
+++ b/src/node/agent.js
@@ -46,6 +46,10 @@ function Agent(options) {
     if (options.cert) {
       this.cert(options.cert);
     }
+
+    if (options.rejectUnauthorized === false) {
+      this.disableTLSCerts();
+    }
   }
 }
 

--- a/src/node/index.js
+++ b/src/node/index.js
@@ -643,6 +643,19 @@ Request.prototype.cert = function(cert) {
 };
 
 /**
+ * Do not reject expired or invalid TLS certs.
+ * sets `rejectUnauthorized=true`. Be warned that this allows MITM attacks.
+ *
+ * @return {Request} for chaining
+ * @api public
+ */
+
+Request.prototype.disableTLSCerts = function() {
+  this._disableTLSCerts = true;
+  return this;
+};
+
+/**
  * Return an http[s] request.
  *
  * @return {OutgoingMessage}
@@ -743,6 +756,7 @@ Request.prototype.request = function() {
   options.cert = this._cert;
   options.passphrase = this._passphrase;
   options.agent = this._agent;
+  options.rejectUnauthorized = !this._disableTLSCerts;
 
   // Allows request.get('https://1.2.3.4/').set('Host', 'example.com')
   if (this._header.host) {

--- a/test/node/https.js
+++ b/test/node/https.js
@@ -102,6 +102,15 @@ describe('https', () => {
           );
       });
 
+      it('should not reject unauthorized response', () => {
+        return request
+          .get(testEndpoint)
+          .disableTLSCerts()
+          .then(({ status }) => {
+            assert.strictEqual(status, 200);
+          });
+      });
+
       it('should trust localhost unauthorized response', () => {
         return request.get(testEndpoint).trustLocalhost(true);
       });


### PR DESCRIPTION
Tackles Issue #926 by adding a new method `disableTLSCerts` to node client to allow bypassing TLS certificate checks.
