### PR TITLE
refactor: make linter happier

### DIFF
--- a/package.json
+++ b/package.json
@@ -217,7 +217,15 @@
       }
     ],
     "rules": {
-      "unicorn/prevent-abbreviations": "warn",
+      "unicorn/prevent-abbreviations": [
+        "warn",
+        {
+          "replacements": {
+            "res": false,
+            "args": false
+          }
+        }
+      ],
       "no-bitwise": "warn",
       "node/prefer-global/buffer": "warn",
       "node/prefer-global/process": "warn",

--- a/test/content-type.js
+++ b/test/content-type.js
@@ -19,7 +19,7 @@ describe('req.set("Content-Type", contentType)', function () {
       .post(`${uri}/echo`)
       .set('Content-Type', 'application/json')
       .send({ name: 'tobi' })
-      .end((error, res) => {
+      .end((error) => {
         assert(!error);
         done();
       });
@@ -30,7 +30,7 @@ describe('req.set("Content-Type", contentType)', function () {
       .post(`${uri}/echo`)
       .set('Content-Type', 'application/json; charset=utf-8')
       .send({ name: 'tobi' })
-      .end((error, res) => {
+      .end((error) => {
         assert(!error);
         done();
       });

--- a/test/node/pipe-redirect.js
+++ b/test/node/pipe-redirect.js
@@ -6,19 +6,20 @@ const getSetup = require('../support/setup');
 describe('pipe on redirect', () => {
   let setup;
   let base;
-  const destPath = 'test/node/fixtures/pipe.txt';
+  const destinationPath = 'test/node/fixtures/pipe.txt';
 
   before(async () => {
     setup = await getSetup();
     base = setup.uri;
   });
 
-  after(function removeTmpfile(done) {
-    fs.unlink(destPath, done);
+  after((done) => {
+    // Remove tmp file
+    fs.unlink(destinationPath, done);
   });
 
   it('should follow Location', (done) => {
-    const stream = fs.createWriteStream(destPath);
+    const stream = fs.createWriteStream(destinationPath);
     const redirects = [];
     const request_ = request
       .get(base)
@@ -30,7 +31,7 @@ describe('pipe on redirect', () => {
       });
     stream.on('finish', () => {
       redirects.should.eql(['/movies', '/movies/all', '/movies/all/0']);
-      fs.readFileSync(destPath, 'utf8').should.eql('first movie page');
+      fs.readFileSync(destinationPath, 'utf8').should.eql('first movie page');
       done();
     });
     request_.pipe(stream);

--- a/test/node/serialize.js
+++ b/test/node/serialize.js
@@ -17,7 +17,7 @@ describe('req.serialize(fn)', () => {
     request
       .post(`${base}/echo`)
       .send({ foo: 123 })
-      .serialize((data) => '{"bar":456}')
+      .serialize(() => '{"bar":456}')
       .end((error, res) => {
         assert.ifError(error);
         assert.equal('{"bar":456}', res.text);

--- a/test/support/express/index.js
+++ b/test/support/express/index.js
@@ -1,3 +1,4 @@
+const process = require('process');
 const express = require('express');
 
 let http2Request;


### PR DESCRIPTION
Didn't fully disabled the prevent-abbreviations...
you tough `res` was ok, I'm fine with that...i think `args` is ok too... it's a good alternative to for not mixing up with arguments, the suggested `arguments_` with suffix is meh.

