### PR TITLE
ci: fixed broken ci 

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "husky": "7",
     "lint-staged": "12",
     "marked": "^4.1.1",
-    "mocha": "^10.1.0",
+    "mocha": "^6.2.3",
     "multer": "1.4.5-lts.1",
     "nyc": "^15.1.0",
     "remark-cli": "^11.0.0",


### PR DESCRIPTION
## fixed ci failing due to incompatible dev dependencies for Node.js <=12
- ci regression from https://github.com/visionmedia/superagent/commit/63340fa19ac00a967c64ab93b50f5544abad0751
  - [chore(deps-dev): downgraded mocha from ^10.1.0 to ^6.2.3](https://github.com/visionmedia/superagent/commit/889e90cb26e970b4b89679f5bad2a6dd69e55b9a)
