### PR TITLE
Check res.text as well to return a better error txt message

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -464,7 +464,9 @@ function Request(method, url) {
     let new_err;
     try {
       if (!self._isResponseOK(res)) {
-        new_err = new Error(res.statusText || 'Unsuccessful HTTP response');
+        new_err = new Error(
+          res.statusText || res.text || 'Unsuccessful HTTP response'
+        );
       }
     } catch (err_) {
       new_err = err_; // ok() callback can throw


### PR DESCRIPTION
Time to time I see my app throws "Unsuccessful HTTP response" error message when it got unsuccessful response even though a backend sent an error message. But sometimes it throws a  correct error that I got from the backend. After some investigation, I realized that sometimes there's no value in `res.statusText` but only `res.text` has one. For example, below both responses are from same API request. 

#### Case 1
```
response: {
  method: 'POST',
  url: 'https://test.url/api/v1/createaccount',
  data: { ... },
  headers: { ... },
  text: 'Unauthorized',
  statusText: '', <-- has no value
  statusCode: 401,
  status: 401,
  statusType: 4,
  info: false,
  ok: false,
  clientError: true,
  serverError: false,
  ...,
}
```
In this case, it always returns "Unsuccessful HTTP response" which is not a helpful message at all even though backend sent frontend a proper error message in the API response

#### Case 2
```
response: {
  method: 'POST',
  url: 'https://test.url/api/v1/createaccount',
  data: { ... },
  headers: { ... },
  text: 'Unauthorized',
  statusText: 'Unauthorized', <-- has the same value with `text` field
  statusCode: 401,
  status: 401,
  statusType: 4,
  info: false,
  ok: false,
  clientError: true,
  serverError: false,
  ...,
}
```
In this case, it throws me a proper error message as I expected