### PR TITLE
Improve .retry() method functionality with delays and prevent calling on successful request

### DIFF
--- a/.dist.babelrc
+++ b/.dist.babelrc
@@ -6,5 +6,7 @@
       }
     }]
   ],
-  "sourceMaps": "inline"
+    "plugins": [
+      ["@babel/plugin-transform-runtime"]
+  ]
 }

--- a/.dist.eslintrc
+++ b/.dist.eslintrc
@@ -18,7 +18,8 @@
     "no-useless-escape": "off",
     "no-cond-assign": "off",
     "no-redeclare": "off",
-    "node/no-exports-assign": "off"
+    "no-fallthrough": "off",
+    "no-constant-condition": "off"
   },
   "globals": {
     "regeneratorRuntime": "writable"

--- a/.lib.babelrc
+++ b/.lib.babelrc
@@ -7,5 +7,7 @@
       }
     }]
   ],
-  "sourceMaps": "inline"
+    "plugins": [
+      ["@babel/plugin-transform-runtime"]
+  ]
 }

--- a/.lib.eslintrc
+++ b/.lib.eslintrc
@@ -11,7 +11,8 @@
     "node/no-unsupported-features/node-builtins": "off",
     "no-func-assign": "off",
     "no-global-assign": ["error", {"exceptions": ["exports"]}],
-    "node/no-exports-assign": "off"
+    "no-fallthrough": "off",
+    "no-constant-condition": "off"
   },
   "overrides": [
     {

--- a/docs/index.md
+++ b/docs/index.md
@@ -246,6 +246,15 @@ This method has two optional arguments: number of retries (default 1) and a call
        .then(finished);
        .catch(failed);
 
+The callback supplied can be async if you need to await any data or to create a delay before retrying. This code will retry 10 times, with a 3 second delay between each retry. To add a delay:
+
+         .retry(10, async function(err, res) {
+          let delay = 3000; // ms
+          log.error(`Request failed, retrying in ${delay / 1000} seconds ...`);
+          await new Promise(resolve => setTimeout(() => resolve(), delay));
+          return true;
+        })
+
 Use `.retry()` only with requests that are *idempotent* (i.e. multiple requests reaching the server won't cause undesirable side effects like duplicate purchases).
 
 ## Setting Accept

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "Nick Baugh <niftylettuce@gmail.com>"
   ],
   "dependencies": {
+    "@babel/runtime": "7.4.5",
     "component-emitter": "^1.3.0",
     "cookiejar": "^2.1.2",
     "debug": "^4.1.1",

--- a/src/client.js
+++ b/src/client.js
@@ -647,7 +647,7 @@ Request.prototype._getFormData = function() {
  */
 
 Request.prototype.callback = async function(err, res) {
-  if (await this._shouldRetry(err, res)) {
+  if (err !== null && await this._shouldRetry(err, res)) {
     return this._retry();
   }
 

--- a/src/client.js
+++ b/src/client.js
@@ -647,7 +647,7 @@ Request.prototype._getFormData = function() {
  */
 
 Request.prototype.callback = async function(err, res) {
-  if (err !== null && await this._shouldRetry(err, res)) {
+  if (err !== null && (await this._shouldRetry(err, res))) {
     return this._retry();
   }
 

--- a/src/client.js
+++ b/src/client.js
@@ -646,8 +646,8 @@ Request.prototype._getFormData = function() {
  * @api private
  */
 
-Request.prototype.callback = function(err, res) {
-  if (this._shouldRetry(err, res)) {
+Request.prototype.callback = async function(err, res) {
+  if (await this._shouldRetry(err, res)) {
     return this._retry();
   }
 

--- a/src/node/index.js
+++ b/src/node/index.js
@@ -858,7 +858,7 @@ Request.prototype.request = function() {
  */
 
 Request.prototype.callback = async function(err, res) {
-  if (await this._shouldRetry(err, res)) {
+  if (err !== null && await this._shouldRetry(err, res)) {
     return this._retry();
   }
 

--- a/src/node/index.js
+++ b/src/node/index.js
@@ -857,8 +857,8 @@ Request.prototype.request = function() {
  * @api private
  */
 
-Request.prototype.callback = function(err, res) {
-  if (this._shouldRetry(err, res)) {
+Request.prototype.callback = async function(err, res) {
+  if (await this._shouldRetry(err, res)) {
     return this._retry();
   }
 

--- a/src/node/index.js
+++ b/src/node/index.js
@@ -858,7 +858,7 @@ Request.prototype.request = function() {
  */
 
 Request.prototype.callback = async function(err, res) {
-  if (err !== null && await this._shouldRetry(err, res)) {
+  if (err !== null && (await this._shouldRetry(err, res))) {
     return this._retry();
   }
 

--- a/src/request-base.js
+++ b/src/request-base.js
@@ -178,14 +178,14 @@ const ERROR_CODES = ['ECONNRESET', 'ETIMEDOUT', 'EADDRINFO', 'ESOCKETTIMEDOUT'];
  * @param {Response} [res] response
  * @returns {Boolean} if segment should be retried
  */
-RequestBase.prototype._shouldRetry = function(err, res) {
+RequestBase.prototype._shouldRetry = async function(err, res) {
   if (!this._maxRetries || this._retries++ >= this._maxRetries) {
     return false;
   }
 
   if (this._retryCallback) {
     try {
-      const override = this._retryCallback(err, res);
+      const override = await this._retryCallback(err, res);
       if (override === true) return true;
       if (override === false) return false;
       // undefined falls back to defaults


### PR DESCRIPTION
This PR adds new functionality:
- The ability to specify the callback of `.retry()` as an `async` function. The purpose is to enable `await`ing a Promise within the callback. This could be to used to fetch some external data, or by simply utilizing a setTimeout to resolve the promise after a specified delay. The result is that the .retry() is delayed by the given amount (or after the data is received). It does not break existing functionality i.e. the `.retry()` method can still be a normal synchronous function without any difference in behavior.

This PR also Resolves #1526 
- It prevents the `.retry()` method from being invoked on a successful request, and only allows it to invoke when there is a specified non-`null` error passed to `.callback()`