### PR TITLE
node agent: ignore query http method. Fix #1835.

### DIFF
--- a/src/node/agent.js
+++ b/src/node/agent.js
@@ -78,6 +78,7 @@ class Agent extends AgentBase {
 
 for (const name of methods) {
   const method = name.toUpperCase();
+  if (method === "QUERY") continue;
   Agent.prototype[name] = function (url, fn) {
     const request_ = new request.Request(method, url);
 


### PR DESCRIPTION
This is needed with newer node versions having QUERY in http.METHODS.
Fix #1835.