### PR TITLE
feat: add github action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,46 @@
+name: CI
+on: 
+  push:
+
+env:
+  SAUCE_USERNAME: shtylman-superagent
+  SAUCE_ACCESS_KEY: 39a45464-cb1d-4b8d-aa1f-83c7c04fa673
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+       include:
+        - node-version: 12.x
+          # test-on-brower: 1
+        - node-version: 14.x
+          # test-http2: 1
+        - node-version: 16.x
+          # test-http2: 1
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Install Node - ${{ matrix.node-version }}
+        uses: actions/setup-node@v2        
+        with:
+          node-version: ${{ matrix.node-version }}
+      - name: Cache node modules
+        uses: actions/cache@v2
+        env:
+          cache-name: cache-node-modules
+        with:
+          # npm cache files are stored in `~/.npm` on Linux/macOS
+          path: ~/.npm
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/yarn.lock') }}
+      - name: Install Dependencies
+        run: yarn install
+      - name: Build
+        run: npm run build
+      - name: Test On Node ${{ matrix.node-version }}
+        env:
+          BROWSER: ${{ matrix.test-on-brower }}
+          HTTP2_TEST: ${{ matrix.test-http2 }}
+        run: |
+          npm run test
+          npm run coverage

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ test:
 	@if [ "x$(BROWSER)" = "x" ]; then make test-node; else make test-browser; fi
 
 test-node:
-	@NODE_ENV=test ./node_modules/.bin/mocha \
+	@NODE_ENV=test nyc ./node_modules/.bin/mocha \
 		--require should \
 		--trace-warnings \
 		--throw-deprecation \


### PR DESCRIPTION
I have done some work on bringing github action on current project. In the process of that, I also found some  problems.

First, the test on low version node is not supported now (https://github.com/yunnysunny/superagent/runs/4895023400). Since we use a newest  version of eslint (8.3.0 in fact), it will emit an error when we run it on node 10.x :
```
Oops! Something went wrong! :(

ESLint: 8.6.0

TypeError: Module.createRequire is not a function
    at Object.<anonymous> (/home/runner/work/superagent/superagent/node_modules/@eslint/eslintrc/dist/eslintrc.cjs:2359:26)
    at Module._compile (/home/runner/work/superagent/superagent/node_modules/v8-compile-cache/v8-compile-cache.js:192:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:789:10)
    at Module.load (internal/modules/cjs/loader.js:653:32)
    at tryModuleLoad (internal/modules/cjs/loader.js:593:12)
    at Function.Module._load (internal/modules/cjs/loader.js:585:3)
    at Module.require (internal/modules/cjs/loader.js:692:17)
    at require (/home/runner/work/superagent/superagent/node_modules/v8-compile-cache/v8-compile-cache.js:159:20)
    at Object.<anonymous> (/home/runner/work/superagent/superagent/node_modules/eslint/lib/cli-engine/cli-engine.js:33:5)
    at Module._compile (/home/runner/work/superagent/superagent/node_modules/v8-compile-cache/v8-compile-cache.js:192:30)
```
We have to reduce the version of eslint , or skip the lint for node 10 , which needs an refactor of our ci code.

Second, the test of browsers failed with such error (https://github.com/yunnysunny/superagent/runs/4895413544):

```
SAUCE_APPIUM_VERSION=1.7 ./node_modules/.bin/zuul -- test/*.js test/client/*.js
(node:2010) [DEP0022] DeprecationWarning: os.tmpDir() is deprecated. Use os.tmpdir() instead.
- testing: chrome @ Mac 11: 97
- testing: firefox @ Mac 10.12: 96
- testing: safari @ Mac 12: 15
- testing: internet explorer @ Windows 2008: 9 10 11
- restarting: <safari 15 on Mac 12>
- restarting: <internet explorer 10 on Windows 2008>
- restarting: <chrome 97 on Mac 11>
- restarting: <firefox 96 on Mac 10.12>
- restarting: <internet explorer 9 on Windows 2008>
- restarting: <internet explorer 10 on Windows 2008>
- restarting: <chrome 97 on Mac 11>
- restarting: <safari 15 on Mac 12>
- restarting: <firefox 96 on Mac 10.12>
- restarting: <internet explorer 9 on Windows 2008>
- restarting: <chrome 97 on Mac 11>
- restarting: <internet explorer 10 on Windows 2008>
- restarting: <chrome 97 on Mac 11>
- restarting: <internet explorer 10 on Windows 2008>
- restarting: <safari 15 on Mac 12>
- restarting: <chrome 97 on Mac 11>
- restarting: <internet explorer 10 on Windows 2008>
- restarting: <firefox 96 on Mac 10.12>
- restarting: <internet explorer 9 on Windows 2008>
- restarting: <safari 15 on Mac 12>
- restarting: <chrome 97 on Mac 11>
- restarting: <internet explorer 10 on Windows 2008>
- restarting: <internet explorer 9 on Windows 2008>
- restarting: <safari 15 on Mac 12>
- failed: <internet explorer 11 on Windows 2008> (0 failed, 0 passed)
- restarting: <internet explorer 9 on Windows 2008>
- failed: <chrome 97 on Mac 11> (0 failed, 0 passed)

/home/runner/work/superagent/superagent/node_modules/zuul/bin/zuul:332
            throw err.message;
            ^
internet explorer@10: localtunnel server returned an error, please try again
(Use `node --trace-uncaught ...` to show where the exception was thrown)
```
I'm not familiar with zuul, and have no idea what happened.

Third, the test on http2 also failed(https://github.com/yunnysunny/superagent/runs/4895023445). It showed many errors , all of them with same reason, this is an example :

```
  1) request
       persistent agent
         should gain a session on POST:
     Uncaught Error [ERR_HTTP2_STREAM_ERROR]: Stream closed with error code NGHTTP2_PROTOCOL_ERROR
      at ClientHttp2Stream._destroy (internal/http2/core.js:2212:13)
      at ClientHttp2Stream.destroy (internal/streams/destroy.js:38:8)
      at Http2Stream.onStreamClose (internal/http2/core.js:518:12)
```

For the problems above, I drop the test of low version nodes, browsers, and http in the github action's yml.
 