### PR TITLE
fix: ensure node retries happen when using .then syntax (#1487)

### DIFF
--- a/src/request-base.js
+++ b/src/request-base.js
@@ -247,6 +247,10 @@ RequestBase.prototype.then = function(resolve, reject) {
 
     this._fullfilledPromise = new Promise((resolve, reject) => {
       self.on('abort', () => {
+        if (this._maxRetries && this._maxRetries > this._retries) {
+          return;
+        }
+
         if (this.timedout && this.timedoutError) {
           reject(this.timedoutError);
           return;

--- a/test/retry.js
+++ b/test/retry.js
@@ -178,6 +178,26 @@ describe('.retry(count)', function() {
       });
   });
 
+  it('should handle successful request after repeat attempt from server timeout when using .then(fulfill, reject)', done => {
+    const url = `/delay/1200/ok/${uniqid()}?built=in`;
+    request
+      .get(base + url)
+      .query('string=ified')
+      .query({ json: 'ed' })
+      .timeout(600)
+      .retry(1)
+      .then((res, err) => {
+        try {
+          assert.ifError(err);
+          assert(res.ok, 'response should be ok');
+          assert.equal(res.text, `ok = ${url}&string=ified&json=ed`);
+          done();
+        } catch (err_) {
+          done(err_);
+        }
+      });
+  });
+
   it('should correctly abort a retry attempt', done => {
     let aborted = false;
     const req = request


### PR DESCRIPTION
This PR is to enforce consistent `retry` behaviour for both  the`.end` and `.then` syntaxes.

The problem I'm trying to fix has been highlighted in these issues:
- https://github.com/visionmedia/superagent/issues/1487
- https://github.com/visionmedia/superagent/issues/1541

When using `.then` syntax in Node.js, we only want to abort a request if there are no retries or the  maximum number of retries has been exceeded.

Please review