### PR TITLE
feat: add lookup method

### DIFF
--- a/src/node/index.js
+++ b/src/node/index.js
@@ -165,6 +165,7 @@ function Request(method, url) {
   this.qsRaw = this._query; // Unused, for backwards compatibility only
   this._redirectList = [];
   this._streamRequest = false;
+  this._lookup = null;
   this.once('end', this.clearTimeout.bind(this));
 }
 
@@ -297,6 +298,20 @@ Request.prototype._getFormData = function () {
 Request.prototype.agent = function (agent) {
   if (arguments.length === 0) return this._agent;
   this._agent = agent;
+  return this;
+};
+
+/**
+ * Gets/sets the `lookup` function to use custom DNS resolver.
+ *
+ * @param {Function} lookup
+ * @return {Function}
+ * @api public
+ */
+
+Request.prototype.lookup = function (lookup) {
+  if (arguments.length === 0) return this._lookup;
+  this._lookup = lookup;
   return this;
 };
 
@@ -759,6 +774,7 @@ Request.prototype.request = function () {
   options.cert = this._cert;
   options.passphrase = this._passphrase;
   options.agent = this._agent;
+  options.lookup = this._lookup;
   options.rejectUnauthorized =
     typeof this._disableTLSCerts === 'boolean'
       ? !this._disableTLSCerts

--- a/test/node/lookup.js
+++ b/test/node/lookup.js
@@ -1,0 +1,21 @@
+'use strict';
+const assert = require('assert');
+const dns = require('dns');
+const request = require('../support/client');
+const setup = require('../support/setup');
+
+const base = setup.uri;
+
+function myLookup(hostname, options, callback) {
+  dns.lookup(hostname, options, callback);
+}
+
+describe('req.lookup()', () => {
+  it('should set a custom lookup', () => {
+    const r = request.get(`${base}/ok`).lookup(myLookup);
+    assert(r.lookup() === myLookup);
+    r.then((res) => {
+      res.text.should.equal('ok');
+    });
+  });
+});


### PR DESCRIPTION
Add the feature of custom DNS resolve in node.
Sometime we use custom DNS to do service discovery, but superagent doesn't have the ability of changing the lookup method when call node's [http.request](https://nodejs.org/dist/latest-v12.x/docs/api/http.html#http_http_request_options_callback) method. 
So I pull this request to solve the problem.