### PR TITLE
package.json: fix invalid syntax in `engines`

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "zuul": "^3.12.0"
   },
   "engines": {
-    "node": ">=6.4.0 !13"
+    "node": ">=6.4.0 <13 || >=14"
   },
   "homepage": "https://github.com/visionmedia/superagent",
   "husky": {


### PR DESCRIPTION
`!` is not supported by the semver library. This fixes a regression in v7
when used with engine-strict mode.

While the change in this PR may look similar to the state before #1660, 
it differs by using two pipe characters instead of one.

Fixes #1665.