### PR TITLE
use custom encoder if it is sent in option object

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -568,10 +568,12 @@ Request.prototype.auth = function (user, pass, options) {
     };
   }
 
-  const encoder = (string) => {
-    if (typeof btoa === 'function') {
-      return btoa(string);
-    }
+  const encoder =
+    options.encoder ||
+    (string) => {
+      if (typeof btoa === 'function') {
+        return btoa(string);
+      }
 
     throw new Error('Cannot use basic auth, btoa is not a function');
   };


### PR DESCRIPTION
Hey! This is basically a fix for the same issue as: https://github.com/visionmedia/superagent/pull/1612
But i did the change requested by @niftylettuce 