### PR TITLE
Update Docs: req.header() is now req.set()

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -289,7 +289,7 @@ In a similar fashion to the `.type()` method it is also possible to set the `Acc
 
 ### Facebook and Accept JSON
 
-If you are calling Facebook's API, be sure to send an `Accept: application/json` header in your request. If you don't do this, Facebook will respond with `Content-Type: text/javascript; charset=UTF-8`, which SuperAgent will not parse and thus `res.body` will be undefined. You can do this with either `req.accept('json')` or `req.header('Accept', 'application/json')`. See [issue 1078](https://github.com/visionmedia/superagent/issues/1078) for details.
+If you are calling Facebook's API, be sure to send an `Accept: application/json` header in your request. If you don't do this, Facebook will respond with `Content-Type: text/javascript; charset=UTF-8`, which SuperAgent will not parse and thus `res.body` will be undefined. You can do this with either `req.accept('json')` or `req.set('Accept', 'application/json')`. See [issue 1078](https://github.com/visionmedia/superagent/issues/1078) for details.
 
 ## Query strings
 


### PR DESCRIPTION
Hope this helps the next person, including future me, to not fall for this deprecated method again. :smiley: 

Great library! Thanks for all the effort that goes into this project!