### PR TITLE
Preserve custom err.status from ok callback

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -477,7 +477,7 @@ function Request(method, url) {
     if (new_err) {
       new_err.original = err;
       new_err.response = res;
-      new_err.status = res.status;
+      new_err.status = new_err.status || res.status;
       self.callback(new_err, res);
     } else {
       self.callback(null, res);

--- a/src/node/index.js
+++ b/src/node/index.js
@@ -881,6 +881,7 @@ Request.prototype.callback = function (err, res) {
       }
     } catch (err_) {
       err = err_;
+      err.status = err.status || (res ? res.status : undefined);
     }
   }
 

--- a/test/basic.js
+++ b/test/basic.js
@@ -206,6 +206,31 @@ describe('request', function () {
             assert.fail();
           },
           (err) => {
+            assert.equal(200, err.status);
+            assert.equal(200, err.response.status);
+            assert.equal(err.message, 'boom');
+          }
+        );
+    });
+
+    it('with .ok() throwing an Error with status', () => {
+      if (typeof Promise === 'undefined') {
+        return;
+      }
+
+      return request
+        .get(`${uri}/echo`)
+        .ok(() => {
+          const err = new Error('boom');
+          err.status = 404;
+          throw err;
+        })
+        .then(
+          () => {
+            assert.fail();
+          },
+          (err) => {
+            assert.equal(404, err.status);
             assert.equal(200, err.response.status);
             assert.equal(err.message, 'boom');
           }


### PR DESCRIPTION
Currently if you throw an error in a custom `.ok` callback, and that error has a `.status` property, it will be accessible in the node client but is overwritten by the response status in the browser client. This patch also adds the `.status` property to the error caught from the `.ok` callback if it didn't have one.