### PR TITLE
feature: Support port overrides in connect()

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -692,6 +692,7 @@ Because the request may be redirected, it's possible to specify multiple hostnam
       .connect({
         "redir.example.com": "127.0.0.1", // redir.example.com:555 will use 127.0.0.1:555
         "www.example.com": false, // don't override this one; use DNS as normal
+        "mapped.example.com": { host: "127.0.0.1", port: 8080}, // mapped.example.com:* will use 127.0.0.1:8080
         "*": "proxy.example.com", // all other requests will go to this host
       });
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "superagent",
   "description": "elegant & feature rich browser / node HTTP with a fluent API",
-  "version": "5.2.2",
+  "version": "5.2.3",
   "author": "TJ Holowaychuk <tj@vision-media.ca>",
   "browser": {
     "./src/node/index.js": "./src/client.js",

--- a/src/node/index.js
+++ b/src/node/index.js
@@ -726,13 +726,25 @@ Request.prototype.request = function() {
         this.set('host', url.host);
       }
 
-      // wrap [ipv6]
-      url.host = /:/.test(match) ? `[${match}]` : match;
-      if (url.port) {
-        url.host += `:${url.port}`;
+      let newHost;
+      let newPort;
+
+      if (typeof match === 'object') {
+        newHost = match.host;
+        newPort = match.port;
+      } else {
+        newHost = match;
+        newPort = url.port;
       }
 
-      url.hostname = match;
+      // wrap [ipv6]
+      url.host = /:/.test(newHost) ? `[${newHost}]` : newHost;
+      if (newPort) {
+        url.host += `:${newPort}`;
+        url.port = newPort;
+      }
+
+      url.hostname = newHost;
     }
   }
 

--- a/test/node/redirects.js
+++ b/test/node/redirects.js
@@ -103,6 +103,24 @@ describe('request', () => {
         });
     });
 
+    it('should follow Location with IP:port override', () => {
+      const redirects = [];
+      const url = URL.parse(base);
+      return request
+        .get(`http://redir.example.com:9999${url.pathname}`)
+        .connect({
+          '*': { host: url.hostname, port: url.port || 80 }
+        })
+        .on('redirect', res => {
+          redirects.push(res.headers.location);
+        })
+        .then(res => {
+          const arr = ['/movies', '/movies/all', '/movies/all/0'];
+          redirects.should.eql(arr);
+          res.text.should.equal('first movie page');
+        });
+    });
+
     it('should not follow on HEAD by default', () => {
       const redirects = [];
 


### PR DESCRIPTION
Allow for .connect({'*': {host: 'hostname', port: 12345}}) overrides to
change the destination port of a request.