### PR TITLE
fix(cookies): parse header correctly when merging cookies

### DIFF
--- a/src/node/index.js
+++ b/src/node/index.js
@@ -855,8 +855,8 @@ Request.prototype.request = function () {
     if (hasOwn(this._header, 'cookie')) {
       // merge
       const temporaryJar = new CookieJar.CookieJar();
-      temporaryJar.setCookies(this._header.cookie.split(';'));
-      temporaryJar.setCookies(this.cookies.split(';'));
+      temporaryJar.setCookies(this._header.cookie.split('; '));
+      temporaryJar.setCookies(this.cookies.split('; '));
       req.setHeader(
         'Cookie',
         temporaryJar.getCookies(CookieJar.CookieAccessInfo.All).toValueString()


### PR DESCRIPTION
Fixes a parsing error introduced by an upstream fix in cookiejar: bmeck/node-cookiejar#38

Prior to 2.1.3, cookiejar was incorrectly producing cookie headers containing multiple cookies with no spaces after the separating semicolon. That space is explicitly required in [the RFC](https://httpwg.org/specs/rfc6265.html#rfc.section.4.2.1).

When Supertest merges cookies provided with via `.set()` with cookies from its internal cookiejar instance, it assumes that incorrect, spaceless format. This results in any cookie names after the first in a given header erroneously containing leading spaces.

I added a test for cookie validity and the fix to split on `; ` instead of just `;`.

Found this issue the same way as #1761, but it's actually unrelated. Fun! 😄 

## Checklist

- [x] I have ensured my pull request is not behind the main or master branch of the original repository.
- [x] I have rebased all commits where necessary so that reviewing this pull request can be done without having to merge it first.
- [x] I have written a commit message that passes commitlint linting.
- [x] I have ensured that my code changes pass linting tests.
- [x] I have ensured that my code changes pass unit tests.
- [x] I have described my pull request and the reasons for code changes along with context if necessary.
