### PR TITLE
fix: attach cookies to agent after plugin is used

### DIFF
--- a/src/node/agent.js
+++ b/src/node/agent.js
@@ -94,8 +94,8 @@ methods.forEach(name => {
     req.on('response', this._saveCookies.bind(this));
     req.on('redirect', this._saveCookies.bind(this));
     req.on('redirect', this._attachCookies.bind(this, req));
-    this._attachCookies(req);
     this._setDefaults(req);
+    this._attachCookies(req);
 
     if (fn) {
       req.end(fn);


### PR DESCRIPTION
This fixes the issue whereby if request.url is modified in a plugin for an agent (eg. superagent-prefix), cookies are not preserved across different requests, using that agent (see issue #1164).

This is fixed by simply executing agent._attachCookies() after agent._setDefaults().

Note: this is my first pull request ever.