### PR TITLE
fix: Whitelist the 'charset' type param to include it in the response

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -410,7 +410,7 @@ The `res.header` contains an object of parsed header fields, lowercasing field n
 
 ### Response Content-Type
 
-The Content-Type response header is special-cased, providing `res.type`, which is void of the charset (if any). For example the Content-Type of "text/html; charset=utf8" will provide "text/html" as `res.type`, and the `res.charset` property would then contain "utf8".
+The Content-Type response header is special-cased, providing `res.type`, which is void of the charset (if any). For example the Content-Type of "text/html; charset=utf8" will provide "text/html" as `res.type`, and the `res.charset` property would then contain "utf8". All type parameters are also available in `res.typeParams`.
 
 ### Response status
 

--- a/src/response-base.js
+++ b/src/response-base.js
@@ -53,9 +53,12 @@ ResponseBase.prototype.get = function(field) {
  * Set header related properties:
  *
  *   - `.type` the content type without params
+ *   - `.charset` the charset param
+ *   - `.typeParams` all params, including the charset.
  *
  * A response of "Content-Type: text/plain; charset=utf-8"
- * will provide you with a `.type` of "text/plain".
+ * will provide you with a `.type` of "text/plain" and a `.charset`
+ * of "utf-8".
  *
  * @param {Object} header
  * @api private
@@ -70,10 +73,9 @@ ResponseBase.prototype._setHeaderProperties = function(header) {
   this.type = utils.type(ct);
 
   // params
-  const params = utils.params(ct);
-  for (const key in params) {
-    if (Object.prototype.hasOwnProperty.call(params, key))
-      this[key] = params[key];
+  this.typeParams = utils.params(ct);
+  if ('charset' in this.typeParams) {
+    this.charset = this.typeParams.charset;
   }
 
   this.links = {};

--- a/test/basic.js
+++ b/test/basic.js
@@ -263,6 +263,7 @@ describe('request', function() {
       request.get(`${uri}/login`).end((err, res) => {
         try {
           res.charset.should.equal('utf-8');
+          res.typeParams.charset.should.equal('utf-8');
           done();
         } catch (err2) {
           done(err2);
@@ -292,11 +293,29 @@ describe('request', function() {
         try {
           res.type.should.equal('text/html');
           res.charset.should.equal('utf-8');
+          res.typeParams.charset.should.equal('utf-8');
           done();
         } catch (err2) {
           done(err2);
         }
       });
+    });
+
+    it('type handling should avoid polluting the res object', done => {
+      request
+        .put(`${uri}/echo`)
+        .set('Content-Type', 'text/plain; foo=bar')
+        .send('wahoo')
+        .end((err, res) => {
+          try {
+            res.type.should.equal('text/plain');
+            res.should.not.have.property('charset');
+            res.typeParams.foo.should.equal('bar');
+            done();
+          } catch (err2) {
+            done(err2);
+          }
+        });
     });
   });
 

--- a/test/node/utils.js
+++ b/test/node/utils.js
@@ -15,8 +15,10 @@ describe('utils.type(str)', () => {
 describe('utils.params(str)', () => {
   it('should return the field parameters', () => {
     const obj = utils.params('application/json; charset=utf-8; foo  = bar');
-    obj.charset.should.equal('utf-8');
-    obj.foo.should.equal('bar');
+    obj.should.deepEqual({
+      charset: 'utf-8',
+      foo: 'bar'
+    });
 
     utils.params('application/json').should.eql({});
   });

--- a/test/request.js
+++ b/test/request.js
@@ -593,6 +593,7 @@ describe('request', function() {
     request.get(`${uri}/text`).end((err, res) => {
       try {
         assert.equal('utf-8', res.charset);
+        assert.equal('utf-8', res.typeParams.charset);
         next();
       } catch (err2) {
         next(err2);


### PR DESCRIPTION
Other params are put in a `typeParams` property.
Fixes #1513