### PR TITLE
fix: fixed the errors of eslint

### DIFF
--- a/.dist.eslintrc
+++ b/.dist.eslintrc
@@ -1,5 +1,5 @@
 {
-  "extends": ["eslint:recommended"],
+  "extends": ["eslint:recommended", "plugin:compat/recommended"],
   "env": {
     "node": false,
     "browser": true,
@@ -8,6 +8,14 @@
   },
   "plugins": ["compat"],
   "rules": {
+    "node/no-unsupported-features/es-builtins": ["error", {
+      "version": ">=8.0.0",
+      "ignores": [
+        "Atomics",
+        "BigInt",
+        "SharedArrayBuffer"
+      ]
+    }],
     "compat/compat": "error",
     "no-console": "off",
     "no-empty": "off",
@@ -44,7 +52,9 @@
       "Reflect",
       "WeakMap",
       "WeakRef",
-      "WeakSet"
+      "WeakSet",
+      "Atomics",
+      "SharedArrayBuffer"
     ]
   }
 }

--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,38 @@
+{
+  "extends": [
+    "eslint:recommended",
+    "plugin:node/recommended"
+  ],
+  "env": {
+    "node": true,
+    "browser": true,
+    "es6": true
+  },
+  "parserOptions": {
+    "ecmaVersion": 2021
+  },
+  "overrides": [
+    {
+      "files": "test/**/*.js",
+      "env": {
+        "mocha": true
+      },
+      "rules": {
+        "no-prototype-builtins": "off",
+        "node/no-deprecated-api": "warn",
+        "node/no-extraneous-require": "warn",
+        "no-unused-vars": "warn"
+      }
+    }
+  ],
+  "rules": {
+    "node/no-unsupported-features/node-builtins": "off",
+    "node/no-unsupported-features/es-syntax": "off",
+    "node/no-exports-assign": "off"
+  },
+  "globals": {
+    "ActiveXObject": "readonly"
+  }
+    
+  
+}

--- a/.lib.eslintrc
+++ b/.lib.eslintrc
@@ -8,7 +8,6 @@
     "no-console": "off",
     "no-unused-vars": "off",
     "no-empty": "off",
-    "node/no-unsupported-features/node-builtins": "off",
     "no-func-assign": "off",
     "no-global-assign": ["error", {"exceptions": ["exports"]}],
     "no-fallthrough": "off",
@@ -21,6 +20,13 @@
       "files": [ "lib/client.js" ],
       "globals": {
         "ActiveXObject": "readable"
+      }
+    },
+    {
+      "files": [ "lib/node/http2wrapper.js" ],
+      "rules": {
+        "node/no-unsupported-features/es-builtins": "off",
+        "node/no-unsupported-features/node-builtins": "off"
       }
     }
   ]

--- a/package.json
+++ b/package.json
@@ -155,7 +155,7 @@
     "build:dist": "npm run browserify && npm run minify",
     "build:lib": "babel --config-file ./.lib.babelrc src --out-dir lib",
     "coverage": "nyc report --reporter=text-lcov > coverage.lcov && codecov",
-    "lint": "xo && remark . -qfo && eslint -c .lib.eslintrc lib && eslint -c .dist.eslintrc dist",
+    "lint": "eslint -c .eslintrc src test && remark . -qfo && eslint -c .lib.eslintrc lib/**/*.js && eslint -c .dist.eslintrc dist/**/*.js",
     "minify": "cross-env NODE_ENV=production browserify src/node/index.js -o dist/superagent.min.js -s superagent -g [ babelify --configFile ./.dist.babelrc ] -p tinyify",
     "nyc": "cross-env NODE_ENV=test nyc ava",
     "test": "npm run build && npm run lint && make test",
@@ -165,6 +165,7 @@
   "xo": {
     "prettier": true,
     "space": true,
+    "nodeVersion": false,
     "extends": [
       "xo-lass"
     ],

--- a/src/client.js
+++ b/src/client.js
@@ -71,19 +71,19 @@ request.getXHR = () => {
 
   try {
     return new ActiveXObject('Microsoft.XMLHTTP');
-  } catch {}
+  } catch {/**/}
 
   try {
     return new ActiveXObject('Msxml2.XMLHTTP.6.0');
-  } catch {}
+  } catch {/**/}
 
   try {
     return new ActiveXObject('Msxml2.XMLHTTP.3.0');
-  } catch {}
+  } catch {/**/}
 
   try {
     return new ActiveXObject('Msxml2.XMLHTTP');
-  } catch {}
+  } catch {/**/}
 
   throw new Error('Browser-only version of superagent could not find XHR');
 };

--- a/test/client/request.js
+++ b/test/client/request.js
@@ -55,7 +55,6 @@ describe('request', function () {
 
     try {
       var file = new File([''], 'image.jpg', { type: 'image/jpeg' });
-      ////eslint-disable-next-line unicorn/prefer-optional-catch-binding
     } catch (err) {
       // Skip if file constructor not supported.
       return next();

--- a/test/client/request.js
+++ b/test/client/request.js
@@ -55,7 +55,7 @@ describe('request', function () {
 
     try {
       var file = new File([''], 'image.jpg', { type: 'image/jpeg' });
-      // eslint-disable-next-line unicorn/prefer-optional-catch-binding
+      ////eslint-disable-next-line unicorn/prefer-optional-catch-binding
     } catch (err) {
       // Skip if file constructor not supported.
       return next();

--- a/test/node/toError.js
+++ b/test/node/toError.js
@@ -26,7 +26,7 @@ before(function listen(done) {
 
 describe('res.toError()', () => {
   it('should return an Error', (done) => {
-    request.get(base).end((error, res) => {
+    request.get(base).end((err, res) => {
       var error = res.toError();
       assert.equal(error.status, 400);
       assert.equal(error.method, 'GET');


### PR DESCRIPTION
Superagent has three eslint configuration files. The `.lib.eslintrc` to valid the files under the directory of lib , the `.dist.eslintrc` to valid the files under the direcotry of dist, the property of `xo` of `package.json` to valid all the project's file.

For the issue of https://github.com/xojs/xo/issues/598 from xo ,we can not disable the rule for low version node check, such as the rule `node/no-unsupported-features/node-builtins`. So I just switch to use the native eslint, and add a new configuration file, named `.eslintrc`. This will also benefit for the vscode, when use the file `.eslintrc` , vscode can use the rules from it.

For current project not install the eslint plugin of `eslint-plugin-unicorn` in `package.json`. So I have not set it as an extendtion to `.eslintrc`. Someone can install it manual and use the rules from it after the pull request is merged.