### PR TITLE
Fix overflow pre tag index.md

### DIFF
--- a/docs/style.css
+++ b/docs/style.css
@@ -73,6 +73,7 @@ pre {
   -webkit-box-shadow: inset 0 0 5px #eee;
   -moz-box-shadow: inset 0 0 5px #eee;
   box-shadow: inset 0 0 5px #eee;
+  overflow: scroll;
 }
 
 code .comment { color: #ddd }


### PR DESCRIPTION
In the docs, at h2#testing-on-localhost second pre child, the code snippet literally breaks and goes outside pre, div and everything. The same happens for h2#promise-and-generator-support third pre child, the code snippet breaks and goes outside the pre and everything.