### PR TITLE
Fix URI encoding

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -128,7 +128,7 @@ function serialize(obj) {
 function pushEncodedKeyValuePair(pairs, key, val) {
   if (val === undefined) return;
   if (val === null) {
-    pairs.push(encodeURIComponent(key));
+    pairs.push(encodeURI(key));
     return;
   }
 
@@ -142,7 +142,7 @@ function pushEncodedKeyValuePair(pairs, key, val) {
         pushEncodedKeyValuePair(pairs, `${key}[${subkey}]`, val[subkey]);
     }
   } else {
-    pairs.push(encodeURIComponent(key) + '=' + encodeURIComponent(val));
+    pairs.push(encodeURI(key) + '=' + encodeURIComponent(val));
   }
 }
 

--- a/test/client/serialize.js
+++ b/test/client/serialize.js
@@ -35,6 +35,7 @@ describe('request.serializeObject()', () => {
     serialize({ name: '&tj&' }, 'name=%26tj%26');
     serialize({ '&name&': 'tj' }, '%26name%26=tj');
     serialize({ hello: '`test`' }, 'hello=%60test%60');
+    serialize({ $hello: 'test' }, '$hello=test');
   });
 });
 


### PR DESCRIPTION
I was having issues with an oData (https://www.odata.org/) based API. oData uses queries like
<http://example.com/todo?$skip=100&$top=50>

Superagent will currently encode this to <http://example.com/todo?%24skip=100&%24top=50>

According to HTTP spec this isn't technically correct. While values of query parameters should have fill encoding applied, the list of reserved characters is smaller for the overall URL.

A correct implementation would be to use encodeURIComponent over the query values and then encodeURI over the entire URL. However, the approach I've taken is equivalent.

Some of the answers to <https://stackoverflow.com/questions/4540753/should-i-use-encodeuri-or-encodeuricomponent-for-encoding-urls> provide some more explanation. I can provide full detail from HTTP and HTML specs if required.

I tried adding a test but the serialize tests seem to be broken. I could only get them to run if I set NODETESTS=tests/client/serialize.js
