### PR TITLE
docs: reverted http2

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -93,6 +93,15 @@ The HTTP method defaults to __GET__, so if you wish, the following is valid:
      });
 ```
 
+## Using HTTP/2
+
+To make a request using HTTP/2 protocol only (with no HTTP/1.x fallback), use the `.http2()` method. Currently we do not have auto-detection of HTTP/2-capable servers. This feature is experimental.
+
+    const request = require('superagent');
+    const res = await request
+      .get('https://example.com/h2')
+      .http2();
+
 ## Setting header fields
 
 Setting header fields is simple, invoke `.set()` with a field name and value:


### PR DESCRIPTION
reverted from "Drop HTTP/2, as it doesn't work in Node 10 any more" (b08371c72fbdca40dda3ad39fe8bbbee4a2718d5)