### PR TITLE
Adding options to pass through form-data

### DIFF
--- a/src/request-base.js
+++ b/src/request-base.js
@@ -446,10 +446,11 @@ RequestBase.prototype.unset = function (field) {
  *
  * @param {String|Object} name name of field
  * @param {String|Blob|File|Buffer|fs.ReadStream} val value of field
+ * @param {String} options extra options, e.g. 'blob'
  * @return {Request} for chaining
  * @api public
  */
-RequestBase.prototype.field = function (name, value) {
+RequestBase.prototype.field = function (name, value, options) {
   // name should be either a string or an object.
   if (name === null || undefined === name) {
     throw new Error('.field(name, val) name can not be empty');
@@ -488,7 +489,7 @@ RequestBase.prototype.field = function (name, value) {
     value = String(value);
   }
 
-  this._getFormData().append(name, value);
+  this._getFormData().append(name, value, options);
   return this;
 };
 


### PR DESCRIPTION
.field function is missing options to attach binary data.
Form-data has the function append(name, value, options) to attach binary data.
This change will add an option string (e.g. 'blob') and pass it to form-data, which will allow attaching binary data directly using .field function.

e.g. .field('mydataid', binary_data_buffer, 'blob')