### PR TITLE
Add missing typing for withCredentials()

### DIFF
--- a/src/request-base.js
+++ b/src/request-base.js
@@ -543,7 +543,8 @@ RequestBase.prototype._auth = function (user, pass, options, base64Encoder) {
  * using "Access-Control-Allow-Origin" with a wildcard,
  * and also must set "Access-Control-Allow-Credentials"
  * to "true".
- *
+ * @param {Boolean} [on=true] - Set 'withCredentials' state
+ * @return {Request} for chaining
  * @api public
  */
 


### PR DESCRIPTION
Hello,

Some typing is missing for `RequestBase.withCredentials(on? boolean)

I made a pull request to update the typescript delcaration of `@types/superagent`
https://github.com/DefinitelyTyped/DefinitelyTyped/pull/63375