### PR TITLE
Make it possible to send in own encoder function as part of options object

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -578,7 +578,9 @@ Request.prototype.auth = function (user, pass, options) {
     throw new Error('Cannot use basic auth, btoa is not a function');
   };
 
-  return this._auth(user, pass, options, encoder);
+  options.encoder = options.encoder || encoder;
+
+  return this._auth(user, pass, options, options.encoder);
 };
 
 /**


### PR DESCRIPTION
The library does not support sending in your own encoder function as argument to `.auth()` (`encoder` is hard coded there).
This PR makes it an optional option.
Without this PR one needs to use the internal `._auth()` method, which is bad practise.

`.auth()`: https://github.com/visionmedia/superagent/blob/master/src/client.js
![Screenshot 2020-12-08 at 12 22 46](https://user-images.githubusercontent.com/1844083/101477893-24a6a500-3950-11eb-9185-24de96bfb081.png)

`._auth()`: https://github.com/visionmedia/superagent/blob/1277a880c32191e300b229e352e0633e421046c8/src/request-base.js#L514
![Screenshot 2020-12-08 at 12 21 05](https://user-images.githubusercontent.com/1844083/101477740-edd08f00-394f-11eb-998e-44b1550f4a7c.png)
